### PR TITLE
Use release-validate-deps to ensure that client-java depends on released versions of grakn and protocol

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: git push --delete origin client-java-release-branch
+      - run: git push --delete https://$REPO_GITHUB_TOKEN@github.com/graknlabs/client-java $CIRCLE_BRANCH
 
 workflows:
   client-java:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,15 @@ jobs:
           export RELEASE_APPROVAL_TOKEN=$REPO_GITHUB_TOKEN
           bazel run @graknlabs_build_tools//ci:release-approval
 
+  release-validate:
+    machine: true
+    steps:
+      - install-bazel-linux-rbe
+      - checkout
+      - run: |
+          bazel run @graknlabs_build_tools//ci:release-validate-deps -- \
+            graknlabs_grakn_core graknlabs_protocol
+
   deploy-github:
     machine: true
     working_directory: ~/client-java
@@ -186,10 +195,16 @@ workflows:
             - sync-dependencies-snapshot
   client-java-release:
     jobs:
+      - release-validate:
+          filters:
+            branch:
+              only: client-java-release-branch
       - deploy-github:
           filters:
             branches:
               only: client-java-release-branch
+          requires:
+            - release-validate
       - deploy-approval:
           type: approval
           requires:


### PR DESCRIPTION
## What is the goal of this PR?

We have added a validation step using `//ci:release-validate-deps` in order to ensure that client-java is releasable only if it depends on released versions of grakn and protocol