### PR TITLE
Add sync-deps marker for grabl-tracing

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -65,5 +65,5 @@ def graknlabs_grabl_tracing():
     git_repository(
         name = "graknlabs_grabl_tracing",
         remote = "https://github.com/graknlabs/grabl-tracing",
-        commit = "7f04b4a9629402b958325717a7ebb9ebf03b47fe"
+        commit = "7f04b4a9629402b958325717a7ebb9ebf03b47fe"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grabl_tracing
     )


### PR DESCRIPTION
## What is the goal of this PR?

Add a sync-dependencies marker for grabl-tracing.