### PR TITLE
Add benchmark:master to sync dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
           export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN_GRABL
           bazel run @graknlabs_build_tools//ci:sync-dependencies -- \
           --source client-java@$CIRCLE_SHA1 \
-          --targets docs:development examples:development
+          --targets docs:development examples:development benchmark:master
 
   release-approval:
     machine: true


### PR DESCRIPTION
## What is the goal of this PR?
Auto-update benchmark dependencies to reflect updates to client-java. This should lead to notifications when benchmark fails because of a breaking change rather than having to notice that the dashboard is not updating anymore. 

## What are the changes implemented in this PR?
* Add benchmark:master to sync dependencies