### PR TITLE
Remove dependency on SimpleURI

### DIFF
--- a/GraknClient.java
+++ b/GraknClient.java
@@ -64,10 +64,6 @@ import io.grpc.ManagedChannelBuilder;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import java.io.Serializable;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -103,13 +99,7 @@ public class GraknClient implements AutoCloseable {
     }
 
     public GraknClient(String address, String username, String password) {
-        URI parsedURI = null;
-        try {
-            parsedURI = new URI(address);
-        } catch (URISyntaxException e) {
-            throw GraknClientException.create("Malformed address [" + address + "] provided.");
-        }
-        channel = ManagedChannelBuilder.forAddress(parsedURI.getHost(), parsedURI.getPort())
+        channel = ManagedChannelBuilder.forTarget(address)
                 .usePlaintext().build();
         this.username = username;
         this.password = password;

--- a/GraknClient.java
+++ b/GraknClient.java
@@ -65,6 +65,8 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
@@ -101,10 +103,10 @@ public class GraknClient implements AutoCloseable {
     }
 
     public GraknClient(String address, String username, String password) {
-        URL parsedURI = null;
+        URI parsedURI = null;
         try {
-            parsedURI = new URL(address);
-        } catch (MalformedURLException e) {
+            parsedURI = new URI(address);
+        } catch (URISyntaxException e) {
             throw GraknClientException.create("Malformed address [" + address + "] provided.");
         }
         channel = ManagedChannelBuilder.forAddress(parsedURI.getHost(), parsedURI.getPort())

--- a/GraknClient.java
+++ b/GraknClient.java
@@ -27,7 +27,6 @@ import grakn.client.rpc.RequestBuilder;
 import grakn.client.rpc.ResponseReader;
 import grakn.client.rpc.Transceiver;
 import grakn.core.common.exception.Validator;
-import grakn.core.common.http.SimpleURI;
 import grakn.core.common.util.CommonUtil;
 import grakn.core.concept.Concept;
 import grakn.core.concept.ConceptId;
@@ -65,6 +64,8 @@ import io.grpc.ManagedChannelBuilder;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import java.io.Serializable;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -100,7 +101,12 @@ public class GraknClient implements AutoCloseable {
     }
 
     public GraknClient(String address, String username, String password) {
-        SimpleURI parsedURI = new SimpleURI(address);
+        URL parsedURI = null;
+        try {
+            parsedURI = new URL(address);
+        } catch (MalformedURLException e) {
+            throw GraknClientException.create("Malformed address [" + address + "] provided.");
+        }
         channel = ManagedChannelBuilder.forAddress(parsedURI.getHost(), parsedURI.getPort())
                 .usePlaintext().build();
         this.username = username;


### PR DESCRIPTION
## What is the goal of this PR?

Remove dependency on `SimpleURI` class which is not used anywhere else and will be soon deleted from Grakn common package

## What are the changes implemented in this PR?

 - use `.forTarget` method instead of `.forAddress`, as the former accepts an address string