### PR TITLE
add dependency update to client-java ci workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,8 +63,26 @@ jobs:
       - bazel:
           command: bazel test //... --test_size_filters=medium,large,enormous --test_output=errors
 
+  dependency-update:
+    machine: true
+    steps:
+      - checkout
+      - bazel_install
+      - run:
+          name: Sync docs:development dependency to the latest Grakn Client Java version
+          command: |
+            bazel run @graknlabs_grabl//sync:dependency-update -- --dependency client-java:master \
+              --user docs:development
+
 workflows:
   client-java:
     jobs:
       - build
       - test
+      - dependency-update:
+          filters:
+            branches:
+              only: master
+          requires:
+            - build
+            - test

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -70,3 +70,9 @@ java_grpc_compile()
 
 load("@graknlabs_grakn_core//dependencies/docker:dependencies.bzl", "docker_dependencies")
 docker_dependencies()
+
+git_repository(
+    name = "graknlabs_grabl",
+    remote = "https://github.com/graknlabs/grabl",
+    commit = "ad79f87f869d25694fe11196e16be42a80e95d14",
+)


### PR DESCRIPTION
## What is the goal of this PR?
to ensure that every commit to `client-java/master`, updates the `doc/development`'s `client-java` dependency to the latest commit of `client-java/master`.

## What are the changes implemented in this PR?
- reuse Grakn's `dependency-update` job that uses Grabl's dependency-update to update `client-java` dependency inside `WORKSPACE` of `docs/development`.
- include `dependency-update` job in the `client-java` workflow requiring `build` and `test`. 
