### PR TITLE
Add benchmark as transitive dependency

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -85,15 +85,13 @@ java_grpc_compile()
 # Load Grakn Core dependencies #
 ################################
 
+load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl", "graknlabs_benchmark")
+graknlabs_benchmark()
+
 load("@graknlabs_grakn_core//dependencies/maven:dependencies.bzl",
 graknlabs_grakn_core_maven_dependencies = "maven_dependencies")
 graknlabs_grakn_core_maven_dependencies()
 
-load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_benchmark")
-graknlabs_benchmark()
-load("@graknlabs_benchmark//dependencies/maven:dependencies.bzl",
-graknlabs_benchmark_maven_dependencies = "maven_dependencies")
-graknlabs_benchmark_maven_dependencies()
 
 load("@graknlabs_build_tools//bazel:dependencies.bzl", "bazel_rules_docker")
 bazel_rules_docker()

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -25,13 +25,6 @@ def graknlabs_grakn_core():
         commit = "c027db0b11b9cfc51ad7006714308c9f30f0df29" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
-def graknlabs_benchmark():
-    git_repository(
-        name = "graknlabs_benchmark",
-        remote = "https://github.com/graknlabs/benchmark.git",
-        commit = "ceb5a2ebb71ee526d788fb4b17a104a6669d4b70" # do not sync - changes much less frequently than repository
-    )
-
 def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",


### PR DESCRIPTION
## What is the goal of this PR?
Fix breaking change caused by the introduction of `benchmark` repository as a Bazel git_repository dependency.

## What are the changes implemented in this PR?
One liner to include `graknlabs_benchmark()` dependency that allows the building of distribution `tar.gz` in CircleCI.
