### PR TITLE
Prefixed artifact IDs of Maven packages with 'grakn-'

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -57,7 +57,7 @@ java_library(
         "//dependencies/maven/artifacts/io/netty:netty-all",
     ],
     resources = ["LICENSE"],
-    tags = ["maven_coordinates=io.grakn.client:api:{pom_version}"],
+    tags = ["maven_coordinates=io.grakn.client:grakn-client:{pom_version}"],
 )
 
 checkstyle_test(


### PR DESCRIPTION
## What is the goal of this PR?

When deploying Maven JARs to Sonatype, the JARs are renamed to be `artifact-id-version.jar`, without the `group-id`. This is done in Sonatype because the JARs are organised into folders where the folder names represent the Group IDs. However, in certain build systems, e.g. Gradle, the JARs are collected under one directory, which means the JAR names are not unique enough to disambiguate itself from each other. We have now renamed the artifact ID of our Maven packages to be prefixed with `grakn-` to solve this problem.

## What are the changes implemented in this PR?

Prefixed artifact IDs of Maven packages with 'grakn-' (fixes https://github.com/graknlabs/grakn/issues/5127, fixes https://github.com/graknlabs/bazel-distribution/issues/112).