### PR TITLE
Adapt to latest changes in bazel-distribution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
       - run: |
           export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
-          bazel run //:deploy-maven -- snapshot $CIRCLE_SHA1
+          bazel run --define version=$(git rev-parse HEAD) //:deploy-maven -- snapshot
 
   test-deployment-maven:
     machine: true
@@ -164,7 +164,7 @@ jobs:
       - run: |
           export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
-          bazel run //:deploy-maven -- release $(cat VERSION)
+          bazel run --define version=$(cat VERSION) //:deploy-maven -- release
 
   sync-dependencies-release:
     machine: true

--- a/BUILD
+++ b/BUILD
@@ -68,7 +68,6 @@ assemble_maven(
     name = "assemble-maven",
     target = ":client-java",
     package = "client-java",
-    version_file = "//:VERSION",
     workspace_refs = "@graknlabs_client_java_workspace_refs//:refs.json",
     project_name = "Grakn Client Java",
     project_description = "Grakn Client API for Java",

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -23,7 +23,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "a898bbb0d88932409addbba2a18846ddaaf18f91", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "fd5991143dc2d7a0db895e2588688313005882d6", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_grakn_core():


### PR DESCRIPTION
## What is the goal of this PR?

graknlabs/bazel-distribution#191 changed the way Maven JARs are built. This PR adapts `protocol` to latest changes

## What are the changes implemented in this PR?

* Use `--define` to supply version to Maven deployment rule
* Remove `version_file` from `assemble_maven` arguments
* Upgrade `@graknlabs_build_tools`
