### PR TITLE
Modify sup() behavior of Types Concept API

### DIFF
--- a/concept/AttributeType.java
+++ b/concept/AttributeType.java
@@ -134,15 +134,6 @@ public interface AttributeType<D> extends Type {
     AttributeType<D> has(AttributeType attributeType);
 
     //------------------------------------- Accessors ---------------------------------
-//
-//    /**
-//     * Returns the supertype of this AttributeType.
-//     *
-//     * @return The supertype of this AttributeType,
-//     */
-//    @Override
-//    @Nullable
-//    AttributeType<D> sup();
 
     /**
      * Get the Attribute with the value provided, and its type, or return NULL

--- a/concept/AttributeType.java
+++ b/concept/AttributeType.java
@@ -134,15 +134,15 @@ public interface AttributeType<D> extends Type {
     AttributeType<D> has(AttributeType attributeType);
 
     //------------------------------------- Accessors ---------------------------------
-
-    /**
-     * Returns the supertype of this AttributeType.
-     *
-     * @return The supertype of this AttributeType,
-     */
-    @Override
-    @Nullable
-    AttributeType<D> sup();
+//
+//    /**
+//     * Returns the supertype of this AttributeType.
+//     *
+//     * @return The supertype of this AttributeType,
+//     */
+//    @Override
+//    @Nullable
+//    AttributeType<D> sup();
 
     /**
      * Get the Attribute with the value provided, and its type, or return NULL

--- a/concept/EntityType.java
+++ b/concept/EntityType.java
@@ -120,15 +120,6 @@ public interface EntityType extends Type {
 
     //------------------------------------- Accessors ----------------------------------
 
-//    /**
-//     * Returns the supertype of this EntityType.
-//     *
-//     * @return The supertype of this EntityType
-//     */
-//    @Override
-//    @Nullable
-//    EntityType sup();
-
     /**
      * Returns a collection of supertypes of this EntityType.
      *

--- a/concept/EntityType.java
+++ b/concept/EntityType.java
@@ -120,14 +120,14 @@ public interface EntityType extends Type {
 
     //------------------------------------- Accessors ----------------------------------
 
-    /**
-     * Returns the supertype of this EntityType.
-     *
-     * @return The supertype of this EntityType
-     */
-    @Override
-    @Nullable
-    EntityType sup();
+//    /**
+//     * Returns the supertype of this EntityType.
+//     *
+//     * @return The supertype of this EntityType
+//     */
+//    @Override
+//    @Nullable
+//    EntityType sup();
 
     /**
      * Returns a collection of supertypes of this EntityType.

--- a/concept/RelationType.java
+++ b/concept/RelationType.java
@@ -117,15 +117,6 @@ public interface RelationType extends Type {
     @Override
     RelationType isAbstract(Boolean isAbstract);
 
-//    /**
-//     * Returns the direct supertype of this RelationType.
-//     *
-//     * @return The direct supertype of this RelationType
-//     */
-//    @Override
-//    @Nullable
-//    RelationType sup();
-
     /**
      * Returns a collection of supertypes of this RelationType.
      *

--- a/concept/RelationType.java
+++ b/concept/RelationType.java
@@ -117,14 +117,14 @@ public interface RelationType extends Type {
     @Override
     RelationType isAbstract(Boolean isAbstract);
 
-    /**
-     * Returns the direct supertype of this RelationType.
-     *
-     * @return The direct supertype of this RelationType
-     */
-    @Override
-    @Nullable
-    RelationType sup();
+//    /**
+//     * Returns the direct supertype of this RelationType.
+//     *
+//     * @return The direct supertype of this RelationType
+//     */
+//    @Override
+//    @Nullable
+//    RelationType sup();
 
     /**
      * Returns a collection of supertypes of this RelationType.

--- a/concept/Role.java
+++ b/concept/Role.java
@@ -49,15 +49,6 @@ public interface Role extends SchemaConcept {
 
     //------------------------------------- Accessors ----------------------------------
 
-//    /**
-//     * Returns the super of this Role.
-//     *
-//     * @return The super of this Role
-//     */
-//    @Nullable
-//    @Override
-//    Role sup();
-
     /**
      * @return All the super-types of this this Role
      */

--- a/concept/Role.java
+++ b/concept/Role.java
@@ -49,14 +49,14 @@ public interface Role extends SchemaConcept {
 
     //------------------------------------- Accessors ----------------------------------
 
-    /**
-     * Returns the super of this Role.
-     *
-     * @return The super of this Role
-     */
-    @Nullable
-    @Override
-    Role sup();
+//    /**
+//     * Returns the super of this Role.
+//     *
+//     * @return The super of this Role
+//     */
+//    @Nullable
+//    @Override
+//    Role sup();
 
     /**
      * @return All the super-types of this this Role

--- a/concept/Rule.java
+++ b/concept/Rule.java
@@ -61,12 +61,12 @@ public interface Rule extends SchemaConcept {
      */
     Rule label(Label label);
 
-    /**
-     * @return The super of this Rule
-     */
-    @Nullable
-    @Override
-    Rule sup();
+//    /**
+//     * @return The super of this Rule
+//     */
+//    @Nullable
+//    @Override
+//    Rule sup();
 
     /**
      * @param superRule The super of this Rule

--- a/concept/Rule.java
+++ b/concept/Rule.java
@@ -61,12 +61,6 @@ public interface Rule extends SchemaConcept {
      */
     Rule label(Label label);
 
-//    /**
-//     * @return The super of this Rule
-//     */
-//    @Nullable
-//    @Override
-//    Rule sup();
 
     /**
      * @param superRule The super of this Rule

--- a/concept/SchemaConceptImpl.java
+++ b/concept/SchemaConceptImpl.java
@@ -74,7 +74,7 @@ public abstract class SchemaConceptImpl<SomeSchemaConcept extends SchemaConcept>
     }
 
     @Nullable
-    public final SomeSchemaConcept sup() {
+    public final SchemaConcept sup() {
         ConceptProto.Method.Req method = ConceptProto.Method.Req.newBuilder()
                 .setSchemaConceptGetSupReq(ConceptProto.SchemaConcept.GetSup.Req.getDefaultInstance()).build();
 
@@ -85,7 +85,8 @@ public abstract class SchemaConceptImpl<SomeSchemaConcept extends SchemaConcept>
                 return null;
             case SCHEMACONCEPT:
                 ConceptImpl concept = ConceptImpl.of(response.getSchemaConcept(), tx());
-                return equalsCurrentBaseType(concept) ? asCurrentBaseType(concept) : null;
+                return concept.asSchemaConcept();
+//                return equalsCurrentBaseType(concept) ? asCurrentBaseType(concept) : null;
             default:
                 throw GraknClientException.unreachableStatement("Unexpected response " + response);
         }

--- a/concept/SchemaConceptImpl.java
+++ b/concept/SchemaConceptImpl.java
@@ -86,7 +86,6 @@ public abstract class SchemaConceptImpl<SomeSchemaConcept extends SchemaConcept>
             case SCHEMACONCEPT:
                 ConceptImpl concept = ConceptImpl.of(response.getSchemaConcept(), tx());
                 return concept.asSchemaConcept();
-//                return equalsCurrentBaseType(concept) ? asCurrentBaseType(concept) : null;
             default:
                 throw GraknClientException.unreachableStatement("Unexpected response " + response);
         }

--- a/concept/Type.java
+++ b/concept/Type.java
@@ -88,13 +88,6 @@ public interface Type extends SchemaConcept {
     @CheckReturnValue
     Stream<AttributeType> keys();
 
-//    /**
-//     * @return The direct super of this Type
-//     */
-//    @CheckReturnValue
-//    @Nullable
-//    Type sup();
-
     /**
      * @return All the the super-types of this Type
      */

--- a/concept/Type.java
+++ b/concept/Type.java
@@ -88,12 +88,12 @@ public interface Type extends SchemaConcept {
     @CheckReturnValue
     Stream<AttributeType> keys();
 
-    /**
-     * @return The direct super of this Type
-     */
-    @CheckReturnValue
-    @Nullable
-    Type sup();
+//    /**
+//     * @return The direct super of this Type
+//     */
+//    @CheckReturnValue
+//    @Nullable
+//    Type sup();
 
     /**
      * @return All the the super-types of this Type

--- a/test/integration/concept/ConceptIT.java
+++ b/test/integration/concept/ConceptIT.java
@@ -347,12 +347,6 @@ public class ConceptIT {
         assertEquals(metaType, livingThing.sup().sup());
     }
 
-
-    @Test
-    public void whenCallingSupOnMetaType_GetNull() {
-        assertNull(tx.getEntityType("entity").sup());
-    }
-
     @Test
     public void whenCallingType_GetTheExpectedResult() {
         assertEquals(email, emailAlice.type());

--- a/test/integration/concept/ConceptIT.java
+++ b/test/integration/concept/ConceptIT.java
@@ -33,6 +33,7 @@ import grakn.client.concept.RelationType;
 import grakn.client.concept.Role;
 import grakn.client.concept.Rule;
 import grakn.client.concept.Thing;
+import grakn.client.concept.Type;
 import grakn.client.test.setup.GraknProperties;
 import grakn.client.test.setup.GraknSetup;
 import graql.lang.Graql;
@@ -128,6 +129,7 @@ public class ConceptIT {
     private RelationType employment;
     private Rule metaRule;
     private Rule testRule;
+    private Type metaType;
 
     private Attribute<String> emailAlice;
     private Attribute<String> emailBob;
@@ -210,6 +212,8 @@ public class ConceptIT {
         // Relations
         aliceAndBob = marriage.create().assign(wife, alice).assign(husband, bob);
         selfEmployment = employment.create().assign(employer, alice).assign(employee, alice);
+
+        metaType = tx.getType(Label.of("thing"));
 
     }
 
@@ -337,6 +341,12 @@ public class ConceptIT {
     public void whenCallingSup_GetTheExpectedResult() {
         assertEquals(livingThing, person.sup());
     }
+
+    @Test
+    public void whenCallingSupOnEntity_GetMetaType() {
+        assertEquals(metaType, livingThing.sup().sup());
+    }
+
 
     @Test
     public void whenCallingSupOnMetaType_GetNull() {


### PR DESCRIPTION
## What is the goal of this PR?
We previously had the behavior that the supertype of one of the base types (`Entity`, `Relation`, `Attribute`) returned null. This was because going further up the chain of `sup()`s results in  a change of the Java Class itself when going from `Entity` to `Thing`.

To make this change, `sup()` now generically returns a `SchemaConcept` instead of a specialised type (such as an `Entity` always returning a `Entity` via `sup()`)

## What are the changes implemented in this PR?
* Remove specialised sup() implementations in each subtype of `SchemaConcept`, using just `SchemaConcept` implementation that returns other `SchemaConcept`
*  Add tests to ensure returning the super type of Entity returns Thing