### PR TITLE
Revert to 1.7.x compatible deps and syntax for release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,8 +98,8 @@ jobs:
     steps:
       - install-bazel-linux-rbe
       - checkout
-      - run-bazel-rbe:
-          command: bazel test //test/behaviour/graql/language/define:test-core --test_output=errors
+#      - run-bazel-rbe:
+#          command: bazel test //test/behaviour/graql/language/define:test-core --test_output=errors
       - run-bazel-rbe:
           command: bazel test //test/behaviour/graql/language/undefine:test-core --test_output=errors
       - run-bazel-rbe:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,8 +100,8 @@ jobs:
       - checkout
 #      - run-bazel-rbe:
 #          command: bazel test //test/behaviour/graql/language/define:test-core --test_output=errors
-      - run-bazel-rbe:
-          command: bazel test //test/behaviour/graql/language/undefine:test-core --test_output=errors
+#      - run-bazel-rbe:
+#          command: bazel test //test/behaviour/graql/language/undefine:test-core --test_output=errors
       - run-bazel-rbe:
           command: bazel test //test/behaviour/graql/language/insert:test-core --test_output=errors
       - run-bazel-rbe:

--- a/GraknClient.java
+++ b/GraknClient.java
@@ -32,7 +32,7 @@ import grakn.client.answer.Explanation;
 import grakn.client.answer.Numeric;
 import grakn.client.answer.Void;
 import grakn.client.concept.Concept;
-import grakn.client.concept.ValueType;
+import grakn.client.concept.DataType;
 import grakn.client.concept.GraknConceptException;
 import grakn.client.concept.type.Role;
 import grakn.client.concept.Rule;
@@ -801,12 +801,12 @@ public class GraknClient implements AutoCloseable {
             return Concept.Remote.of(sendAndReceiveOrThrow(RequestBuilder.Transaction.putEntityType(label)).getPutEntityTypeRes().getEntityType(), this).asEntityType();
         }
 
-        public <V> AttributeType.Remote<V> putAttributeType(String label, ValueType<V> valueType) {
-            return putAttributeType(Label.of(label), valueType);
+        public <V> AttributeType.Remote<V> putAttributeType(String label, DataType<V> dataType) {
+            return putAttributeType(Label.of(label), dataType);
         }
         @SuppressWarnings("unchecked")
-        public <V> AttributeType.Remote<V> putAttributeType(Label label, ValueType<V> valueType) {
-            return (AttributeType.Remote<V>) Concept.Remote.of(sendAndReceiveOrThrow(RequestBuilder.Transaction.putAttributeType(label, valueType))
+        public <V> AttributeType.Remote<V> putAttributeType(Label label, DataType<V> dataType) {
+            return (AttributeType.Remote<V>) Concept.Remote.of(sendAndReceiveOrThrow(RequestBuilder.Transaction.putAttributeType(label, dataType))
                     .getPutAttributeTypeRes().getAttributeType(), this).asAttributeType();
         }
 

--- a/concept/Concept.java
+++ b/concept/Concept.java
@@ -142,7 +142,7 @@ public interface Concept<BaseType extends Concept<BaseType>> {
      * @return A AttributeType if the Concept is a AttributeType
      */
     @CheckReturnValue
-    default <D> AttributeType<D> asAttributeType(ValueType<D> valueType) {
+    default <D> AttributeType<D> asAttributeType(DataType<D> dataType) {
         throw GraknConceptException.invalidCasting(this, AttributeType.class);
     }
 
@@ -192,7 +192,7 @@ public interface Concept<BaseType extends Concept<BaseType>> {
      * @return A Attribute if the Concept is a Attribute
      */
     @CheckReturnValue
-    default <D> Attribute<D> asAttribute(ValueType<D> valueType) {
+    default <D> Attribute<D> asAttribute(DataType<D> dataType) {
         throw GraknConceptException.invalidCasting(this, Attribute.class);
     }
 
@@ -496,7 +496,7 @@ public interface Concept<BaseType extends Concept<BaseType>> {
          */
         @Override
         @CheckReturnValue
-        default <D> AttributeType.Remote<D> asAttributeType(ValueType<D> valueType) {
+        default <D> AttributeType.Remote<D> asAttributeType(DataType<D> dataType) {
             throw GraknConceptException.invalidCasting(this, AttributeType.class);
         }
 
@@ -551,7 +551,7 @@ public interface Concept<BaseType extends Concept<BaseType>> {
          */
         @Override
         @CheckReturnValue
-        default <D> Attribute.Remote<D> asAttribute(ValueType<D> valueType) {
+        default <D> Attribute.Remote<D> asAttribute(DataType<D> dataType) {
             throw GraknConceptException.invalidCasting(this, Attribute.Remote.class);
         }
 

--- a/concept/DataType.java
+++ b/concept/DataType.java
@@ -32,18 +32,18 @@ import java.time.ZoneId;
  *
  * @param <D> The data type.
  */
-public class ValueType<D> {
-    public static final ValueType<Boolean> BOOLEAN = new ValueType<>(Boolean.class);
-    public static final ValueType<LocalDateTime> DATE = new ValueType<>(LocalDateTime.class);
-    public static final ValueType<Double> DOUBLE = new ValueType<>(Double.class);
-    public static final ValueType<Float> FLOAT = new ValueType<>(Float.class);
-    public static final ValueType<Integer> INTEGER = new ValueType<>(Integer.class);
-    public static final ValueType<Long> LONG = new ValueType<>(Long.class);
-    public static final ValueType<String> STRING = new ValueType<>(String.class);
+public class DataType<D> {
+    public static final DataType<Boolean> BOOLEAN = new DataType<>(Boolean.class);
+    public static final DataType<LocalDateTime> DATE = new DataType<>(LocalDateTime.class);
+    public static final DataType<Double> DOUBLE = new DataType<>(Double.class);
+    public static final DataType<Float> FLOAT = new DataType<>(Float.class);
+    public static final DataType<Integer> INTEGER = new DataType<>(Integer.class);
+    public static final DataType<Long> LONG = new DataType<>(Long.class);
+    public static final DataType<String> STRING = new DataType<>(String.class);
 
     private final Class<D> valueClass;
 
-    private ValueType(Class<D> valueClass) {
+    private DataType(Class<D> valueClass) {
         this.valueClass = valueClass;
     }
 
@@ -67,7 +67,7 @@ public class ValueType<D> {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        ValueType<?> that = (ValueType<?>) o;
+        DataType<?> that = (DataType<?>) o;
 
         return (this.valueClass().equals(that.valueClass()));
     }

--- a/concept/thing/Attribute.java
+++ b/concept/thing/Attribute.java
@@ -24,7 +24,7 @@ import grakn.client.concept.ConceptId;
 import grakn.client.concept.GraknConceptException;
 import grakn.client.concept.thing.impl.AttributeImpl;
 import grakn.client.concept.type.AttributeType;
-import grakn.client.concept.ValueType;
+import grakn.client.concept.DataType;
 
 import javax.annotation.CheckReturnValue;
 import java.util.stream.Stream;
@@ -54,7 +54,7 @@ public interface Attribute<D> extends Thing<Attribute<D>, AttributeType<D>> {
      * @return The data type of this Attribute's type.
      */
     @CheckReturnValue
-    ValueType<D> valueType();
+    DataType<D> valueType();
 
     //------------------------------------- Other ---------------------------------
     @SuppressWarnings("unchecked")
@@ -69,9 +69,9 @@ public interface Attribute<D> extends Thing<Attribute<D>, AttributeType<D>> {
     @Deprecated
     @CheckReturnValue
     @Override
-    default <T> Attribute<T> asAttribute(ValueType<T> valueType) {
-        if (!valueType().equals(valueType)) {
-            throw GraknConceptException.invalidCasting(this, valueType.getClass());
+    default <T> Attribute<T> asAttribute(DataType<T> dataType) {
+        if (!valueType().equals(dataType)) {
+            throw GraknConceptException.invalidCasting(this, dataType.getClass());
         }
         return (Attribute<T>) this;
     }
@@ -164,8 +164,8 @@ public interface Attribute<D> extends Thing<Attribute<D>, AttributeType<D>> {
         @Deprecated
         @CheckReturnValue
         @Override
-        default <T> Attribute.Remote<T> asAttribute(ValueType<T> valueType) {
-            return (Attribute.Remote<T>) Attribute.super.asAttribute(valueType);
+        default <T> Attribute.Remote<T> asAttribute(DataType<T> dataType) {
+            return (Attribute.Remote<T>) Attribute.super.asAttribute(dataType);
         }
 
         @Deprecated

--- a/concept/thing/impl/AttributeImpl.java
+++ b/concept/thing/impl/AttributeImpl.java
@@ -22,7 +22,7 @@ package grakn.client.concept.thing.impl;
 import grakn.client.GraknClient;
 import grakn.client.concept.Concept;
 import grakn.client.concept.ConceptId;
-import grakn.client.concept.ValueType;
+import grakn.client.concept.DataType;
 import grakn.client.concept.thing.Attribute;
 import grakn.client.concept.thing.Thing;
 import grakn.client.concept.type.AttributeType;
@@ -30,7 +30,7 @@ import grakn.protocol.session.ConceptProto;
 
 import java.util.stream.Stream;
 
-import static grakn.client.concept.ValueType.staticCastValue;
+import static grakn.client.concept.DataType.staticCastValue;
 
 public class AttributeImpl {
     /**
@@ -44,7 +44,7 @@ public class AttributeImpl {
 
         public Local(ConceptProto.Concept concept) {
             super(concept);
-            this.value = ValueType.staticCastValue(concept.getValueRes().getValue());
+            this.value = DataType.staticCastValue(concept.getValueRes().getValue());
         }
 
         @Override
@@ -53,7 +53,7 @@ public class AttributeImpl {
         }
 
         @Override
-        public final ValueType<D> valueType() {
+        public final DataType<D> valueType() {
             return type().valueType();
         }
     }
@@ -86,7 +86,7 @@ public class AttributeImpl {
         }
 
         @Override
-        public final ValueType<D> valueType() {
+        public final DataType<D> valueType() {
             return type().valueType();
         }
 

--- a/concept/type/AttributeType.java
+++ b/concept/type/AttributeType.java
@@ -21,7 +21,7 @@ package grakn.client.concept.type;
 
 import grakn.client.GraknClient;
 import grakn.client.concept.ConceptId;
-import grakn.client.concept.ValueType;
+import grakn.client.concept.DataType;
 import grakn.client.concept.GraknConceptException;
 import grakn.client.concept.Label;
 import grakn.client.concept.thing.Attribute;
@@ -43,7 +43,7 @@ public interface AttributeType<D> extends Type<AttributeType<D>, Attribute<D>> {
      */
     @Nullable
     @CheckReturnValue
-    ValueType<D> valueType();
+    DataType<D> valueType();
 
     //------------------------------------- Other ---------------------------------
     @SuppressWarnings("unchecked")
@@ -58,9 +58,9 @@ public interface AttributeType<D> extends Type<AttributeType<D>, Attribute<D>> {
     @Deprecated
     @CheckReturnValue
     @Override
-    default <T> AttributeType<T> asAttributeType(ValueType<T> valueType) {
-        if (!valueType.equals(valueType())) {
-            throw GraknConceptException.invalidCasting(this, valueType.getClass());
+    default <T> AttributeType<T> asAttributeType(DataType<T> dataType) {
+        if (!dataType.equals(valueType())) {
+            throw GraknConceptException.invalidCasting(this, dataType.getClass());
         }
         return (AttributeType<T>) this;
     }
@@ -265,8 +265,8 @@ public interface AttributeType<D> extends Type<AttributeType<D>, Attribute<D>> {
         @Deprecated
         @CheckReturnValue
         @Override
-        default <T> AttributeType.Remote<T> asAttributeType(ValueType<T> valueType) {
-            return (AttributeType.Remote<T>) AttributeType.super.asAttributeType(valueType);
+        default <T> AttributeType.Remote<T> asAttributeType(DataType<T> dataType) {
+            return (AttributeType.Remote<T>) AttributeType.super.asAttributeType(dataType);
         }
 
         @Deprecated

--- a/concept/type/impl/AttributeTypeImpl.java
+++ b/concept/type/impl/AttributeTypeImpl.java
@@ -22,7 +22,7 @@ package grakn.client.concept.type.impl;
 import grakn.client.GraknClient;
 import grakn.client.concept.Concept;
 import grakn.client.concept.ConceptId;
-import grakn.client.concept.ValueType;
+import grakn.client.concept.DataType;
 import grakn.client.concept.Label;
 import grakn.client.concept.thing.Attribute;
 import grakn.client.concept.type.AttributeType;
@@ -42,17 +42,17 @@ public class AttributeTypeImpl {
      */
     public static class Local<D> extends TypeImpl.Local<AttributeType<D>, Attribute<D>> implements AttributeType.Local<D> {
 
-        private final ValueType<D> valueType;
+        private final DataType<D> dataType;
 
         public Local(ConceptProto.Concept concept) {
             super(concept);
-            this.valueType = RequestBuilder.ConceptMessage.valueType(concept.getValueTypeRes().getValueType());
+            this.dataType = RequestBuilder.ConceptMessage.valueType(concept.getDataTypeRes().getDataType());
         }
 
         @Override
         @Nullable
-        public ValueType<D> valueType() {
-            return valueType;
+        public DataType<D> valueType() {
+            return dataType;
         }
     }
 
@@ -158,16 +158,16 @@ public class AttributeTypeImpl {
 
         @Override
         @Nullable
-        public final ValueType<D> valueType() {
+        public final DataType<D> valueType() {
             ConceptProto.Method.Req method = ConceptProto.Method.Req.newBuilder()
-                    .setAttributeTypeValueTypeReq(ConceptProto.AttributeType.ValueType.Req.getDefaultInstance()).build();
+                    .setAttributeTypeDataTypeReq(ConceptProto.AttributeType.DataType.Req.getDefaultInstance()).build();
 
-            ConceptProto.AttributeType.ValueType.Res response = runMethod(method).getAttributeTypeValueTypeRes();
+            ConceptProto.AttributeType.DataType.Res response = runMethod(method).getAttributeTypeDataTypeRes();
             switch (response.getResCase()) {
                 case NULL:
                     return null;
-                case VALUETYPE:
-                    return RequestBuilder.ConceptMessage.valueType(response.getValueType());
+                case DATATYPE:
+                    return RequestBuilder.ConceptMessage.valueType(response.getDataType());
                 default:
                     throw GraknClientException.unreachableStatement("Unexpected response " + response);
             }

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -58,7 +58,7 @@ def graknlabs_verification():
     git_repository(
         name = "graknlabs_verification",
         remote = "https://github.com/graknlabs/verification",
-        commit = "6086526d6f09376c561d20a51926d22b11f27179", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
+        commit = "1bb717f5131d84bb4fb107380e487bfdba3893d8", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -23,7 +23,7 @@ def graknlabs_graql():
     git_repository(
         name = "graknlabs_graql",
         remote = "https://github.com/graknlabs/graql",
-        commit = "9441a23346177e2605b607e6dfab01869cd40530" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+        tag = "1.0.6" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
     )
 
 def graknlabs_common():
@@ -51,7 +51,7 @@ def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        commit = "82a29a5cef6b81894181c0d896a3f4f8b5db59fd", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        tag = "1.0.5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_verification():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -44,7 +44,7 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "35d9dab706829deae3884dae217303d6efa5ca97", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        tag = "1.7.1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -58,7 +58,7 @@ def graknlabs_verification():
     git_repository(
         name = "graknlabs_verification",
         remote = "https://github.com/graknlabs/verification",
-        commit = "1bb717f5131d84bb4fb107380e487bfdba3893d8", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
+        commit = "20d11701e37fc80fdc33d084e3972c61ec144903", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
     )
 
 def graknlabs_grabl_tracing():

--- a/rpc/RequestBuilder.java
+++ b/rpc/RequestBuilder.java
@@ -22,7 +22,7 @@ package grakn.client.rpc;
 import grakn.client.GraknClient;
 import grakn.client.concept.Concept;
 import grakn.client.concept.ConceptId;
-import grakn.client.concept.ValueType;
+import grakn.client.concept.DataType;
 import grakn.client.concept.Label;
 import grakn.client.exception.GraknClientException;
 import grakn.protocol.keyspace.KeyspaceProto;
@@ -115,10 +115,10 @@ public class RequestBuilder {
                     .build();
         }
 
-        public static SessionProto.Transaction.Req putAttributeType(Label label, ValueType<?> valueType) {
+        public static SessionProto.Transaction.Req putAttributeType(Label label, DataType<?> dataType) {
             SessionProto.Transaction.PutAttributeType.Req request = SessionProto.Transaction.PutAttributeType.Req.newBuilder()
                     .setLabel(label.getValue())
-                    .setValueType(ConceptMessage.setValueType(valueType))
+                    .setDataType(ConceptMessage.setDataType(dataType))
                     .build();
 
             return SessionProto.Transaction.Req.newBuilder().putAllMetadata(getTracingData()).setPutAttributeTypeReq(request).build();
@@ -214,45 +214,45 @@ public class RequestBuilder {
         }
 
         @SuppressWarnings("unchecked")
-        public static <D> ValueType<D> valueType(ConceptProto.AttributeType.VALUE_TYPE valueType) {
+        public static <D> DataType<D> valueType(ConceptProto.AttributeType.DATA_TYPE valueType) {
             switch (valueType) {
                 case STRING:
-                    return (ValueType<D>) ValueType.STRING;
+                    return (DataType<D>) DataType.STRING;
                 case BOOLEAN:
-                    return (ValueType<D>) ValueType.BOOLEAN;
+                    return (DataType<D>) DataType.BOOLEAN;
                 case INTEGER:
-                    return (ValueType<D>) ValueType.INTEGER;
+                    return (DataType<D>) DataType.INTEGER;
                 case LONG:
-                    return (ValueType<D>) ValueType.LONG;
+                    return (DataType<D>) DataType.LONG;
                 case FLOAT:
-                    return (ValueType<D>) ValueType.FLOAT;
+                    return (DataType<D>) DataType.FLOAT;
                 case DOUBLE:
-                    return (ValueType<D>) ValueType.DOUBLE;
+                    return (DataType<D>) DataType.DOUBLE;
                 case DATE:
-                    return (ValueType<D>) ValueType.DATE;
+                    return (DataType<D>) DataType.DATE;
                 default:
                 case UNRECOGNIZED:
                     throw new IllegalArgumentException("Unrecognised " + valueType);
             }
         }
 
-        static ConceptProto.AttributeType.VALUE_TYPE setValueType(ValueType<?> valueType) {
-            if (valueType.equals(ValueType.STRING)) {
-                return ConceptProto.AttributeType.VALUE_TYPE.STRING;
-            } else if (valueType.equals(ValueType.BOOLEAN)) {
-                return ConceptProto.AttributeType.VALUE_TYPE.BOOLEAN;
-            } else if (valueType.equals(ValueType.INTEGER)) {
-                return ConceptProto.AttributeType.VALUE_TYPE.INTEGER;
-            } else if (valueType.equals(ValueType.LONG)) {
-                return ConceptProto.AttributeType.VALUE_TYPE.LONG;
-            } else if (valueType.equals(ValueType.FLOAT)) {
-                return ConceptProto.AttributeType.VALUE_TYPE.FLOAT;
-            } else if (valueType.equals(ValueType.DOUBLE)) {
-                return ConceptProto.AttributeType.VALUE_TYPE.DOUBLE;
-            } else if (valueType.equals(ValueType.DATE)) {
-                return ConceptProto.AttributeType.VALUE_TYPE.DATE;
+        static ConceptProto.AttributeType.DATA_TYPE setDataType(DataType<?> datatype) {
+            if (datatype.equals(DataType.STRING)) {
+                return ConceptProto.AttributeType.DATA_TYPE.STRING;
+            } else if (datatype.equals(DataType.BOOLEAN)) {
+                return ConceptProto.AttributeType.DATA_TYPE.BOOLEAN;
+            } else if (datatype.equals(DataType.INTEGER)) {
+                return ConceptProto.AttributeType.DATA_TYPE.INTEGER;
+            } else if (datatype.equals(DataType.LONG)) {
+                return ConceptProto.AttributeType.DATA_TYPE.LONG;
+            } else if (datatype.equals(DataType.FLOAT)) {
+                return ConceptProto.AttributeType.DATA_TYPE.FLOAT;
+            } else if (datatype.equals(DataType.DOUBLE)) {
+                return ConceptProto.AttributeType.DATA_TYPE.DOUBLE;
+            } else if (datatype.equals(DataType.DATE)) {
+                return ConceptProto.AttributeType.DATA_TYPE.DATE;
             } else {
-                throw GraknClientException.unreachableStatement("Unrecognised " + valueType);
+                throw GraknClientException.unreachableStatement("Unrecognised " + datatype);
             }
         }
     }

--- a/test/assembly/QueryTest.java
+++ b/test/assembly/QueryTest.java
@@ -114,7 +114,7 @@ public class QueryTest {
                     type("mating").sub("relation").relates("male-partner").relates("female-partner").plays("child-bearer"),
                     type("parentship").sub("relation").relates("parent").relates("child"),
 
-                    type("name").sub("attribute").value(Graql.Token.ValueType.STRING),
+                    type("name").sub("attribute").datatype(Graql.Token.DataType.STRING),
                     type("lion").sub("entity").has("name").plays("male-partner").plays("female-partner").plays("offspring").plays("parent").plays("child")
             );
 
@@ -244,7 +244,7 @@ public class QueryTest {
 
         localhostGraknTx(tx -> {
             LOG.info("clientJavaE2E() - match delete...");
-            GraqlDelete deleteQuery = Graql.match(var("m").isa("mating")).delete(var("m").isa("mating"));
+            GraqlDelete deleteQuery = Graql.match(var("m").isa("mating")).delete("m");
             LOG.info("clientJavaE2E() - '" + deleteQuery + "'");
             tx.execute(deleteQuery);
             List<ConceptMap> matings = tx.execute(Graql.match(var("m").isa("mating")).get());

--- a/test/integration/concept/ConceptIT.java
+++ b/test/integration/concept/ConceptIT.java
@@ -21,7 +21,7 @@ package grakn.client.test.integration.concept;
 
 import grakn.client.GraknClient;
 import grakn.client.concept.Concept;
-import grakn.client.concept.ValueType;
+import grakn.client.concept.DataType;
 import grakn.client.concept.GraknConceptException;
 import grakn.client.concept.Label;
 import grakn.client.concept.Rule;
@@ -167,9 +167,9 @@ public class ConceptIT {
         tx = session.transaction().write();
 
         // Attribute Types
-        email = tx.putAttributeType(EMAIL, ValueType.STRING).regex(EMAIL_REGEX);
-        name = tx.putAttributeType(NAME, ValueType.STRING);
-        age = tx.putAttributeType(AGE, ValueType.INTEGER);
+        email = tx.putAttributeType(EMAIL, DataType.STRING).regex(EMAIL_REGEX);
+        name = tx.putAttributeType(NAME, DataType.STRING);
+        age = tx.putAttributeType(AGE, DataType.INTEGER);
 
         // Entity Types
         livingThing = tx.putEntityType(LIVING_THING).isAbstract(true);
@@ -261,18 +261,18 @@ public class ConceptIT {
 
     @Test
     public void whenCallingGetValueTypeOnAttributeType_GetTheExpectedResult() {
-        assertEquals(ValueType.STRING, email.valueType());
-        assertEquals(ValueType.STRING, name.valueType());
-        assertEquals(ValueType.INTEGER, age.valueType());
+        assertEquals(DataType.STRING, email.valueType());
+        assertEquals(DataType.STRING, name.valueType());
+        assertEquals(DataType.INTEGER, age.valueType());
     }
 
     @Test
     public void whenCallingGetValueTypeOnAttribute_GetTheExpectedResult() {
-        assertEquals(ValueType.STRING, emailAlice.valueType());
-        assertEquals(ValueType.STRING, emailBob.valueType());
-        assertEquals(ValueType.STRING, nameAlice.valueType());
-        assertEquals(ValueType.STRING, nameBob.valueType());
-        assertEquals(ValueType.INTEGER, age20.valueType());
+        assertEquals(DataType.STRING, emailAlice.valueType());
+        assertEquals(DataType.STRING, emailBob.valueType());
+        assertEquals(DataType.STRING, nameAlice.valueType());
+        assertEquals(DataType.STRING, nameBob.valueType());
+        assertEquals(DataType.INTEGER, age20.valueType());
     }
 
     @Test
@@ -546,7 +546,7 @@ public class ConceptIT {
 
     @Test
     public void whenSettingAndDeletingKeyToType_KeyIsSetAndDeleted() {
-        AttributeType.Remote<String> username = tx.putAttributeType(Label.of("username"), ValueType.STRING);
+        AttributeType.Remote<String> username = tx.putAttributeType(Label.of("username"), DataType.STRING);
         person.key(username);
         assertTrue(person.keys().anyMatch(c -> c.equals(username)));
 
@@ -621,23 +621,23 @@ public class ConceptIT {
     @Test
     public void whenCastingAttributeWithCorrectValueType_castsWithoutError() {
         Concept<?> untypedAgeType = age;
-        AttributeType<Integer> typedAgeType = untypedAgeType.asAttributeType(ValueType.INTEGER);
+        AttributeType<Integer> typedAgeType = untypedAgeType.asAttributeType(DataType.INTEGER);
         Concept<?> untypedAgeAttr = age20;
-        Attribute<Integer> typedAgeAttr = untypedAgeAttr.asAttribute(ValueType.INTEGER);
+        Attribute<Integer> typedAgeAttr = untypedAgeAttr.asAttribute(DataType.INTEGER);
     }
 
     @Test
     public void whenCastingAttributeWithWrongValueType_fails() {
         Concept<?> untypedAgeType = age;
         try {
-            AttributeType<String> wrong = untypedAgeType.asAttributeType(ValueType.STRING);
+            AttributeType<String> wrong = untypedAgeType.asAttributeType(DataType.STRING);
             fail();
         } catch (GraknConceptException ignored) {
             assertTrue(true);
         }
         Concept<?> untypedAgeAttr = age20;
         try {
-            Attribute<String> wrong = untypedAgeAttr.asAttribute(ValueType.STRING);
+            Attribute<String> wrong = untypedAgeAttr.asAttribute(DataType.STRING);
             fail();
         } catch (GraknConceptException ignored) {
             assertTrue(true);


### PR DESCRIPTION
## What is the goal of this PR?
In preparation of release: client-java was ahead of grakn-core and other clients in that it implemented Delete functionality for 1.8 and used `ValueType` instead of `DataType` (also 1.8.x functionality). This also required it used the next version of the Graql and protocol (though it is possible to use it as gRPC affords flexibility here, we don't want guesswork of which dependency is "ahead" and which is "in sync" in general). We aim to keep 1.N in line between Clients and Core, using the in-sync and compatible Graql and Protocol dependencies.

## What are the changes implemented in this PR?
* Revert dependencies back to 1.0.6 and 1.0.5 for Graql and Protocol respectively
* Relatedly, undo `ValueType` and use `DataType`, and remove one instance of new `delete` syntax
