### PR TITLE
Handle query cancellation

### DIFF
--- a/rpc/Transceiver.java
+++ b/rpc/Transceiver.java
@@ -95,7 +95,6 @@ public class Transceiver implements AutoCloseable {
             //2. Error can lead to connection closures but the transaction may stay open
             //When this occurs a "half-closed" state is thrown which we can safely ignore
         }
-        responseListener.close();
     }
 
     public boolean isClosed() {
@@ -106,7 +105,7 @@ public class Transceiver implements AutoCloseable {
      * A StreamObserver that stores all responses in a blocking queue.
          * A response can be polled with the #poll() method.
      */
-    private static class ResponseListener implements StreamObserver<Transaction.Res>, AutoCloseable {
+    private static class ResponseListener implements StreamObserver<Transaction.Res> {
 
         private final BlockingQueue<Response> queue = new LinkedBlockingDeque<>();
         private final AtomicBoolean terminated = new AtomicBoolean(false);
@@ -145,17 +144,6 @@ public class Transceiver implements AutoCloseable {
 
             // Block for a response (because we are confident there are no responses and the connection has not closed)
             return queue.take();
-        }
-
-        @Override
-        public void close() {
-            while (!terminated.get()) {
-                try {
-                    poll();
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-            }
         }
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

We want to enable the possibility to cancel running queries.

This PR updates client-java to handle interrupted state of Transaction, more specifically:
it might now happen that the client, while blocked on a queue waiting for the server response, receives a `COMPLETED` response. This case was not handled before as it was not possible to complete a connection while a query was running (before we were expecting either an `OK` response or an `ERROR` response).


## What are the changes implemented in this PR?

- changed `usePlainText(true)` to `usePlainText()` as the former is deprecated now
- added new case handling in switch-case inside `responseOrThrow()`
- removed `close()` method from `Transceiver` as it was just polling the queue without doing anything with the content of it. Leaving the `close()` leads to dead-lock when 2 threads are trying to terminate the connection but only one will receive a response:
```
- thread 1 run `query` request and blocks on the queue (`poll()`)
- thread 2 executes `onCompleted()` because the user wants to interrupt the running query and then calls `close()` which in turn calls `poll()`, blocking on the queue
- thread 1 will take from the queue the response from the server which indicates the end of the transaction (because thread 2 asked to close transaction)
- thread 2 keeps waiting for something that will never come
```