### PR TITLE
Add grabl-marker for autoupdating

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "graknlabs_grakn_core",
     remote = "https://github.com/graknlabs/grakn",
-    commit = "a1ae6ebc3ec2a76dadf52ad09fbd00138bff8d70"
+    commit = "a1ae6ebc3ec2a76dadf52ad09fbd00138bff8d70" # grabl-marker: do not remove this comment, this is used for dependency-update by @graknlabs_grakn_core
 )
 
 load("@graknlabs_grakn_core//dependencies/compilers:dependencies.bzl", "grpc_dependencies")


### PR DESCRIPTION
## What is the goal of this PR?

Needed for graknlabs/grakn#4894

## What are the changes implemented in this PR?

Adds `grabl-marker` so dependency script knows how to update it