### PR TITLE
Update test to reflect new behaviour when deleting non existing keyspace

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -29,7 +29,7 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "b5f28083d133757ca75e553c068ed373c7918ca3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "cf29ddd6862e33d9aa3916d4f3c559f7f47641d3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():


### PR DESCRIPTION
## What is the goal of this PR?

Now Grakn returns exception when trying to delete a non existing keyspace, whereas before we were silently ignoring the request.
This new behaviour follow existing dbs behaviours which warn you when trying to delete a non existing database.

## What are the changes implemented in this PR?

- add check in `tearDown` method in tests, to delete keyspace only if it exists
- added new test to confirm behaviour
- updated dependency on Grakn Core
