### PR TITLE
Remove all references to implicits

### DIFF
--- a/concept/SchemaConcept.java
+++ b/concept/SchemaConcept.java
@@ -109,15 +109,6 @@ public interface SchemaConcept<BaseType extends SchemaConcept<BaseType>> extends
         @CheckReturnValue
         Stream<? extends SchemaConcept.Remote<BaseType>> subs();
 
-        /**
-         * Return whether the SchemaConcept was created implicitly.
-         * By default, SchemaConcept are not implicit.
-         *
-         * @return returns true if the type was created implicitly through the Attribute syntax
-         */
-        @CheckReturnValue
-        Boolean isImplicit();
-
 
         //------------------------------------- Other ---------------------------------
         @Deprecated

--- a/concept/impl/SchemaConceptImpl.java
+++ b/concept/impl/SchemaConceptImpl.java
@@ -78,14 +78,6 @@ public abstract class SchemaConceptImpl {
         }
 
         @Override
-        public final Boolean isImplicit() {
-            ConceptProto.Method.Req method = ConceptProto.Method.Req.newBuilder()
-                    .setSchemaConceptIsImplicitReq(ConceptProto.SchemaConcept.IsImplicit.Req.getDefaultInstance()).build();
-
-            return runMethod(method).getSchemaConceptIsImplicitRes().getImplicit();
-        }
-
-        @Override
         public SchemaConcept.Remote<BaseType> label(Label label) {
             ConceptProto.Method.Req method = ConceptProto.Method.Req.newBuilder()
                     .setSchemaConceptSetLabelReq(ConceptProto.SchemaConcept.SetLabel.Req.newBuilder()

--- a/concept/thing/Thing.java
+++ b/concept/thing/Thing.java
@@ -133,15 +133,6 @@ public interface Thing<SomeThing extends Thing<SomeThing, SomeType>,
         Thing.Remote<SomeRemoteThing, SomeRemoteType> has(Attribute<?> attribute);
 
         /**
-         * Creates a Relation from this instance to the provided Attribute.
-         * This has the same effect as #has(Attribute), but returns the new Relation.
-         *
-         * @param attribute The Attribute to which a Relation is created
-         * @return The Relation connecting the Thing and the Attribute
-         */
-        Relation.Remote relhas(Attribute<?> attribute);
-
-        /**
          * Retrieves a collection of Attribute attached to this Thing
          *
          * @param attributeTypes AttributeTypes of the Attributes attached to this entity

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -159,19 +159,13 @@ public abstract class ThingImpl {
 
             @Override
             public Thing.Remote<SomeRemoteThing, SomeRemoteType> has(Attribute<?> attribute) {
-                relhas(attribute);
-                return this;
-            }
-
-            @Deprecated
-            public final Relation.Remote relhas(Attribute<?> attribute) {
                 // TODO: replace usage of this method as a getter, with relations(Attribute attribute)
                 // TODO: then remove this method altogether and just use has(Attribute attribute)
                 ConceptProto.Method.Req method = ConceptProto.Method.Req.newBuilder()
-                        .setThingRelhasReq(ConceptProto.Thing.Relhas.Req.newBuilder()
+                        .setThingHasReq(ConceptProto.Thing.Has.Req.newBuilder()
                                                    .setAttribute(RequestBuilder.ConceptMessage.from(attribute))).build();
-
-                return Concept.Remote.of(runMethod(method).getThingRelhasRes().getRelation(), tx()).asRelation();
+                runMethod(method);
+                return this;
             }
 
             @Override

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -43,15 +43,15 @@ def graknlabs_build_tools():
 def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
-        remote = "https://github.com/graknlabs/grakn",
+        remote = "https://github.com/flyingsilverfin/grakn",
         commit = "35d9dab706829deae3884dae217303d6efa5ca97", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/graknlabs/protocol",
-        commit = "82a29a5cef6b81894181c0d896a3f4f8b5db59fd", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/flyingsilverfin/protocol",
+        commit = "87cdf74ed08d9ba541d31494ca5bc8ccccf12ef2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_verification():

--- a/test/integration/concept/ConceptIT.java
+++ b/test/integration/concept/ConceptIT.java
@@ -239,13 +239,6 @@ public class ConceptIT {
     }
 
     @Test
-    public void whenCallingIsicit_GetTheExpectedResult() {
-        email.playing().forEach(role -> assertTrue(role.isImplicit()));
-        name.playing().forEach(role -> assertTrue(role.isImplicit()));
-        age.playing().forEach(role -> assertTrue(role.isImplicit()));
-    }
-
-    @Test
     public void whenCallingIsAbstract_GetTheExpectedResult() {
         assertTrue(livingThing.isAbstract());
     }
@@ -390,7 +383,7 @@ public class ConceptIT {
 
     @Test
     public void whenCallingPlays_GetTheExpectedResult() {
-        assertThat(person.playing().filter(r -> !r.isImplicit()).collect(toSet()), containsInAnyOrder(wife, husband));
+        assertThat(person.playing().collect(toSet()), containsInAnyOrder(wife, husband));
     }
 
     @Test
@@ -404,14 +397,14 @@ public class ConceptIT {
 
     @Test
     public void whenCallingThingPlays_GetTheExpectedResult() {
-        assertThat(alice.roles().filter(r -> !r.isImplicit()).collect(toSet()), containsInAnyOrder(wife, employee, employer, friend));
-        assertThat(bob.roles().filter(r -> !r.isImplicit()).collect(toSet()), containsInAnyOrder(husband));
+        assertThat(alice.roles().collect(toSet()), containsInAnyOrder(wife, employee, employer, friend));
+        assertThat(bob.roles().collect(toSet()), containsInAnyOrder(husband));
     }
 
     @Test
     public void whenCallingRelationsWithNoArguments_GetTheExpectedResult() {
-        assertThat(alice.relations().filter(rel -> !rel.type().isImplicit()).collect(toSet()), containsInAnyOrder(aliceAndBob, selfEmployment, selfFriendship));
-        assertThat(bob.relations().filter(rel -> !rel.type().isImplicit()).collect(toSet()), containsInAnyOrder(aliceAndBob));
+        assertThat(alice.relations().collect(toSet()), containsInAnyOrder(aliceAndBob, selfEmployment, selfFriendship));
+        assertThat(bob.relations().collect(toSet()), containsInAnyOrder(aliceAndBob));
     }
 
     @Test
@@ -579,16 +572,6 @@ public class ConceptIT {
 
         email.regex(EMAIL_REGEX);
         assertEquals(EMAIL_REGEX, email.regex());
-    }
-
-    @Test
-    public void whenCallingAddAttributeRelationOnThing_RelationIsicit() {
-        assertTrue(alice.relhas(emailAlice).type().isImplicit());
-        assertTrue(alice.relhas(nameAlice).type().isImplicit());
-        assertTrue(alice.relhas(age20).type().isImplicit());
-        assertTrue(bob.relhas(emailBob).type().isImplicit());
-        assertTrue(bob.relhas(nameBob).type().isImplicit());
-        assertTrue(bob.relhas(age20).type().isImplicit());
     }
 
     @Test


### PR DESCRIPTION
## What is the goal of this PR?
We no longer have implicit relations. Therefore, we remove `isImplicit` and `relHas()`, keeping just `has()`.

## What are the changes implemented in this PR?

{ Please explain what you implemented, why your changes are the best way to achieve the goal(s) above, and reference the GitHub issues to be automatically closed, such like 'closes #number'. }
