### PR TITLE
Close transaction on fully on commit

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -58,5 +58,5 @@ def graknlabs_verification():
     git_repository(
         name = "graknlabs_verification",
         remote = "https://github.com/graknlabs/verification",
-        commit = "df43b13b5cb9f8c991ece1a610983f412366a9a0"
+        commit = "d2ba7fe88d67dd75152c20e7858c64f8b2be37e5"
     )

--- a/rpc/Transceiver.java
+++ b/rpc/Transceiver.java
@@ -88,6 +88,7 @@ public class Transceiver implements AutoCloseable {
     public void close() {
         try {
             requestSender.onCompleted();
+            responseListener.onCompleted();
         } catch (IllegalStateException e) {
             //IGNORED
             //This is needed to handle the fact that:


### PR DESCRIPTION
## What is the goal of this PR?
A transaction can currently be committed but still return `true` for `isOpen()`. We should have the following behavior:

1. comitting the tx should close the tx; re-committing the tx should throw an exception
2. closing a committed/closed tx should be idempotent and do nothing.

## What are the changes implemented in this PR?
* Fully close the receivers and senders 

