### PR TITLE
CI: sync-dependencies now syncs to grakn-kgms

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
           export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN_GRABL
           bazel run @graknlabs_build_tools//ci:sync-dependencies -- \
           --source client-java@$CIRCLE_SHA1 \
-          --targets docs:development examples:development benchmark:master grakn-kgms:master
+          --targets grakn-kgms:master benchmark:master docs:development examples:development
 
   release-approval:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
           export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN_GRABL
           bazel run @graknlabs_build_tools//ci:sync-dependencies -- \
           --source client-java@$CIRCLE_SHA1 \
-          --targets docs:development examples:development benchmark:master
+          --targets docs:development examples:development benchmark:master grakn-kgms:master
 
   release-approval:
     machine: true


### PR DESCRIPTION
## What is the goal of this PR?

`sync-dependencies` now syncs to grakn-kgms.