### PR TITLE
Add steps for tx commit and close BDD

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -58,5 +58,5 @@ def graknlabs_verification():
     git_repository(
         name = "graknlabs_verification",
         remote = "https://github.com/graknlabs/verification",
-        commit = "d2ba7fe88d67dd75152c20e7858c64f8b2be37e5"
+        commit = "4751651f2129e9a09cfc41e3d5cd77721c8f6bb4"
     )

--- a/test/behaviour/connection/transaction/TransactionSteps.java
+++ b/test/behaviour/connection/transaction/TransactionSteps.java
@@ -32,6 +32,7 @@ import java.util.function.Consumer;
 
 import static java.util.Objects.isNull;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class TransactionSteps {
@@ -62,17 +63,8 @@ public class TransactionSteps {
         for_each_session_transactions_are(transaction -> assertEquals(isOpen, transaction.isOpen()));
     }
 
-    @Then("for each session, transaction commit")
-    public void for_each_session_transaction_commit() {
-        for (GraknClient.Session session : ConnectionSteps.sessions) {
-            for (GraknClient.Transaction transaction : ConnectionSteps.sessionsToTransactions.get(session)) {
-                transaction.commit();
-            }
-        }
-    }
-
-    @Then("for each session, transaction commit throws")
-    public void for_each_session_transaction_commit_throws() {
+    @Then("for each session, transaction commits successfully: {bool}")
+    public void for_each_session_transaction_commit(boolean expectNoException) {
         for (GraknClient.Session session : ConnectionSteps.sessions) {
             for (GraknClient.Transaction transaction : ConnectionSteps.sessionsToTransactions.get(session)) {
                 boolean threw = false;
@@ -81,7 +73,11 @@ public class TransactionSteps {
                 } catch (RuntimeException commitException) {
                     threw = true;
                 }
-                assertTrue(threw);
+                if (expectNoException) {
+                    assertFalse(threw);
+                } else {
+                    assertTrue(threw);
+                }
             }
         }
     }

--- a/test/behaviour/connection/transaction/TransactionSteps.java
+++ b/test/behaviour/connection/transaction/TransactionSteps.java
@@ -62,6 +62,39 @@ public class TransactionSteps {
         for_each_session_transactions_are(transaction -> assertEquals(isOpen, transaction.isOpen()));
     }
 
+    @Then("for each session, transaction commit")
+    public void for_each_session_transaction_commit() {
+        for (GraknClient.Session session : ConnectionSteps.sessions) {
+            for (GraknClient.Transaction transaction : ConnectionSteps.sessionsToTransactions.get(session)) {
+                transaction.commit();
+            }
+        }
+    }
+
+    @Then("for each session, transaction commit throws")
+    public void for_each_session_transaction_commit_throws() {
+        for (GraknClient.Session session : ConnectionSteps.sessions) {
+            for (GraknClient.Transaction transaction : ConnectionSteps.sessionsToTransactions.get(session)) {
+                boolean threw = false;
+                try {
+                    transaction.commit();
+                } catch (RuntimeException commitException) {
+                    threw = true;
+                }
+                assertTrue(threw);
+            }
+        }
+    }
+
+    @Then("for each session, transaction close")
+    public void for_each_session_transaction_close() {
+        for (GraknClient.Session session : ConnectionSteps.sessions) {
+            for (GraknClient.Transaction transaction : ConnectionSteps.sessionsToTransactions.get(session)) {
+                transaction.close();
+            }
+        }
+    }
+
     private void for_each_session_transactions_are(Consumer<GraknClient.Transaction> assertion) {
         for (GraknClient.Session session : ConnectionSteps.sessions) {
             for (GraknClient.Transaction transaction : ConnectionSteps.sessionsToTransactions.get(session)) {


### PR DESCRIPTION
## What is the goal of this PR?
To match BDD steps for transaction close and commit, we implement corresponding steps for commit throwing and closing transactions explicitly

## What are the changes implemented in this PR?
Implement  steps:
* `for_each_session_transaction_commit`
* `for_each_session_transaction_commit_throws`
* `for_each_session_transaction_close`
