### PR TITLE
Use release version of tracing

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -65,5 +65,5 @@ def graknlabs_grabl_tracing():
     git_repository(
         name = "graknlabs_grabl_tracing",
         remote = "https://github.com/graknlabs/grabl-tracing",
-        commit = "42f507d6b973cbc87d18a27ee83121c791295184"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grabl_tracing
+        tag = "0.1.0"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grabl_tracing
     )

--- a/test/deployment/pom.xml
+++ b/test/deployment/pom.xml
@@ -13,11 +13,6 @@
             <name>repo.grakn.ai</name>
             <url>http://repo.grakn.ai/repository/maven/</url>
         </repository>
-        <repository>
-            <id>repo.grakn.ai.snapshot</id>
-            <name>repo.grakn.ai</name>
-            <url>http://repo.grakn.ai/repository/maven-snapshot/</url>
-        </repository>
     </repositories>
     <dependencies>
         <dependency>

--- a/test/deployment/pom.xml
+++ b/test/deployment/pom.xml
@@ -13,6 +13,11 @@
             <name>repo.grakn.ai</name>
             <url>http://repo.grakn.ai/repository/maven/</url>
         </repository>
+        <repository>
+            <id>repo.grakn.ai.snapshot</id>
+            <name>repo.grakn.ai</name>
+            <url>http://repo.grakn.ai/repository/maven-snapshot/</url>
+        </repository>
     </repositories>
     <dependencies>
         <dependency>


### PR DESCRIPTION
## What is the goal of this PR?

To fix a dependency issue where a snapshot version of grabl tracing was being used rather than a release version, requiring the user to add our snapshot repo. This release version was not available at the time but the snapshot repo was already in the maven test pom, which meant the issue was not noticed when the snapshot version was used.

## What are the changes implemented in this PR?

- Removed snapshot repo from maven test application
- Changed version of grabl tracing to 0.1.0