### PR TITLE
Replaced the term 'DataType' with 'AttributeType'

### DIFF
--- a/GraknClient.java
+++ b/GraknClient.java
@@ -32,7 +32,7 @@ import grakn.client.answer.Explanation;
 import grakn.client.answer.Numeric;
 import grakn.client.answer.Void;
 import grakn.client.concept.Concept;
-import grakn.client.concept.DataType;
+import grakn.client.concept.ValueType;
 import grakn.client.concept.GraknConceptException;
 import grakn.client.concept.type.Role;
 import grakn.client.concept.Rule;
@@ -72,12 +72,10 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
@@ -803,12 +801,12 @@ public class GraknClient implements AutoCloseable {
             return Concept.Remote.of(sendAndReceiveOrThrow(RequestBuilder.Transaction.putEntityType(label)).getPutEntityTypeRes().getEntityType(), this).asEntityType();
         }
 
-        public <V> AttributeType.Remote<V> putAttributeType(String label, DataType<V> dataType) {
-            return putAttributeType(Label.of(label), dataType);
+        public <V> AttributeType.Remote<V> putAttributeType(String label, ValueType<V> valueType) {
+            return putAttributeType(Label.of(label), valueType);
         }
         @SuppressWarnings("unchecked")
-        public <V> AttributeType.Remote<V> putAttributeType(Label label, DataType<V> dataType) {
-            return (AttributeType.Remote<V>) Concept.Remote.of(sendAndReceiveOrThrow(RequestBuilder.Transaction.putAttributeType(label, dataType))
+        public <V> AttributeType.Remote<V> putAttributeType(Label label, ValueType<V> valueType) {
+            return (AttributeType.Remote<V>) Concept.Remote.of(sendAndReceiveOrThrow(RequestBuilder.Transaction.putAttributeType(label, valueType))
                     .getPutAttributeTypeRes().getAttributeType(), this).asAttributeType();
         }
 

--- a/concept/Concept.java
+++ b/concept/Concept.java
@@ -142,7 +142,7 @@ public interface Concept<BaseType extends Concept<BaseType>> {
      * @return A AttributeType if the Concept is a AttributeType
      */
     @CheckReturnValue
-    default <D> AttributeType<D> asAttributeType(DataType<D> dataType) {
+    default <D> AttributeType<D> asAttributeType(ValueType<D> valueType) {
         throw GraknConceptException.invalidCasting(this, AttributeType.class);
     }
 
@@ -192,7 +192,7 @@ public interface Concept<BaseType extends Concept<BaseType>> {
      * @return A Attribute if the Concept is a Attribute
      */
     @CheckReturnValue
-    default <D> Attribute<D> asAttribute(DataType<D> dataType) {
+    default <D> Attribute<D> asAttribute(ValueType<D> valueType) {
         throw GraknConceptException.invalidCasting(this, Attribute.class);
     }
 
@@ -496,7 +496,7 @@ public interface Concept<BaseType extends Concept<BaseType>> {
          */
         @Override
         @CheckReturnValue
-        default <D> AttributeType.Remote<D> asAttributeType(DataType<D> dataType) {
+        default <D> AttributeType.Remote<D> asAttributeType(ValueType<D> valueType) {
             throw GraknConceptException.invalidCasting(this, AttributeType.class);
         }
 
@@ -551,7 +551,7 @@ public interface Concept<BaseType extends Concept<BaseType>> {
          */
         @Override
         @CheckReturnValue
-        default <D> Attribute.Remote<D> asAttribute(DataType<D> dataType) {
+        default <D> Attribute.Remote<D> asAttribute(ValueType<D> valueType) {
             throw GraknConceptException.invalidCasting(this, Attribute.Remote.class);
         }
 

--- a/concept/ValueType.java
+++ b/concept/ValueType.java
@@ -32,29 +32,29 @@ import java.time.ZoneId;
  *
  * @param <D> The data type.
  */
-public class DataType<D> {
-    public static final DataType<Boolean> BOOLEAN = new DataType<>(Boolean.class);
-    public static final DataType<LocalDateTime> DATE = new DataType<>(LocalDateTime.class);
-    public static final DataType<Double> DOUBLE = new DataType<>(Double.class);
-    public static final DataType<Float> FLOAT = new DataType<>(Float.class);
-    public static final DataType<Integer> INTEGER = new DataType<>(Integer.class);
-    public static final DataType<Long> LONG = new DataType<>(Long.class);
-    public static final DataType<String> STRING = new DataType<>(String.class);
+public class ValueType<D> {
+    public static final ValueType<Boolean> BOOLEAN = new ValueType<>(Boolean.class);
+    public static final ValueType<LocalDateTime> DATE = new ValueType<>(LocalDateTime.class);
+    public static final ValueType<Double> DOUBLE = new ValueType<>(Double.class);
+    public static final ValueType<Float> FLOAT = new ValueType<>(Float.class);
+    public static final ValueType<Integer> INTEGER = new ValueType<>(Integer.class);
+    public static final ValueType<Long> LONG = new ValueType<>(Long.class);
+    public static final ValueType<String> STRING = new ValueType<>(String.class);
 
-    private final Class<D> dataClass;
+    private final Class<D> valueClass;
 
-    private DataType(Class<D> dataClass) {
-        this.dataClass = dataClass;
+    private ValueType(Class<D> valueClass) {
+        this.valueClass = valueClass;
     }
 
     @CheckReturnValue
-    public Class<D> dataClass() {
-        return dataClass;
+    public Class<D> valueClass() {
+        return valueClass;
     }
 
     @CheckReturnValue
     public String name() {
-        return dataClass.getName();
+        return valueClass.getName();
     }
 
     @Override
@@ -67,16 +67,16 @@ public class DataType<D> {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        DataType<?> that = (DataType<?>) o;
+        ValueType<?> that = (ValueType<?>) o;
 
-        return (this.dataClass().equals(that.dataClass()));
+        return (this.valueClass().equals(that.valueClass()));
     }
 
     @Override
     public int hashCode() {
         int h = 1;
         h *= 1000003;
-        h ^=  dataClass.hashCode();
+        h ^=  valueClass.hashCode();
         return h;
     }
 
@@ -85,8 +85,7 @@ public class DataType<D> {
      *
      * @param value The value protocol object.
      * @return the value cast to D Java type.
-     * @throws IllegalArgumentException if the value type is not recognised or does not match the type of this
-     *      DataType.
+     * @throws IllegalArgumentException if the value type is not recognised or does not match the type of this ValueType.
      */
     @SuppressWarnings("unchecked")
     public static <D> D staticCastValue(ConceptProto.ValueObject value) {
@@ -112,17 +111,16 @@ public class DataType<D> {
                     throw new IllegalArgumentException("Unexpected value for attribute: " + value);
             }
         } catch (ClassCastException ex) {
-            throw new IllegalArgumentException("Value type did not match DataType ", ex);
+            throw new IllegalArgumentException("Value type did not match ValueType ", ex);
         }
     }
 
     /**
-     * Obtains the value from the given value protocol and casts it to this DataType's type D.
+     * Obtains the value from the given value protocol and casts it to this ValueType's type D.
      *
      * @param value The value protocol object.
      * @return the value cast to D Java type.
-     * @throws IllegalArgumentException if the value type is not recognised or does not match the type of this
-     *      DataType.
+     * @throws IllegalArgumentException if the value type is not recognised or does not match the type of this ValueType.
      */
     D instanceCastValue(ConceptProto.ValueObject value) {
         return staticCastValue(value);

--- a/concept/thing/Attribute.java
+++ b/concept/thing/Attribute.java
@@ -24,10 +24,9 @@ import grakn.client.concept.ConceptId;
 import grakn.client.concept.GraknConceptException;
 import grakn.client.concept.thing.impl.AttributeImpl;
 import grakn.client.concept.type.AttributeType;
-import grakn.client.concept.DataType;
+import grakn.client.concept.ValueType;
 
 import javax.annotation.CheckReturnValue;
-import java.util.Objects;
 import java.util.stream.Stream;
 
 public interface Attribute<D> extends Thing<Attribute<D>, AttributeType<D>> {
@@ -55,7 +54,7 @@ public interface Attribute<D> extends Thing<Attribute<D>, AttributeType<D>> {
      * @return The data type of this Attribute's type.
      */
     @CheckReturnValue
-    DataType<D> dataType();
+    ValueType<D> valueType();
 
     //------------------------------------- Other ---------------------------------
     @SuppressWarnings("unchecked")
@@ -70,9 +69,9 @@ public interface Attribute<D> extends Thing<Attribute<D>, AttributeType<D>> {
     @Deprecated
     @CheckReturnValue
     @Override
-    default <T> Attribute<T> asAttribute(DataType<T> dataType) {
-        if (!dataType().equals(dataType)) {
-            throw GraknConceptException.invalidCasting(this, dataType.getClass());
+    default <T> Attribute<T> asAttribute(ValueType<T> valueType) {
+        if (!valueType().equals(valueType)) {
+            throw GraknConceptException.invalidCasting(this, valueType.getClass());
         }
         return (Attribute<T>) this;
     }
@@ -94,7 +93,7 @@ public interface Attribute<D> extends Thing<Attribute<D>, AttributeType<D>> {
      * Represent a literal Attribute in the graph.
      * Acts as an Thing when relating to other instances except it has the added functionality of:
      * 1. It is unique to its AttributeType based on it's value.
-     * 2. It has an AttributeType.DataType associated with it which constrains the allowed values.
+     * 2. It has an AttributeType.ValueType associated with it which constrains the allowed values.
      *
      * @param <D> The data type of this resource type.
      *            Supported Types include: String, Long, Double, and Boolean
@@ -106,7 +105,7 @@ public interface Attribute<D> extends Thing<Attribute<D>, AttributeType<D>> {
      * Represent a literal Attribute in the graph.
      * Acts as an Thing when relating to other instances except it has the added functionality of:
      * 1. It is unique to its AttributeType based on it's value.
-     * 2. It has an AttributeType.DataType associated with it which constrains the allowed values.
+     * 2. It has an AttributeType.ValueType associated with it which constrains the allowed values.
      *
      * @param <D> The data type of this resource type.
      *            Supported Types include: String, Long, Double, and Boolean
@@ -165,8 +164,8 @@ public interface Attribute<D> extends Thing<Attribute<D>, AttributeType<D>> {
         @Deprecated
         @CheckReturnValue
         @Override
-        default <T> Attribute.Remote<T> asAttribute(DataType<T> dataType) {
-            return (Attribute.Remote<T>) Attribute.super.asAttribute(dataType);
+        default <T> Attribute.Remote<T> asAttribute(ValueType<T> valueType) {
+            return (Attribute.Remote<T>) Attribute.super.asAttribute(valueType);
         }
 
         @Deprecated

--- a/concept/thing/impl/AttributeImpl.java
+++ b/concept/thing/impl/AttributeImpl.java
@@ -22,7 +22,7 @@ package grakn.client.concept.thing.impl;
 import grakn.client.GraknClient;
 import grakn.client.concept.Concept;
 import grakn.client.concept.ConceptId;
-import grakn.client.concept.DataType;
+import grakn.client.concept.ValueType;
 import grakn.client.concept.thing.Attribute;
 import grakn.client.concept.thing.Thing;
 import grakn.client.concept.type.AttributeType;
@@ -30,7 +30,7 @@ import grakn.protocol.session.ConceptProto;
 
 import java.util.stream.Stream;
 
-import static grakn.client.concept.DataType.staticCastValue;
+import static grakn.client.concept.ValueType.staticCastValue;
 
 public class AttributeImpl {
     /**
@@ -44,7 +44,7 @@ public class AttributeImpl {
 
         public Local(ConceptProto.Concept concept) {
             super(concept);
-            this.value = DataType.staticCastValue(concept.getValueRes().getValue());
+            this.value = ValueType.staticCastValue(concept.getValueRes().getValue());
         }
 
         @Override
@@ -53,8 +53,8 @@ public class AttributeImpl {
         }
 
         @Override
-        public final DataType<D> dataType() {
-            return type().dataType();
+        public final ValueType<D> valueType() {
+            return type().valueType();
         }
     }
 
@@ -86,8 +86,8 @@ public class AttributeImpl {
         }
 
         @Override
-        public final DataType<D> dataType() {
-            return type().dataType();
+        public final ValueType<D> valueType() {
+            return type().valueType();
         }
 
         @Override

--- a/concept/type/AttributeType.java
+++ b/concept/type/AttributeType.java
@@ -21,14 +21,13 @@ package grakn.client.concept.type;
 
 import grakn.client.GraknClient;
 import grakn.client.concept.ConceptId;
-import grakn.client.concept.DataType;
+import grakn.client.concept.ValueType;
 import grakn.client.concept.GraknConceptException;
 import grakn.client.concept.Label;
 import grakn.client.concept.thing.Attribute;
 import grakn.client.concept.type.impl.AttributeTypeImpl;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.stream.Stream;
 
@@ -44,7 +43,7 @@ public interface AttributeType<D> extends Type<AttributeType<D>, Attribute<D>> {
      */
     @Nullable
     @CheckReturnValue
-    DataType<D> dataType();
+    ValueType<D> valueType();
 
     //------------------------------------- Other ---------------------------------
     @SuppressWarnings("unchecked")
@@ -59,9 +58,9 @@ public interface AttributeType<D> extends Type<AttributeType<D>, Attribute<D>> {
     @Deprecated
     @CheckReturnValue
     @Override
-    default <T> AttributeType<T> asAttributeType(DataType<T> dataType) {
-        if (!dataType.equals(dataType())) {
-            throw GraknConceptException.invalidCasting(this, dataType.getClass());
+    default <T> AttributeType<T> asAttributeType(ValueType<T> valueType) {
+        if (!valueType.equals(valueType())) {
+            throw GraknConceptException.invalidCasting(this, valueType.getClass());
         }
         return (AttributeType<T>) this;
     }
@@ -82,7 +81,7 @@ public interface AttributeType<D> extends Type<AttributeType<D>, Attribute<D>> {
      * An ontological element which models and categorises the various Attribute in the graph.
      * This ontological element behaves similarly to Type when defining how it relates to other
      * types. It has two additional functions to be aware of:
-     * 1. It has a DataType constraining the data types of the values it's instances may take.
+     * 1. It has a ValueType constraining the data types of the values it's instances may take.
      * 2. Any of it's instances are unique to the type.
      * For example if you have an AttributeType modelling month throughout the year there can only be one January.
      *
@@ -96,7 +95,7 @@ public interface AttributeType<D> extends Type<AttributeType<D>, Attribute<D>> {
      * An ontological element which models and categorises the various Attribute in the graph.
      * This ontological element behaves similarly to Type when defining how it relates to other
      * types. It has two additional functions to be aware of:
-     * 1. It has a DataType constraining the data types of the values it's instances may take.
+     * 1. It has a ValueType constraining the data types of the values it's instances may take.
      * 2. Any of it's instances are unique to the type.
      * For example if you have an AttributeType modelling month throughout the year there can only be one January.
      *
@@ -266,8 +265,8 @@ public interface AttributeType<D> extends Type<AttributeType<D>, Attribute<D>> {
         @Deprecated
         @CheckReturnValue
         @Override
-        default <T> AttributeType.Remote<T> asAttributeType(DataType<T> dataType) {
-            return (AttributeType.Remote<T>) AttributeType.super.asAttributeType(dataType);
+        default <T> AttributeType.Remote<T> asAttributeType(ValueType<T> valueType) {
+            return (AttributeType.Remote<T>) AttributeType.super.asAttributeType(valueType);
         }
 
         @Deprecated

--- a/concept/type/impl/AttributeTypeImpl.java
+++ b/concept/type/impl/AttributeTypeImpl.java
@@ -22,7 +22,7 @@ package grakn.client.concept.type.impl;
 import grakn.client.GraknClient;
 import grakn.client.concept.Concept;
 import grakn.client.concept.ConceptId;
-import grakn.client.concept.DataType;
+import grakn.client.concept.ValueType;
 import grakn.client.concept.Label;
 import grakn.client.concept.thing.Attribute;
 import grakn.client.concept.type.AttributeType;
@@ -42,17 +42,17 @@ public class AttributeTypeImpl {
      */
     public static class Local<D> extends TypeImpl.Local<AttributeType<D>, Attribute<D>> implements AttributeType.Local<D> {
 
-        private final DataType<D> dataType;
+        private final ValueType<D> valueType;
 
         public Local(ConceptProto.Concept concept) {
             super(concept);
-            this.dataType = RequestBuilder.ConceptMessage.dataType(concept.getDataTypeRes().getDataType());
+            this.valueType = RequestBuilder.ConceptMessage.valueType(concept.getDataTypeRes().getDataType());
         }
 
         @Override
         @Nullable
-        public DataType<D> dataType() {
-            return dataType;
+        public ValueType<D> valueType() {
+            return valueType;
         }
     }
 
@@ -158,7 +158,7 @@ public class AttributeTypeImpl {
 
         @Override
         @Nullable
-        public final DataType<D> dataType() {
+        public final ValueType<D> valueType() {
             ConceptProto.Method.Req method = ConceptProto.Method.Req.newBuilder()
                     .setAttributeTypeDataTypeReq(ConceptProto.AttributeType.DataType.Req.getDefaultInstance()).build();
 
@@ -167,7 +167,7 @@ public class AttributeTypeImpl {
                 case NULL:
                     return null;
                 case DATATYPE:
-                    return RequestBuilder.ConceptMessage.dataType(response.getDataType());
+                    return RequestBuilder.ConceptMessage.valueType(response.getDataType());
                 default:
                     throw GraknClientException.unreachableStatement("Unexpected response " + response);
             }

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -43,8 +43,8 @@ def graknlabs_build_tools():
 def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
-        remote = "https://github.com/graknlabs/grakn",
-        commit = "6c07d56b4458f62962e08aaab44b68eb1275e6e3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        remote = "https://github.com/haikalpribadi/grakn",
+        commit = "71193066a0b98aa35c4845c8e8d70039a4d0b0b0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -23,7 +23,7 @@ def graknlabs_graql():
     git_repository(
         name = "graknlabs_graql",
         remote = "https://github.com/graknlabs/graql",
-        commit = "1c573108b3ab8505ab0168f146071fe032d62a61" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+        commit = "71e25d448805f34090bdd408205cdef7aa8eb929" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
     )
 
 def graknlabs_common():
@@ -44,7 +44,7 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/haikalpribadi/grakn",
-        commit = "0f158aaf03a68deac396739f2ce38d8905be47ef", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "2d6bf04de0e5ab0aa19c93f81ee6608c4f147aea", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -57,8 +57,8 @@ def graknlabs_protocol():
 def graknlabs_verification():
     git_repository(
         name = "graknlabs_verification",
-        remote = "https://github.com/graknlabs/verification",
-        commit = "2e776ed631dd2c1162506adb2a560df8df8c71f5"
+        remote = "https://github.com/haikalpribadi/verification",
+        commit = "cad7ad5a7d4ad9cda03ca370e3f4c76bc1266928"
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -44,7 +44,7 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/haikalpribadi/grakn",
-        commit = "71193066a0b98aa35c4845c8e8d70039a4d0b0b0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "0f158aaf03a68deac396739f2ce38d8905be47ef", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -23,7 +23,7 @@ def graknlabs_graql():
     git_repository(
         name = "graknlabs_graql",
         remote = "https://github.com/graknlabs/graql",
-        tag = "1.0.6" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+        commit = "1c573108b3ab8505ab0168f146071fe032d62a61" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
     )
 
 def graknlabs_common():

--- a/rpc/RequestBuilder.java
+++ b/rpc/RequestBuilder.java
@@ -22,14 +22,13 @@ package grakn.client.rpc;
 import grakn.client.GraknClient;
 import grakn.client.concept.Concept;
 import grakn.client.concept.ConceptId;
-import grakn.client.concept.DataType;
+import grakn.client.concept.ValueType;
 import grakn.client.concept.Label;
 import grakn.client.exception.GraknClientException;
 import grakn.protocol.keyspace.KeyspaceProto;
 import grakn.protocol.session.ConceptProto;
 import grakn.protocol.session.SessionProto;
 import graql.lang.pattern.Pattern;
-import graql.lang.query.GraqlQuery;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -116,10 +115,10 @@ public class RequestBuilder {
                     .build();
         }
 
-        public static SessionProto.Transaction.Req putAttributeType(Label label, DataType<?> dataType) {
+        public static SessionProto.Transaction.Req putAttributeType(Label label, ValueType<?> valueType) {
             SessionProto.Transaction.PutAttributeType.Req request = SessionProto.Transaction.PutAttributeType.Req.newBuilder()
                     .setLabel(label.getValue())
-                    .setDataType(ConceptMessage.setDataType(dataType))
+                    .setDataType(ConceptMessage.setValueType(valueType))
                     .build();
 
             return SessionProto.Transaction.Req.newBuilder().putAllMetadata(getTracingData()).setPutAttributeTypeReq(request).build();
@@ -215,45 +214,45 @@ public class RequestBuilder {
         }
 
         @SuppressWarnings("unchecked")
-        public static <D> DataType<D> dataType(ConceptProto.AttributeType.DATA_TYPE dataType) {
-            switch (dataType) {
+        public static <D> ValueType<D> valueType(ConceptProto.AttributeType.DATA_TYPE valueType) {
+            switch (valueType) {
                 case STRING:
-                    return (DataType<D>) DataType.STRING;
+                    return (ValueType<D>) ValueType.STRING;
                 case BOOLEAN:
-                    return (DataType<D>) DataType.BOOLEAN;
+                    return (ValueType<D>) ValueType.BOOLEAN;
                 case INTEGER:
-                    return (DataType<D>) DataType.INTEGER;
+                    return (ValueType<D>) ValueType.INTEGER;
                 case LONG:
-                    return (DataType<D>) DataType.LONG;
+                    return (ValueType<D>) ValueType.LONG;
                 case FLOAT:
-                    return (DataType<D>) DataType.FLOAT;
+                    return (ValueType<D>) ValueType.FLOAT;
                 case DOUBLE:
-                    return (DataType<D>) DataType.DOUBLE;
+                    return (ValueType<D>) ValueType.DOUBLE;
                 case DATE:
-                    return (DataType<D>) DataType.DATE;
+                    return (ValueType<D>) ValueType.DATE;
                 default:
                 case UNRECOGNIZED:
-                    throw new IllegalArgumentException("Unrecognised " + dataType);
+                    throw new IllegalArgumentException("Unrecognised " + valueType);
             }
         }
 
-        static ConceptProto.AttributeType.DATA_TYPE setDataType(DataType<?> dataType) {
-            if (dataType.equals(DataType.STRING)) {
+        static ConceptProto.AttributeType.DATA_TYPE setValueType(ValueType<?> valueType) {
+            if (valueType.equals(ValueType.STRING)) {
                 return ConceptProto.AttributeType.DATA_TYPE.STRING;
-            } else if (dataType.equals( DataType.BOOLEAN)) {
+            } else if (valueType.equals(ValueType.BOOLEAN)) {
                 return ConceptProto.AttributeType.DATA_TYPE.BOOLEAN;
-            } else if (dataType.equals( DataType.INTEGER)) {
+            } else if (valueType.equals(ValueType.INTEGER)) {
                 return ConceptProto.AttributeType.DATA_TYPE.INTEGER;
-            } else if (dataType.equals( DataType.LONG)) {
+            } else if (valueType.equals(ValueType.LONG)) {
                 return ConceptProto.AttributeType.DATA_TYPE.LONG;
-            } else if (dataType.equals( DataType.FLOAT)) {
+            } else if (valueType.equals(ValueType.FLOAT)) {
                 return ConceptProto.AttributeType.DATA_TYPE.FLOAT;
-            } else if (dataType.equals( DataType.DOUBLE)) {
+            } else if (valueType.equals(ValueType.DOUBLE)) {
                 return ConceptProto.AttributeType.DATA_TYPE.DOUBLE;
-            } else if (dataType.equals( DataType.DATE)) {
+            } else if (valueType.equals(ValueType.DATE)) {
                 return ConceptProto.AttributeType.DATA_TYPE.DATE;
             } else {
-                throw GraknClientException.unreachableStatement("Unrecognised " + dataType);
+                throw GraknClientException.unreachableStatement("Unrecognised " + valueType);
             }
         }
     }

--- a/test/behaviour/graql/GraqlSteps.java
+++ b/test/behaviour/graql/GraqlSteps.java
@@ -181,6 +181,7 @@ public class GraqlSteps {
         }
     }
 
+
     @Then("answers are labeled")
     public void answers_satisfy_labels(List<Map<String, String>> conceptLabels) {
         assertEquals(conceptLabels.size(), answers.size());
@@ -212,6 +213,16 @@ public class GraqlSteps {
             List<? extends Answer> answers = tx.execute(graqlQuery);
             assertEquals(1, answers.size());
         }
+    }
+
+    @Then("concept identifiers are")
+    public void concept_identifiers_are(Map<String, Map<String, String>> identifiers) {
+        // TODO: to implement
+    }
+
+    @Then("uniquely identify answer concepts")
+    public void uniquely_identify_answer_concepts(List<Map<String, String>> answersIdentifiers) {
+        // TODO: to implement
     }
 
     private String applyQueryTemplate(String template, ConceptMap templateFiller) {

--- a/test/integration/concept/ConceptIT.java
+++ b/test/integration/concept/ConceptIT.java
@@ -21,7 +21,7 @@ package grakn.client.test.integration.concept;
 
 import grakn.client.GraknClient;
 import grakn.client.concept.Concept;
-import grakn.client.concept.DataType;
+import grakn.client.concept.ValueType;
 import grakn.client.concept.GraknConceptException;
 import grakn.client.concept.Label;
 import grakn.client.concept.Rule;
@@ -162,9 +162,9 @@ public class ConceptIT {
         tx = session.transaction().write();
 
         // Attribute Types
-        email = tx.putAttributeType(EMAIL, DataType.STRING).regex(EMAIL_REGEX);
-        name = tx.putAttributeType(NAME, DataType.STRING);
-        age = tx.putAttributeType(AGE, DataType.INTEGER);
+        email = tx.putAttributeType(EMAIL, ValueType.STRING).regex(EMAIL_REGEX);
+        name = tx.putAttributeType(NAME, ValueType.STRING);
+        age = tx.putAttributeType(AGE, ValueType.INTEGER);
 
         // Entity Types
         livingThing = tx.putEntityType(LIVING_THING).isAbstract(true);
@@ -255,19 +255,19 @@ public class ConceptIT {
     }
 
     @Test
-    public void whenCallingGetDataTypeOnAttributeType_GetTheExpectedResult() {
-        assertEquals(DataType.STRING, email.dataType());
-        assertEquals(DataType.STRING, name.dataType());
-        assertEquals(DataType.INTEGER, age.dataType());
+    public void whenCallingGetValueTypeOnAttributeType_GetTheExpectedResult() {
+        assertEquals(ValueType.STRING, email.valueType());
+        assertEquals(ValueType.STRING, name.valueType());
+        assertEquals(ValueType.INTEGER, age.valueType());
     }
 
     @Test
-    public void whenCallingGetDataTypeOnAttribute_GetTheExpectedResult() {
-        assertEquals(DataType.STRING, emailAlice.dataType());
-        assertEquals(DataType.STRING, emailBob.dataType());
-        assertEquals(DataType.STRING, nameAlice.dataType());
-        assertEquals(DataType.STRING, nameBob.dataType());
-        assertEquals(DataType.INTEGER, age20.dataType());
+    public void whenCallingGetValueTypeOnAttribute_GetTheExpectedResult() {
+        assertEquals(ValueType.STRING, emailAlice.valueType());
+        assertEquals(ValueType.STRING, emailBob.valueType());
+        assertEquals(ValueType.STRING, nameAlice.valueType());
+        assertEquals(ValueType.STRING, nameBob.valueType());
+        assertEquals(ValueType.INTEGER, age20.valueType());
     }
 
     @Test
@@ -541,7 +541,7 @@ public class ConceptIT {
 
     @Test
     public void whenSettingAndDeletingKeyToType_KeyIsSetAndDeleted() {
-        AttributeType.Remote<String> username = tx.putAttributeType(Label.of("username"), DataType.STRING);
+        AttributeType.Remote<String> username = tx.putAttributeType(Label.of("username"), ValueType.STRING);
         person.key(username);
         assertTrue(person.keys().anyMatch(c -> c.equals(username)));
 
@@ -615,25 +615,25 @@ public class ConceptIT {
     }
 
     @Test
-    public void whenCastingAttributeWithCorrectDataType_castsWithoutError() {
+    public void whenCastingAttributeWithCorrectValueType_castsWithoutError() {
         Concept<?> untypedAgeType = age;
-        AttributeType<Integer> typedAgeType = untypedAgeType.asAttributeType(DataType.INTEGER);
+        AttributeType<Integer> typedAgeType = untypedAgeType.asAttributeType(ValueType.INTEGER);
         Concept<?> untypedAgeAttr = age20;
-        Attribute<Integer> typedAgeAttr = untypedAgeAttr.asAttribute(DataType.INTEGER);
+        Attribute<Integer> typedAgeAttr = untypedAgeAttr.asAttribute(ValueType.INTEGER);
     }
 
     @Test
-    public void whenCastingAttributeWithWrongDataType_fails() {
+    public void whenCastingAttributeWithWrongValueType_fails() {
         Concept<?> untypedAgeType = age;
         try {
-            AttributeType<String> wrong = untypedAgeType.asAttributeType(DataType.STRING);
+            AttributeType<String> wrong = untypedAgeType.asAttributeType(ValueType.STRING);
             fail();
         } catch (GraknConceptException ignored) {
             assertTrue(true);
         }
         Concept<?> untypedAgeAttr = age20;
         try {
-            Attribute<String> wrong = untypedAgeAttr.asAttribute(DataType.STRING);
+            Attribute<String> wrong = untypedAgeAttr.asAttribute(ValueType.STRING);
             fail();
         } catch (GraknConceptException ignored) {
             assertTrue(true);


### PR DESCRIPTION
## What is the goal of this PR?

We are replacing the term `DataType` in `AttributeType` with `ValueType`). Previously, an `AttributeType` has a `DataType`. And an `Attribute` has `Value`. The type of `Value` is defined by `DataType`. We can see the inconsistency there. Now, `AttributeType` has `ValueType`, and `Attribute` has `Value`. The type of `Value` is `ValueType`. So it's all consistent.

## What are the changes implemented in this PR?

- Renamed the `DataType` class to `ValueType`
- Renamed method names
- Renamed method arguments
- Renamed variable names
- Updated comments