### PR TITLE
Cast meta types to Type base type so that subs is compatible

### DIFF
--- a/concept/type/impl/MetaTypeImpl.java
+++ b/concept/type/impl/MetaTypeImpl.java
@@ -61,7 +61,7 @@ public class MetaTypeImpl {
         @SuppressWarnings("unchecked")
         @Override
         protected final Type.Remote<SomeRemoteType, SomeRemoteThing> asCurrentBaseType(Concept.Remote<?> other) {
-            return (Type.Remote<SomeRemoteType, SomeRemoteThing>) other.asMetaType();
+            return (Type.Remote<SomeRemoteType, SomeRemoteThing>) other.asType();
         }
 
         @Override

--- a/concept/type/impl/MetaTypeImpl.java
+++ b/concept/type/impl/MetaTypeImpl.java
@@ -60,8 +60,8 @@ public class MetaTypeImpl {
 
         @SuppressWarnings("unchecked")
         @Override
-        protected final MetaType.Remote<SomeRemoteType, SomeRemoteThing> asCurrentBaseType(Concept.Remote<?> other) {
-            return (MetaType.Remote<SomeRemoteType, SomeRemoteThing>) other.asMetaType();
+        protected final Type.Remote<SomeRemoteType, SomeRemoteThing> asCurrentBaseType(Concept.Remote<?> other) {
+            return (Type.Remote<SomeRemoteType, SomeRemoteThing>) other.asMetaType();
         }
 
         @Override

--- a/test/integration/concept/ConceptIT.java
+++ b/test/integration/concept/ConceptIT.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 import static graql.lang.Graql.var;
 import static java.util.stream.Collectors.toList;
@@ -637,5 +638,11 @@ public class ConceptIT {
         } catch (GraknConceptException ignored) {
             assertTrue(true);
         }
+    }
+
+    @Test
+    public void subtypes() {
+        List<Concept<?>> subs = tx.getSchemaConcept(Label.of("thing")).subs().collect(Collectors.toList());
+        subs.forEach(System.out::println);
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

fix #98 

To fix an issue where getting meta types via concept API causes a cast error. The `MetaType` class should be treated as a `Type` so that it is compatible with regular type instances. This should prevents calls like `subs` on the meta type from incorrectly casting their subs to a `MetaType`.

## What are the changes implemented in this PR?

* `MetaType`s are treated like `Type` for the purposes of casting.