### PR TITLE
Allow duplicate role players

### DIFF
--- a/concept/Relation.java
+++ b/concept/Relation.java
@@ -20,6 +20,7 @@
 package grakn.client.concept;
 
 import javax.annotation.CheckReturnValue;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -60,7 +61,7 @@ public interface Relation extends Thing {
      * @see Role
      */
     @CheckReturnValue
-    Map<Role, Set<Thing>> rolePlayersMap();
+    Map<Role, List<Thing>> rolePlayersMap();
 
     /**
      * Retrieves a list of every Thing involved in the Relation, filtered by Role played.

--- a/concept/RelationImpl.java
+++ b/concept/RelationImpl.java
@@ -23,10 +23,12 @@ import grakn.client.GraknClient;
 import grakn.client.rpc.RequestBuilder;
 import grakn.protocol.session.ConceptProto;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -41,7 +43,7 @@ public class RelationImpl extends ThingImpl<Relation, RelationType> implements R
     }
 
     @Override
-    public final Map<Role, Set<Thing>> rolePlayersMap() {
+    public final Map<Role, List<Thing>> rolePlayersMap() {
         ConceptProto.Method.Req method = ConceptProto.Method.Req.newBuilder()
                 .setRelationRolePlayersMapReq(ConceptProto.Relation.RolePlayersMap.Req.getDefaultInstance()).build();
 
@@ -50,14 +52,14 @@ public class RelationImpl extends ThingImpl<Relation, RelationType> implements R
                 iteratorId, res -> res.getConceptMethodIterRes().getRelationRolePlayersMapIterRes()
         );
 
-        Map<Role, Set<Thing>> rolePlayerMap = new HashMap<>();
+        Map<Role, List<Thing>> rolePlayerMap = new HashMap<>();
         for (ConceptProto.Relation.RolePlayersMap.Iter.Res rolePlayer : rolePlayers) {
             Role role = ConceptImpl.of(rolePlayer.getRole(), tx()).asRole();
             Thing player = ConceptImpl.of(rolePlayer.getPlayer(), tx()).asThing();
             if (rolePlayerMap.containsKey(role)) {
                 rolePlayerMap.get(role).add(player);
             } else {
-                rolePlayerMap.put(role, new HashSet<>(Collections.singletonList(player)));
+                rolePlayerMap.put(role, new ArrayList<>(Collections.singletonList(player)));
             }
         }
 

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -44,7 +44,7 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "0518f925b715158053fc3f8c4a65cb0f73cd3c42", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "b8e230acb6a62f3722962d7132463f5071255c4e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -59,7 +59,7 @@ def graknlabs_verification():
         name = "graknlabs_verification",
 #        remote = "https://github.com/graknlabs/verification",
         remote = "https://github.com/flyingsilverfin/verification",
-        commit = "a72b4943bd30aa13071568e014d7d1e30224008b"
+        commit = "99bbe914fb2f97233cea697b42b8966d05bf58cc"
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -43,8 +43,8 @@ def graknlabs_build_tools():
 def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
-        remote = "https://github.com/flyingsilverfin/grakn",
-        commit = "3aff8167a639fe8d6f0d716b87124be8a992e76b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        remote = "https://github.com/graknlabs/grakn",
+        commit = "0518f925b715158053fc3f8c4a65cb0f73cd3c42", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -57,9 +57,8 @@ def graknlabs_protocol():
 def graknlabs_verification():
     git_repository(
         name = "graknlabs_verification",
-#        remote = "https://github.com/graknlabs/verification",
-        remote = "https://github.com/flyingsilverfin/verification",
-        commit = "99bbe914fb2f97233cea697b42b8966d05bf58cc"
+        remote = "https://github.com/graknlabs/verification",
+        commit = "2e776ed631dd2c1162506adb2a560df8df8c71f5"
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -44,7 +44,7 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/flyingsilverfin/grakn",
-        commit = "10f9f1c453a00b27c77223e9f0b1a22dbeb9c982", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "3aff8167a639fe8d6f0d716b87124be8a992e76b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -57,8 +57,9 @@ def graknlabs_protocol():
 def graknlabs_verification():
     git_repository(
         name = "graknlabs_verification",
-        remote = "https://github.com/graknlabs/verification",
-        commit = "cc7237bcf1babbf46c281476971849a1872048e2"
+#        remote = "https://github.com/graknlabs/verification",
+        remote = "https://github.com/flyingsilverfin/verification",
+        commit = "a72b4943bd30aa13071568e014d7d1e30224008b"
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -43,8 +43,8 @@ def graknlabs_build_tools():
 def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
-        remote = "https://github.com/graknlabs/grakn",
-        commit = "833dba18e4b4adc5a584f41de35ed2cc9689c3bd", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        remote = "https://github.com/flyingsilverfin/grakn",
+        commit = "10f9f1c453a00b27c77223e9f0b1a22dbeb9c982", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():

--- a/test/integration/concept/ConceptIT.java
+++ b/test/integration/concept/ConceptIT.java
@@ -434,16 +434,16 @@ public class ConceptIT {
 
     @Test
     public void whenCallingAllRolePlayers_GetTheExpectedResult() {
-        Map<Role, Set<Thing>> expected = new HashMap<>();
-        expected.put(wife, Collections.singleton(alice));
-        expected.put(husband, Collections.singleton(bob));
+        Map<Role, List<Thing>> expected = new HashMap<>();
+        expected.put(wife, Collections.singletonList(alice));
+        expected.put(husband, Collections.singletonList(bob)));
 
         assertEquals(expected, aliceAndBob.rolePlayersMap());
     }
 
     @Test
     public void whenCallingRolePlayersWithNoArguments_GetTheExpectedResult() {
-        assertThat(aliceAndBob.rolePlayers().collect(toSet()), containsInAnyOrder(alice, bob));
+        assertThat(aliceAndBob.rolePlayers().collect(toList()), containsInAnyOrder(alice, bob));
     }
 
     @Test
@@ -455,8 +455,8 @@ public class ConceptIT {
 
     @Test
     public void whenCallingRolePlayersWithRoles_GetTheExpectedResult() {
-        assertThat(aliceAndBob.rolePlayers(wife).collect(toSet()), containsInAnyOrder(alice));
-        assertThat(aliceAndBob.rolePlayers(husband).collect(toSet()), containsInAnyOrder(bob));
+        assertThat(aliceAndBob.rolePlayers(wife).collect(toList()), containsInAnyOrder(alice));
+        assertThat(aliceAndBob.rolePlayers(husband).collect(toList()), containsInAnyOrder(bob));
     }
 
     @Test
@@ -599,12 +599,12 @@ public class ConceptIT {
                 .assign(friend, dylan)
                 .assign(friend, emily);
 
-        assertThat(dylanAndEmily.rolePlayers().collect(toSet()), containsInAnyOrder(dylan, emily));
+        assertThat(dylanAndEmily.rolePlayers().collect(toList()), containsInAnyOrder(dylan, emily));
 
         dylanAndEmily.unassign(friend, dylan);
         dylanAndEmily.unassign(friend, emily);
 
-        assertTrue(dylanAndEmily.rolePlayers().collect(toSet()).isEmpty());
+        assertTrue(dylanAndEmily.rolePlayers().collect(toList()).isEmpty());
     }
 
 

--- a/test/integration/concept/ConceptIT.java
+++ b/test/integration/concept/ConceptIT.java
@@ -402,13 +402,13 @@ public class ConceptIT {
 
     @Test
     public void whenCallingThingPlays_GetTheExpectedResult() {
-        assertThat(alice.roles().filter(r -> !r.isImplicit()).collect(toSet()), containsInAnyOrder(wife, employee, employer));
+        assertThat(alice.roles().filter(r -> !r.isImplicit()).collect(toSet()), containsInAnyOrder(wife, employee, employer, friend));
         assertThat(bob.roles().filter(r -> !r.isImplicit()).collect(toSet()), containsInAnyOrder(husband));
     }
 
     @Test
     public void whenCallingRelationsWithNoArguments_GetTheExpectedResult() {
-        assertThat(alice.relations().filter(rel -> !rel.type().isImplicit()).collect(toSet()), containsInAnyOrder(aliceAndBob, selfEmployment));
+        assertThat(alice.relations().filter(rel -> !rel.type().isImplicit()).collect(toSet()), containsInAnyOrder(aliceAndBob, selfEmployment, selfFriendship));
         assertThat(bob.relations().filter(rel -> !rel.type().isImplicit()).collect(toSet()), containsInAnyOrder(aliceAndBob));
     }
 
@@ -457,10 +457,10 @@ public class ConceptIT {
     }
 
     @Test
-    public void whenCallingRolePlayersWithNoArgumentsOnReflexiveRelation_GetDistinctExpectedResult() {
+    public void whenCallingRolePlayersWithNoArgumentsOnReflexiveRelation_GetExpectedResult() {
         List<Thing> list = selfEmployment.rolePlayers().collect(toList());
-        assertEquals(1, list.size());
-        assertThat(list, containsInAnyOrder(alice));
+        assertEquals(2, list.size());
+        assertThat(list, containsInAnyOrder(alice, alice));
     }
 
     @Test

--- a/test/integration/concept/ConceptIT.java
+++ b/test/integration/concept/ConceptIT.java
@@ -47,6 +47,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -140,6 +141,7 @@ public class ConceptIT {
     private Entity bob;
     private Relation aliceAndBob;
     private Relation selfEmployment;
+    private Relation selfFriendship;
 
     @BeforeClass
     public static void setUpClass() throws InterruptedException, IOException, TimeoutException {
@@ -212,6 +214,7 @@ public class ConceptIT {
         // Relations
         aliceAndBob = marriage.create().assign(wife, alice).assign(husband, bob);
         selfEmployment = employment.create().assign(employer, alice).assign(employee, alice);
+        selfFriendship = friendship.create().assign(friend, alice).assign(friend, alice);
 
         metaType = tx.getType(Label.of("thing"));
 
@@ -436,9 +439,16 @@ public class ConceptIT {
     public void whenCallingAllRolePlayers_GetTheExpectedResult() {
         Map<Role, List<Thing>> expected = new HashMap<>();
         expected.put(wife, Collections.singletonList(alice));
-        expected.put(husband, Collections.singletonList(bob)));
+        expected.put(husband, Collections.singletonList(bob));
 
         assertEquals(expected, aliceAndBob.rolePlayersMap());
+    }
+
+    @Test
+    public void whenCallingAllRolePlayers_GetExpectedDuplicates() {
+        Map<Role, List<Thing>> expected = new HashMap<>();
+        expected.put(friend, Arrays.asList(alice, alice));
+        assertEquals(expected, selfFriendship.rolePlayersMap());
     }
 
     @Test


### PR DESCRIPTION
## What is the goal of this PR?
Allowing duplicate roles to be played in a relation as of https://github.com/graknlabs/grakn/pull/5667.

This means now that `relation.getRolePlayerMap()` should return a map from `Role` to `List<Thing>` rather than `Set<Thing>`

## What are the changes implemented in this PR?
* Write new test for retrieving duplicate role players
* Update types for `rolePlayerMap` in the concept API