### PR TITLE
Move to new Delete answer type Void

### DIFF
--- a/answer/ConceptSet.java
+++ b/answer/ConceptSet.java
@@ -33,12 +33,8 @@ public class ConceptSet extends Answer {
     private final Explanation explanation;
 
     public ConceptSet(Set<ConceptId> set) {
-        this(set, new Explanation());
-    }
-
-    public ConceptSet(Set<ConceptId> set, Explanation explanation) {
         this.set = Collections.unmodifiableSet(set);
-        this.explanation = explanation;
+        this.explanation = new Explanation();
     }
 
     @Override

--- a/answer/ConceptSetMeasure.java
+++ b/answer/ConceptSetMeasure.java
@@ -31,11 +31,7 @@ public class ConceptSetMeasure extends ConceptSet {
     private final Number measurement;
 
     public ConceptSetMeasure(Set<ConceptId> set, Number measurement) {
-        this(set, measurement, new Explanation());
-    }
-
-    public ConceptSetMeasure(Set<ConceptId> set, Number measurement, Explanation explanation) {
-        super(set, explanation);
+        super(set);
         this.measurement = measurement;
     }
 

--- a/answer/Void.java
+++ b/answer/Void.java
@@ -19,41 +19,24 @@
 
 package grakn.client.answer;
 
-import graql.lang.pattern.Pattern;
-
-import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
-import java.util.Collections;
-import java.util.List;
 
-/**
- * Reasoner explanation for inferred answers
- */
-public class Explanation {
+public class Void extends Answer {
+    private final Explanation explanation;
+    private final String message;
 
-    private final Pattern pattern;
-    private final List<ConceptMap> answers;
-
-    Explanation() {
-        this.pattern = null;
-        this.answers = Collections.unmodifiableList(Collections.emptyList());
+    public Void(String message) {
+        this.message = message;
+        explanation = new Explanation();
     }
 
-    public Explanation(Pattern pattern, List<ConceptMap> ans) {
-        this.pattern = pattern;
-        this.answers = Collections.unmodifiableList(ans);
-    }
-
-    /**
-     * @return query pattern associated with this explanation
-     */
-    @CheckReturnValue
     @Nullable
-    public Pattern getPattern() { return pattern;}
+    @Override
+    public Explanation explanation() {
+        return explanation;
+    }
 
-    /**
-     * @return answers this explanation is dependent on
-     */
-    @CheckReturnValue
-    public List<ConceptMap> getAnswers() { return answers;}
+    public String message() {
+        return message;
+    }
 }

--- a/rpc/ResponseReader.java
+++ b/rpc/ResponseReader.java
@@ -20,6 +20,7 @@
 package grakn.client.rpc;
 
 import grakn.client.GraknClient;
+import grakn.client.answer.Void;
 import grakn.client.concept.ConceptImpl;
 import grakn.protocol.session.AnswerProto;
 import graql.lang.Graql;
@@ -67,6 +68,8 @@ public class ResponseReader {
                 return conceptSetMeasure(res.getConceptSetMeasure());
             case VALUE:
                 return value(res.getValue());
+            case VOID:
+                return voidAnswer(res.getVoid());
             default:
             case ANSWER_NOT_SET:
                 throw new IllegalArgumentException("Unexpected " + res);
@@ -112,6 +115,10 @@ public class ResponseReader {
 
     private static Numeric value(AnswerProto.Value res) {
         return new Numeric(number(res.getNumber()));
+    }
+
+    private static Void voidAnswer(AnswerProto.Void res) {
+        return new Void(res.getMessage());
     }
 
     private static Number number(AnswerProto.Number res) {


### PR DESCRIPTION
## What is the goal of this PR?
To resolve the issue https://github.com/graknlabs/grakn/issues/4969, where the response to a delete query is too large for a GRPC message, we have decided in a slight paradigm shift with `delete` queries:

1. straight delete queries `match...; delete...;` only return a message rather than the halfway house of all deleted Concept IDs (this was always awkward, should either return a Concept -- hard because vertex deleted, or nothing. We have opted for nothing).
2. If you want to know what was deleted, this implies your behavior was a _retrieve_ followed by a _delete_. This retrieve should be performed explicltly by the user not implicitly by Grakn, ie. a `match...; get...;` followed by `delete` using Concept API, or using a separate `match...; delete;` query.

## What are the changes implemented in this PR?
* `GraqlDelete` queries now return `grakn.client.answer.Void` answer type with just a status message.
