### PR TITLE
Fix nullpointer when there is a NOOP trace on the thread

### DIFF
--- a/rpc/RequestBuilder.java
+++ b/rpc/RequestBuilder.java
@@ -38,6 +38,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import static grabl.tracing.client.GrablTracingThreadStatic.ThreadTrace;
 import static grabl.tracing.client.GrablTracingThreadStatic.currentThreadTrace;
@@ -311,6 +312,10 @@ public class RequestBuilder {
         if (isTracingEnabled()) {
             ThreadTrace threadTrace = currentThreadTrace();
             if (threadTrace == null) {
+                return Collections.emptyMap();
+            }
+
+            if (threadTrace.getId() == null || threadTrace.getRootId() == null) {
                 return Collections.emptyMap();
             }
 

--- a/rpc/RequestBuilder.java
+++ b/rpc/RequestBuilder.java
@@ -38,7 +38,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 import static grabl.tracing.client.GrablTracingThreadStatic.ThreadTrace;
 import static grabl.tracing.client.GrablTracingThreadStatic.currentThreadTrace;


### PR DESCRIPTION
## What is the goal of this PR?

To fix a bug when there is a NOOP trace on the thread.

## What are the changes implemented in this PR?

- Check that the relevant fields are not null before attempting to convert them.