### PR TITLE
Fix static tracing not working for async requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,15 @@ jobs:
       - run-bazel-rbe:
           command: bazel test //test/integration/answer:answer-it --test_output=errors
 
+  test-integration-tracing:
+    machine: true
+    working_directory: ~/client-java
+    steps:
+      - install-bazel-linux-rbe
+      - checkout
+      - run-bazel-rbe:
+          command: bazel test //test/integration/tracing:tracing-it --test_output=errors
+
   test-behaviour-connection:
     machine: true
     working_directory: ~/client-java
@@ -240,6 +249,10 @@ workflows:
           filters:
             branches:
               ignore: client-java-release-branch
+      - test-integration-tracing:
+          filters:
+            branches:
+              ignore: client-java-release-branch
       - test-behaviour-connection:
           filters:
             branches:
@@ -266,6 +279,7 @@ workflows:
             - test-assembly-query
             - test-integration-concept
             - test-integration-answer
+            - test-integration-tracing
             - test-behaviour-connection
             - test-behaviour-graql-language
             - test-behaviour-graql-reasoner

--- a/test/integration/tracing/BUILD
+++ b/test/integration/tracing/BUILD
@@ -1,0 +1,62 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
+
+
+package(default_visibility = ["//visibility:__subpackages__"])
+
+load("@graknlabs_build_tools//checkstyle:rules.bzl", "checkstyle_test")
+
+java_test(
+    name = "tracing-it",
+    srcs = ["TracingIT.java"],
+    test_class = "grakn.client.test.integration.tracing.TracingIT",
+    deps = [
+        # Grakn Core dependencies
+        "//:client-java",
+        "//test/setup:grakn-setup",
+        "//test/setup:grakn-properties",
+
+        # Grakn Labs dependencies
+        "@graknlabs_graql//java:graql",
+        "@graknlabs_grabl_tracing//client",
+
+        # Maven External dependencies
+        "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
+        "//dependencies/maven/artifacts/org/slf4j:slf4j-api", # TODO: Do we still need this?
+    ],
+    classpath_resources = [
+        "//test/setup:logback",
+    ],
+    data = [
+        "@graknlabs_grakn_core//:assemble-linux-targz", # Make sure to pass the path in args below
+    ],
+    args = [ # The order of the arguments matter
+        "grakn-core", # Keep at index 0, will be accessible at args[1]
+        "$(location @graknlabs_grakn_core//:assemble-linux-targz)", # Keep at index 1, will be accessible at args[2]
+    ],
+)
+
+
+checkstyle_test(
+    name = "checkstyle",
+    targets = [":tracing-it"],
+    license_type = "apache"
+)

--- a/test/integration/tracing/TracingIT.java
+++ b/test/integration/tracing/TracingIT.java
@@ -72,7 +72,7 @@ public class TracingIT {
                             "name sub attribute, datatype string;\n" +
                             "person sub entity, has name;").asDefine());
 
-                    tx.execute(Graql.parse("insert $x isa person, has name \"bob\"").asInsert());
+                    tx.execute(Graql.parse("insert $x isa person, has name \"bob\";").asInsert());
 
                     Stream<ConceptMap> answers = tx.stream(Graql.parse("match $x isa person, has name \"bob\"; get $x;").asGet());
 

--- a/test/integration/tracing/TracingIT.java
+++ b/test/integration/tracing/TracingIT.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package grakn.client.test.integration.tracing;
+
+import grabl.tracing.client.GrablTracingThreadStatic;
+import grabl.tracing.client.GrablTracingThreadStatic.ThreadContext;
+import grakn.client.GraknClient;
+import grakn.client.answer.ConceptMap;
+import grakn.client.test.setup.GraknProperties;
+import grakn.client.test.setup.GraknSetup;
+import graql.lang.Graql;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+
+import static grabl.tracing.client.GrablTracing.tracingNoOp;
+import static grabl.tracing.client.GrablTracingThreadStatic.contextOnThread;
+import static grabl.tracing.client.GrablTracingThreadStatic.openGlobalAnalysis;
+import static grabl.tracing.client.GrablTracingThreadStatic.setGlobalTracingClient;
+import static org.junit.Assert.assertEquals;
+
+public class TracingIT {
+    private static final String[] args = System.getProperty("sun.java.command").split(" ");
+    private static final GraknSetup.GraknType graknType = GraknSetup.GraknType.of(args[1]);
+    private static final File graknDistributionFile = new File(args[2]);
+    private static GraknClient client;
+
+    @BeforeClass
+    public static void setUpClass() throws InterruptedException, IOException, TimeoutException {
+        setGlobalTracingClient(tracingNoOp());
+        openGlobalAnalysis("owner", "repo", "commit");
+        GraknSetup.bootup(graknType, graknDistributionFile);
+        String address = System.getProperty(GraknProperties.GRAKN_ADDRESS);
+        client = new GraknClient(address);
+    }
+
+    @AfterClass
+    public static void closeSession() throws Exception {
+        client.close();
+        GraknSetup.shutdown(graknType);
+        GrablTracingThreadStatic.getGrablTracing().close();
+    }
+
+    @Test
+    public void testWithTracing() {
+        try (ThreadContext ignored = contextOnThread("tracker", 1)) {
+            try (GraknClient.Session session = client.session("test_tracing")) {
+                try (GraknClient.Transaction tx = session.transaction().write()) {
+                    tx.execute(Graql.parse("define\n" +
+                            "name sub attribute, datatype string;\n" +
+                            "person sub entity, has name;").asDefine());
+
+                    tx.execute(Graql.parse("insert $x isa person, has name \"bob\"").asInsert());
+
+                    Stream<ConceptMap> answers = tx.stream(Graql.parse("match $x isa person, has name \"bob\"; get $x;").asGet());
+
+                    assertEquals(1, answers.count());
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What is the goal of this PR?

Grabl tracing requires us to propagate the trace across threads ourselves, so the introduction of an async decoupling executor in our RPC transceiver (for the results streaming) breaks users of Grabl tracing. We have fixed this.

## What are the changes implemented in this PR?

Propagate the grabl tracing trace to the transceiver executor task.