### PR TITLE
Fix attribute type parameter args

### DIFF
--- a/concept/Concept.java
+++ b/concept/Concept.java
@@ -132,7 +132,7 @@ public interface Concept<BaseType extends Concept<BaseType>> {
      * @return A AttributeType if the Concept is a AttributeType
      */
     @CheckReturnValue
-    default AttributeType<?> asAttributeType() {
+    default <T> AttributeType<T> asAttributeType() {
         throw GraknConceptException.invalidCasting(this, AttributeType.class);
     }
 
@@ -172,7 +172,7 @@ public interface Concept<BaseType extends Concept<BaseType>> {
      * @return A Attribute if the Concept is a Attribute
      */
     @CheckReturnValue
-    default Attribute<?> asAttribute() {
+    default <T> Attribute<T> asAttribute() {
         throw GraknConceptException.invalidCasting(this, Attribute.class);
     }
 
@@ -465,7 +465,7 @@ public interface Concept<BaseType extends Concept<BaseType>> {
          */
         @Override
         @CheckReturnValue
-        default AttributeType.Remote<?> asAttributeType() {
+        default <T> AttributeType.Remote<T> asAttributeType() {
             throw GraknConceptException.invalidCasting(this, AttributeType.Remote.class);
         }
 
@@ -509,7 +509,7 @@ public interface Concept<BaseType extends Concept<BaseType>> {
          */
         @Override
         @CheckReturnValue
-        default Attribute.Remote<?> asAttribute() {
+        default <T> Attribute.Remote<T> asAttribute() {
             throw GraknConceptException.invalidCasting(this, Attribute.Remote.class);
         }
 

--- a/concept/Concept.java
+++ b/concept/Concept.java
@@ -132,7 +132,17 @@ public interface Concept<BaseType extends Concept<BaseType>> {
      * @return A AttributeType if the Concept is a AttributeType
      */
     @CheckReturnValue
-    default <T> AttributeType<T> asAttributeType() {
+    default <D> AttributeType<D> asAttributeType() {
+        throw GraknConceptException.invalidCasting(this, AttributeType.class);
+    }
+
+    /**
+     * Return as a AttributeType if the Concept is a AttributeType
+     *
+     * @return A AttributeType if the Concept is a AttributeType
+     */
+    @CheckReturnValue
+    default <D> AttributeType<D> asAttributeType(DataType<D> dataType) {
         throw GraknConceptException.invalidCasting(this, AttributeType.class);
     }
 
@@ -172,7 +182,17 @@ public interface Concept<BaseType extends Concept<BaseType>> {
      * @return A Attribute if the Concept is a Attribute
      */
     @CheckReturnValue
-    default <T> Attribute<T> asAttribute() {
+    default <D> Attribute<D> asAttribute() {
+        throw GraknConceptException.invalidCasting(this, Attribute.class);
+    }
+
+    /**
+     * Return as a Attribute  if the Concept is a Attribute Thing.
+     *
+     * @return A Attribute if the Concept is a Attribute
+     */
+    @CheckReturnValue
+    default <D> Attribute<D> asAttribute(DataType<D> dataType) {
         throw GraknConceptException.invalidCasting(this, Attribute.class);
     }
 
@@ -465,8 +485,19 @@ public interface Concept<BaseType extends Concept<BaseType>> {
          */
         @Override
         @CheckReturnValue
-        default <T> AttributeType.Remote<T> asAttributeType() {
-            throw GraknConceptException.invalidCasting(this, AttributeType.Remote.class);
+        default <D> AttributeType.Remote<D> asAttributeType() {
+            throw GraknConceptException.invalidCasting(this, AttributeType.class);
+        }
+
+        /**
+         * Return as a AttributeType if the Concept is a AttributeType
+         *
+         * @return A AttributeType if the Concept is a AttributeType
+         */
+        @Override
+        @CheckReturnValue
+        default <D> AttributeType.Remote<D> asAttributeType(DataType<D> dataType) {
+            throw GraknConceptException.invalidCasting(this, AttributeType.class);
         }
 
         /**
@@ -509,7 +540,18 @@ public interface Concept<BaseType extends Concept<BaseType>> {
          */
         @Override
         @CheckReturnValue
-        default <T> Attribute.Remote<T> asAttribute() {
+        default <D> Attribute.Remote<D> asAttribute() {
+            throw GraknConceptException.invalidCasting(this, Attribute.Remote.class);
+        }
+
+        /**
+         * Return as a Attribute  if the Concept is a Attribute Thing.
+         *
+         * @return A Attribute if the Concept is a Attribute
+         */
+        @Override
+        @CheckReturnValue
+        default <D> Attribute.Remote<D> asAttribute(DataType<D> dataType) {
             throw GraknConceptException.invalidCasting(this, Attribute.Remote.class);
         }
 

--- a/concept/thing/Attribute.java
+++ b/concept/thing/Attribute.java
@@ -57,6 +57,7 @@ public interface Attribute<D> extends Thing<Attribute<D>, AttributeType<D>> {
 
     //------------------------------------- Other ---------------------------------
     @Deprecated
+    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @Override
     default Attribute<D> asAttribute() {
@@ -140,6 +141,7 @@ public interface Attribute<D> extends Thing<Attribute<D>, AttributeType<D>> {
         Attribute.Remote<D> unhas(Attribute<?> attribute);
 
         //------------------------------------- Other ---------------------------------
+        @SuppressWarnings("unchecked")
         @Deprecated
         @CheckReturnValue
         @Override

--- a/concept/thing/Attribute.java
+++ b/concept/thing/Attribute.java
@@ -21,11 +21,13 @@ package grakn.client.concept.thing;
 
 import grakn.client.GraknClient;
 import grakn.client.concept.ConceptId;
+import grakn.client.concept.GraknConceptException;
 import grakn.client.concept.thing.impl.AttributeImpl;
 import grakn.client.concept.type.AttributeType;
 import grakn.client.concept.DataType;
 
 import javax.annotation.CheckReturnValue;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 public interface Attribute<D> extends Thing<Attribute<D>, AttributeType<D>> {
@@ -56,12 +58,23 @@ public interface Attribute<D> extends Thing<Attribute<D>, AttributeType<D>> {
     DataType<D> dataType();
 
     //------------------------------------- Other ---------------------------------
-    @Deprecated
     @SuppressWarnings("unchecked")
+    @Deprecated
     @CheckReturnValue
     @Override
-    default Attribute<D> asAttribute() {
-        return this;
+    default <T> Attribute<T> asAttribute() {
+        return (Attribute<T>) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Deprecated
+    @CheckReturnValue
+    @Override
+    default <T> Attribute<T> asAttribute(DataType<T> dataType) {
+        if (!dataType().equals(dataType)) {
+            throw GraknConceptException.invalidCasting(this, dataType.getClass());
+        }
+        return (Attribute<T>) this;
     }
 
     @CheckReturnValue
@@ -145,8 +158,15 @@ public interface Attribute<D> extends Thing<Attribute<D>, AttributeType<D>> {
         @Deprecated
         @CheckReturnValue
         @Override
-        default Attribute.Remote<D> asAttribute() {
-            return this;
+        default <T> Attribute.Remote<T> asAttribute() {
+            return (Attribute.Remote<T>) this;
+        }
+
+        @Deprecated
+        @CheckReturnValue
+        @Override
+        default <T> Attribute.Remote<T> asAttribute(DataType<T> dataType) {
+            return (Attribute.Remote<T>) Attribute.super.asAttribute(dataType);
         }
 
         @Deprecated

--- a/concept/type/AttributeType.java
+++ b/concept/type/AttributeType.java
@@ -45,6 +45,7 @@ public interface AttributeType<D> extends Type<AttributeType<D>, Attribute<D>> {
     DataType<D> dataType();
 
     //------------------------------------- Other ---------------------------------
+    @SuppressWarnings("unchecked")
     @Deprecated
     @CheckReturnValue
     @Override
@@ -242,6 +243,7 @@ public interface AttributeType<D> extends Type<AttributeType<D>, Attribute<D>> {
         String regex();
 
         //------------------------------------- Other ---------------------------------
+        @SuppressWarnings("unchecked")
         @Deprecated
         @CheckReturnValue
         @Override

--- a/concept/type/AttributeType.java
+++ b/concept/type/AttributeType.java
@@ -22,11 +22,13 @@ package grakn.client.concept.type;
 import grakn.client.GraknClient;
 import grakn.client.concept.ConceptId;
 import grakn.client.concept.DataType;
+import grakn.client.concept.GraknConceptException;
 import grakn.client.concept.Label;
 import grakn.client.concept.thing.Attribute;
 import grakn.client.concept.type.impl.AttributeTypeImpl;
 
 import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.stream.Stream;
 
@@ -49,11 +51,21 @@ public interface AttributeType<D> extends Type<AttributeType<D>, Attribute<D>> {
     @Deprecated
     @CheckReturnValue
     @Override
-    default AttributeType<D> asAttributeType() {
-        return this;
+    default <T> AttributeType<T> asAttributeType() {
+        return (AttributeType<T>) this;
     }
 
+    @SuppressWarnings("unchecked")
+    @Deprecated
     @CheckReturnValue
+    @Override
+    default <T> AttributeType<T> asAttributeType(DataType<T> dataType) {
+        if (!dataType.equals(dataType())) {
+            throw GraknConceptException.invalidCasting(this, dataType.getClass());
+        }
+        return (AttributeType<T>) this;
+    }
+
     @Override
     default AttributeType.Remote<D> asRemote(GraknClient.Transaction tx) {
         return AttributeType.Remote.of(tx, id());
@@ -249,6 +261,13 @@ public interface AttributeType<D> extends Type<AttributeType<D>, Attribute<D>> {
         @Override
         default AttributeType.Remote<D> asAttributeType() {
             return this;
+        }
+
+        @Deprecated
+        @CheckReturnValue
+        @Override
+        default <T> AttributeType.Remote<T> asAttributeType(DataType<T> dataType) {
+            return (AttributeType.Remote<T>) AttributeType.super.asAttributeType(dataType);
         }
 
         @Deprecated

--- a/concept/type/AttributeType.java
+++ b/concept/type/AttributeType.java
@@ -259,8 +259,8 @@ public interface AttributeType<D> extends Type<AttributeType<D>, Attribute<D>> {
         @Deprecated
         @CheckReturnValue
         @Override
-        default AttributeType.Remote<D> asAttributeType() {
-            return this;
+        default <T> AttributeType.Remote<T> asAttributeType() {
+            return (AttributeType.Remote<T>) this;
         }
 
         @Deprecated

--- a/test/integration/concept/ConceptIT.java
+++ b/test/integration/concept/ConceptIT.java
@@ -48,7 +48,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 

--- a/test/integration/concept/ConceptIT.java
+++ b/test/integration/concept/ConceptIT.java
@@ -22,6 +22,7 @@ package grakn.client.test.integration.concept;
 import grakn.client.GraknClient;
 import grakn.client.concept.Concept;
 import grakn.client.concept.DataType;
+import grakn.client.concept.GraknConceptException;
 import grakn.client.concept.Label;
 import grakn.client.concept.Rule;
 import grakn.client.concept.type.Role;
@@ -62,6 +63,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Integration Tests for testing methods of all subclasses of grakn.client.concept.RemoteConcept.
@@ -613,8 +615,26 @@ public class ConceptIT {
     }
 
     @Test
-    public void whenCastingAttributeWithDataType_castsWithoutError() {
-        Concept<?> untypedAge = age;
-        AttributeType<Integer> typedAge = untypedAge.asAttributeType(DataType.INTEGER);
+    public void whenCastingAttributeWithCorrectDataType_castsWithoutError() {
+        Concept<?> untypedAgeType = age;
+        AttributeType<Integer> typedAgeType = untypedAgeType.asAttributeType(DataType.INTEGER);
+        Concept<?> untypedAgeAttr = age20;
+        Attribute<Integer> typedAgeAttr = untypedAgeAttr.asAttribute(DataType.INTEGER);
+    }
+
+    @Test
+    public void whenCastingAttributeWithWrongDataType_fails() {
+        Concept<?> untypedAgeType = age;
+        try {
+            AttributeType<String> wrong = untypedAgeType.asAttributeType(DataType.STRING);
+            fail();
+        } catch (GraknConceptException ignored) {
+        }
+        Concept<?> untypedAgeAttr = age20;
+        try {
+            Attribute<String> wrong = untypedAgeAttr.asAttribute(DataType.STRING);
+            fail();
+        } catch (GraknConceptException ignored) {
+        }
     }
 }

--- a/test/integration/concept/ConceptIT.java
+++ b/test/integration/concept/ConceptIT.java
@@ -20,6 +20,7 @@
 package grakn.client.test.integration.concept;
 
 import grakn.client.GraknClient;
+import grakn.client.concept.Concept;
 import grakn.client.concept.DataType;
 import grakn.client.concept.Label;
 import grakn.client.concept.Rule;
@@ -611,4 +612,9 @@ public class ConceptIT {
         assertTrue(dylanAndEmily.rolePlayers().collect(toList()).isEmpty());
     }
 
+    @Test
+    public void whenCastingAttributeWithDataType_castsWithoutError() {
+        Concept<?> untypedAge = age;
+        AttributeType<Integer> typedAge = untypedAge.asAttributeType(DataType.INTEGER);
+    }
 }

--- a/test/integration/concept/ConceptIT.java
+++ b/test/integration/concept/ConceptIT.java
@@ -629,12 +629,14 @@ public class ConceptIT {
             AttributeType<String> wrong = untypedAgeType.asAttributeType(DataType.STRING);
             fail();
         } catch (GraknConceptException ignored) {
+            assertTrue(true);
         }
         Concept<?> untypedAgeAttr = age20;
         try {
             Attribute<String> wrong = untypedAgeAttr.asAttribute(DataType.STRING);
             fail();
         } catch (GraknConceptException ignored) {
+            assertTrue(true);
         }
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

When we updated the concept API, we broke using type parameters to cast `asAttribute()` to a particular data type e.g. `concept.<String>asAttribute()`.

## What are the changes implemented in this PR?

Added back the ability to use type parameters in `asAttribute()`