### PR TITLE
Readd missing Tx And ConceptMap methods

### DIFF
--- a/GraknClient.java
+++ b/GraknClient.java
@@ -319,10 +319,6 @@ public class GraknClient implements AutoCloseable {
             return stream(query, true);
         }
 
-        public Stream<? extends Answer> stream(GraqlQuery query) {
-            return stream(query, true);
-        }
-
         // Aggregate Query
 
         public List<Numeric> execute(GraqlGet.Aggregate query) {
@@ -418,8 +414,19 @@ public class GraknClient implements AutoCloseable {
             return StreamSupport.stream(iterable.spliterator(), false);
         }
 
+        // Generic queries
 
+        public List<? extends Answer> execute(GraqlQuery query) {
+            return execute(query, true);
+        }
 
+        public List<? extends Answer> execute(GraqlQuery query, boolean infer) {
+            return stream(query, infer).collect(Collectors.toList());
+        }
+
+        public Stream<? extends Answer> stream(GraqlQuery query) {
+            return stream(query, true);
+        }
 
         public Stream<? extends Answer> stream(GraqlQuery query, boolean infer) {
             if (query instanceof GraqlDefine) {

--- a/answer/ConceptMap.java
+++ b/answer/ConceptMap.java
@@ -24,6 +24,7 @@ import grakn.client.concept.GraknConceptException;
 import graql.lang.statement.Variable;
 
 import javax.annotation.CheckReturnValue;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Map;
@@ -54,9 +55,17 @@ public class ConceptMap extends Answer {
     }
 
 
+    public Collection<Concept> concepts() {
+        return map.values();
+    }
+
     @CheckReturnValue
     public Concept get(String variable) {
-        Variable var = new Variable(variable);
+        return get(new Variable(variable));
+    }
+
+    @CheckReturnValue
+    public Concept get(Variable var) {
         Concept Concept = map.get(var);
         if (Concept == null) throw GraknConceptException.variableDoesNotExist(var.toString());
         return Concept;


### PR DESCRIPTION
## What is the goal of this PR?
Prior refactors forgot to re-implemented generic query methods from the now-removed `Transaction` interface -- `Transaction.execute(GraqlQuery)`. This has been re-added.

## What are the changes implemented in this PR?
* Add missing methods in `Transaction`
* Add some extra helper methods in `ConceptMap` that were being used in Core tests and Docs for now
