### PR TITLE
Return Type rather than SchemaConcept in getMetaConcept()

### DIFF
--- a/GraknClient.java
+++ b/GraknClient.java
@@ -581,7 +581,7 @@ public class GraknClient implements AutoCloseable {
             }
         }
 
-        public SchemaConcept getMetaConcept() {
+        public grakn.client.concept.Type getMetaConcept() {
             return getSchemaConcept(Label.of(Graql.Token.Type.THING.toString()));
         }
 


### PR DESCRIPTION
## What is the goal of this PR?
Recent changes return `SchemaConcept` instead of `Type` from `tx.getMetaConcept()`, which has been reverted to the old beavhior.

## What are the changes implemented in this PR?
* return `Type` instead of `SchemaConcept`