### PR TITLE
Supply authentication credentials for keyspace operations

### DIFF
--- a/GraknClient.java
+++ b/GraknClient.java
@@ -101,7 +101,7 @@ public class GraknClient implements AutoCloseable {
                 .usePlaintext().build();
         this.username = username;
         this.password = password;
-        keyspaces = new Keyspaces(channel);
+        keyspaces = new Keyspaces(channel, this.username, this.password);
     }
 
     public GraknClient overrideChannel(ManagedChannel channel) {
@@ -557,20 +557,24 @@ public class GraknClient implements AutoCloseable {
      */
 
     public static final class Keyspaces {
+        private String username;
+        private String password;
 
         private KeyspaceServiceBlockingStub keyspaceBlockingStub;
 
-        public Keyspaces(ManagedChannel channel) {
+        public Keyspaces(ManagedChannel channel, String username, String password) {
             keyspaceBlockingStub = KeyspaceServiceGrpc.newBlockingStub(channel);
+            this.username = username;
+            this.password = password;
         }
 
         public void delete(String name) {
-            KeyspaceProto.Keyspace.Delete.Req request = RequestBuilder.Keyspace.delete(name);
+            KeyspaceProto.Keyspace.Delete.Req request = RequestBuilder.Keyspace.delete(name, this.username, this.password);
             keyspaceBlockingStub.delete(request);
         }
 
         public List<String> retrieve() {
-            KeyspaceProto.Keyspace.Retrieve.Req request = RequestBuilder.Keyspace.retrieve();
+            KeyspaceProto.Keyspace.Retrieve.Req request = RequestBuilder.Keyspace.retrieve(this.username, this.password);
             return ImmutableList.copyOf(keyspaceBlockingStub.retrieve(request).getNamesList().iterator());
         }
     }

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -36,5 +36,5 @@ def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        commit = "dbbea5ae6870dc0624658091c221fe9fc292bad1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "887409713c38deeebbdae01fa00946097887d20c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )

--- a/rpc/RequestBuilder.java
+++ b/rpc/RequestBuilder.java
@@ -270,12 +270,26 @@ public class RequestBuilder {
      */
     public static class Keyspace {
 
-        public static KeyspaceProto.Keyspace.Delete.Req delete(String name) {
-            return KeyspaceProto.Keyspace.Delete.Req.newBuilder().setName(name).build();
+        public static KeyspaceProto.Keyspace.Delete.Req delete(String name, String username, String password) {
+            KeyspaceProto.Keyspace.Delete.Req.Builder builder = KeyspaceProto.Keyspace.Delete.Req.newBuilder();
+            if (username != null) {
+                builder.setUsername(username);
+            }
+            if (password != null) {
+                builder.setPassword(password);
+            }
+            return builder.setName(name).build();
         }
 
-        public static KeyspaceProto.Keyspace.Retrieve.Req retrieve() {
-            return KeyspaceProto.Keyspace.Retrieve.Req.newBuilder().build();
+        public static KeyspaceProto.Keyspace.Retrieve.Req retrieve(String username, String password) {
+            KeyspaceProto.Keyspace.Retrieve.Req.Builder builder = KeyspaceProto.Keyspace.Retrieve.Req.newBuilder();
+            if (username != null) {
+                builder.setUsername(username);
+            }
+            if (password != null) {
+                builder.setPassword(password);
+            }
+            return builder.build();
         }
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

Recent changes in protocol (graknlabs/protocol#7) allow keyspace operations to be authenticated. This PR adapts Grakn Client Java to these recent changes.

## What are the changes implemented in this PR?

- Builder methods in `RequestBuilder.Keyspace` now accept `username` and `password`
- `Keyspaces` constructor now accepts `username` and `password`
- Bump `@graknlabs_protocol` to latest version