### PR TITLE
Integrate checking for unused Java dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,8 @@ jobs:
       - run: bazel run @graknlabs_build_tools//checkstyle:test-coverage
       - run-bazel-rbe:
           command: bazel build //...
+      - run: bazel run @graknlabs_build_tools//unused_deps -- list
+
 
   build-checkstyle:
     machine: true
@@ -60,16 +62,6 @@ jobs:
       - run: bazel run @graknlabs_build_tools//checkstyle:test-coverage
       - run-bazel-rbe:
           command: bazel test $(bazel query 'kind(checkstyle_test, //...)')
-
-  build-unused-deps:
-    machine: true
-    working_directory: ~/grakn
-    steps:
-      - install-bazel-linux-rbe
-      - checkout
-      - run:
-          command: bazel run @graknlabs_build_tools//unused_deps -- list
-          no_output_timeout: 30m
 
   test-concept:
     machine: true
@@ -202,10 +194,6 @@ workflows:
             branches:
               ignore: client-java-release-branch
       - build-checkstyle:
-          filters:
-            branches:
-              ignore: client-java-release-branch
-      - build-unused-deps:
           filters:
             branches:
               ignore: client-java-release-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,16 @@ jobs:
       - run-bazel-rbe:
           command: bazel test $(bazel query 'kind(checkstyle_test, //...)')
 
+  build-unused-deps:
+    machine: true
+    working_directory: ~/grakn
+    steps:
+      - install-bazel-linux-rbe
+      - checkout
+      - run:
+          command: bazel run @graknlabs_build_tools//unused_deps -- list
+          no_output_timeout: 30m
+
   test-concept:
     machine: true
     working_directory: ~/client-java
@@ -192,6 +202,10 @@ workflows:
             branches:
               ignore: client-java-release-branch
       - build-checkstyle:
+          filters:
+            branches:
+              ignore: client-java-release-branch
+      - build-unused-deps:
           filters:
             branches:
               ignore: client-java-release-branch

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,6 +38,9 @@ graknlabs_graql()
 load("@graknlabs_build_tools//distribution:dependencies.bzl", "graknlabs_bazel_distribution")
 graknlabs_bazel_distribution()
 
+load("@graknlabs_build_tools//unused_deps:dependencies.bzl", "unused_deps_dependencies")
+unused_deps_dependencies()
+
 
 ###########################
 # Load Bazel dependencies #

--- a/test/behaviour/connection/keyspace/BUILD
+++ b/test/behaviour/connection/keyspace/BUILD
@@ -30,7 +30,6 @@ java_test(
     deps = [
         # Package dependencies
         "//test/behaviour/connection:steps",
-        "//test/behaviour/config:type-registry-config",
         "//test/setup:grakn-setup",
 
         "@graknlabs_common//:common",
@@ -40,6 +39,9 @@ java_test(
         "//dependencies/maven/artifacts/io/cucumber:cucumber-core",
         "//dependencies/maven/artifacts/io/cucumber:cucumber-java",
         "//dependencies/maven/artifacts/io/cucumber:cucumber-junit",
+    ],
+    runtime_deps = [
+        "//test/behaviour/config:type-registry-config",
     ],
     data = [
         "@graknlabs_behaviour//connection:keyspace.feature",
@@ -67,7 +69,6 @@ java_test(
     deps = [
         # Package dependencies
         "//test/behaviour/connection:steps",
-        "//test/behaviour/config:type-registry-config",
         "//test/setup:grakn-setup",
 
         "@graknlabs_common//:common",
@@ -80,6 +81,9 @@ java_test(
     ],
     data = [
         "@graknlabs_behaviour//connection:keyspace.feature",
+    ],
+    runtime_deps = [
+        "//test/behaviour/config:type-registry-config",
     ],
     args = [ # The order of the arguments matter
         "grakn-kgms", # Keep at index 0, will be accessible at args[1]

--- a/test/behaviour/connection/session/BUILD
+++ b/test/behaviour/connection/session/BUILD
@@ -31,7 +31,6 @@ java_test(
         # Package dependencies
         "//:client-java",
         "//test/behaviour/connection:steps",
-        "//test/behaviour/config:type-registry-config",
         "//test/setup:grakn-setup",
 
         # External dependencies from Maven
@@ -43,6 +42,9 @@ java_test(
     data = [
         "@graknlabs_behaviour//connection:session.feature",
         "@graknlabs_grakn_core//:assemble-linux-targz", # Make sure to pass the path in args below
+    ],
+    runtime_deps = [
+        "//test/behaviour/config:type-registry-config",
     ],
     args = [ # The order of the arguments matter
         "grakn-core", # Keep at index 0, will be accessible at args[1]
@@ -67,7 +69,6 @@ java_test(
         # Package dependencies
         "//:client-java",
         "//test/behaviour/connection:steps",
-        "//test/behaviour/config:type-registry-config",
         "//test/setup:grakn-setup",
 
         # External dependencies from Maven
@@ -75,6 +76,9 @@ java_test(
         "//dependencies/maven/artifacts/io/cucumber:cucumber-core",
         "//dependencies/maven/artifacts/io/cucumber:cucumber-java",
         "//dependencies/maven/artifacts/io/cucumber:cucumber-junit",
+    ],
+    runtime_deps = [
+        "//test/behaviour/config:type-registry-config",
     ],
     data = [
         "@graknlabs_behaviour//connection:session.feature",

--- a/test/behaviour/connection/transaction/BUILD
+++ b/test/behaviour/connection/transaction/BUILD
@@ -29,13 +29,15 @@ java_test(
     test_class = "grakn.client.test.behaviour.connection.transaction.TransactionTest",
     deps = [
         # Package dependencies
-        "//test/behaviour/connection:steps",
-        "//test/behaviour/config:type-registry-config",
         "//test/setup:grakn-setup",
 
         # External dependencies from Maven
         "//dependencies/maven/artifacts/io/cucumber:cucumber-core",
         "//dependencies/maven/artifacts/io/cucumber:cucumber-junit",
+    ],
+    runtime_deps = [
+        "//test/behaviour/connection:steps",
+        "//test/behaviour/config:type-registry-config",
     ],
     data = [
         "@graknlabs_behaviour//connection:transaction.feature",
@@ -62,8 +64,6 @@ java_test(
     test_class = "grakn.client.test.behaviour.connection.transaction.TransactionTest",
     deps = [
         # Package dependencies
-        "//test/behaviour/connection:steps",
-        "//test/behaviour/config:type-registry-config",
         "//test/setup:grakn-setup",
 
         # External dependencies from Maven
@@ -72,6 +72,10 @@ java_test(
     ],
     data = [
         "@graknlabs_behaviour//connection:transaction.feature",
+    ],
+    runtime_deps = [
+        "//test/behaviour/connection:steps",
+        "//test/behaviour/config:type-registry-config",
     ],
     args = [ # The order of the arguments matter
         "grakn-kgms", # Keep at index 0, will be accessible at args[1]

--- a/test/behaviour/debug/BUILD
+++ b/test/behaviour/debug/BUILD
@@ -28,8 +28,6 @@ java_test(
     test_class = "grakn.client.test.behaviour.debug.DebugTest",
     deps = [
         # Package dependencies
-        "//test/behaviour/connection:steps",
-        "//test/behaviour/config:type-registry-config",
         "//test/setup:grakn-setup",
 
         # TODO: Add your addition debugging dependencies here
@@ -38,6 +36,10 @@ java_test(
         # External dependencies from Maven
         "//dependencies/maven/artifacts/io/cucumber:cucumber-core",
         "//dependencies/maven/artifacts/io/cucumber:cucumber-junit",
+    ],
+    runtime_deps = [
+        "//test/behaviour/connection:steps",
+        "//test/behaviour/config:type-registry-config",
     ],
     data = [
         ":debug.feature",


### PR DESCRIPTION
## What is the goal of this PR?

Integrate checking for unused Java dependencies

## What are the changes implemented in this PR?

- Load `@graknlabs_build_tools//unused_deps`'s dependencies
- Check for unused dependencies in `build` CI job
- Move libraries that are only required in runtime to `runtime_deps`
