### PR TITLE
Fix CI by upgrading @graknlabs_build_tools

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,7 +22,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "04c69fbe5277bf2ed9e2baf5e9a53ac3c9ebee80", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "697bef1f7c71582d719fb4fef6b2f7af935b2fee", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_grakn_core():


### PR DESCRIPTION
## What is the goal of this PR?

`deploy-maven-snapshot` CI job needs to be fixed by upgrading `bazel-distribution` rules

## What are the changes implemented in this PR?

Upgrade `@graknlabs_build_tools` to include latest `bazel-distribution`