### PR TITLE
Throw correct exception on failures with keyspace operations

### DIFF
--- a/GraknClient.java
+++ b/GraknClient.java
@@ -58,6 +58,7 @@ import graql.lang.query.GraqlQuery;
 import graql.lang.query.GraqlUndefine;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.StatusRuntimeException;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
@@ -569,13 +570,21 @@ public class GraknClient implements AutoCloseable {
         }
 
         public void delete(String name) {
-            KeyspaceProto.Keyspace.Delete.Req request = RequestBuilder.Keyspace.delete(name, this.username, this.password);
-            keyspaceBlockingStub.delete(request);
+            try {
+                KeyspaceProto.Keyspace.Delete.Req request = RequestBuilder.Keyspace.delete(name, this.username, this.password);
+                keyspaceBlockingStub.delete(request);
+            } catch (StatusRuntimeException e) {
+                throw GraknClientException.create(e.getMessage(), e);
+            }
         }
 
         public List<String> retrieve() {
-            KeyspaceProto.Keyspace.Retrieve.Req request = RequestBuilder.Keyspace.retrieve(this.username, this.password);
-            return ImmutableList.copyOf(keyspaceBlockingStub.retrieve(request).getNamesList().iterator());
+            try {
+                KeyspaceProto.Keyspace.Retrieve.Req request = RequestBuilder.Keyspace.retrieve(this.username, this.password);
+                return ImmutableList.copyOf(keyspaceBlockingStub.retrieve(request).getNamesList().iterator());
+            } catch (StatusRuntimeException e) {
+                throw GraknClientException.create(e.getMessage(), e);
+            }
         }
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

Failures with keyspace operations should throw exceptions of correct kind (`GraknClientException`) instead of raw RPC exceptions.

## What are the changes implemented in this PR?

Catch raw RPC exceptions and re-throw them as `GraknClientException`