### PR TITLE
Refactor how version is provided to deployment rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
           bazel run @graknlabs_build_tools//ci:release-notes -- client-java $(cat VERSION) ./RELEASE_TEMPLATE.md
       - run: |
           export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
-          bazel run //:deploy-github -- $CIRCLE_SHA1
+          bazel run --define version=$(cat VERSION) //:deploy-github -- $CIRCLE_SHA1
 
   deploy-maven-release:
     machine: true

--- a/BUILD
+++ b/BUILD
@@ -86,5 +86,4 @@ deploy_github(
     title = "Grakn Client Java",
     title_append_version = True,
     deployment_properties = "//:deployment.properties",
-    version_file = "//:VERSION"
 )


### PR DESCRIPTION
## What is the goal of this PR?

Adapt `@graknlabs_client_java` to latest changes in bazel-distribution (in particular, graknlabs/bazel-distribution#150)

## What are the changes implemented in this PR?

Instead of supplying `version_file` everywhere, use `--define version=<>` as a Bazel argument to supply version.

