### PR TITLE
Remove references to benchmark

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ jobs:
           export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
           bazel run @graknlabs_build_tools//ci:sync-dependencies -- \
           --source client-java@$CIRCLE_SHA1 \
-          --targets console:master grakn-kgms:master benchmark:master
+          --targets console:master grakn-kgms:master
 
   release-approval:
     machine: true
@@ -230,7 +230,7 @@ jobs:
           export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
           bazel run @graknlabs_build_tools//ci:sync-dependencies -- \
           --source client-java@$(cat VERSION) \
-          --targets console:master grakn-kgms:master benchmark:master docs:master examples:master
+          --targets console:master grakn-kgms:master docs:master examples:master
 
   release-cleanup:
     machine: true

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -101,18 +101,13 @@ java_grpc_compile()
 ################################
 
 load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl",
-"graknlabs_common", "graknlabs_benchmark", "graknlabs_console")
+"graknlabs_common", "graknlabs_console")
 graknlabs_common()
-graknlabs_benchmark()
 graknlabs_console()
 
 load("@graknlabs_grakn_core//dependencies/maven:dependencies.bzl",
 graknlabs_grakn_core_maven_dependencies = "maven_dependencies")
 graknlabs_grakn_core_maven_dependencies()
-
-load("@graknlabs_benchmark//dependencies/maven:dependencies.bzl",
-graknlabs_benchmark_maven_dependencies = "maven_dependencies")
-graknlabs_benchmark_maven_dependencies()
 
 load("@graknlabs_build_tools//bazel:dependencies.bzl", "bazel_rules_docker")
 bazel_rules_docker()

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -43,8 +43,8 @@ def graknlabs_build_tools():
 def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
-        remote = "https://github.com/adammitchelldev/grakn", # TODO: Revert to graknlabs
-        commit = "d4b3b38ab621a437412186070b1c433355b998cc", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        remote = "https://github.com/graknlabs/grakn",
+        commit = "3a55caa6b9c729be912e37d33c73fdb4257348b7", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():


### PR DESCRIPTION
## What is the goal of this PR?
Remove all usages and references remaining that pointed to the `graknlabs/benchmark` repository

## What are the changes implemented in this PR?
* remove usages of and dependencies on `graknlabs/benchmark`