### PR TITLE
Fix metatypes

### DIFF
--- a/GraknClient.java
+++ b/GraknClient.java
@@ -750,28 +750,28 @@ public class GraknClient implements AutoCloseable {
             }
         }
 
-        public SchemaConcept<?> getMetaConcept() {
+        public SchemaConcept.Remote<?> getMetaConcept() {
             return getSchemaConcept(Label.of(Graql.Token.Type.THING.toString()));
         }
 
-        public MetaType.Remote<?, ?> getMetaRelationType() {
-            return getSchemaConcept(Label.of(Graql.Token.Type.RELATION.toString())).asMetaType();
+        public RelationType.Remote getMetaRelationType() {
+            return getSchemaConcept(Label.of(Graql.Token.Type.RELATION.toString())).asRelationType();
         }
 
-        public MetaType.Remote<?, ?> getMetaRole() {
-            return getSchemaConcept(Label.of(Graql.Token.Type.ROLE.toString())).asMetaType();
+        public Role.Remote getMetaRole() {
+            return getSchemaConcept(Label.of(Graql.Token.Type.ROLE.toString())).asRole();
         }
 
-        public MetaType.Remote<?, ?> getMetaAttributeType() {
-            return getSchemaConcept(Label.of(Graql.Token.Type.ATTRIBUTE.toString())).asMetaType();
+        public AttributeType.Remote<?> getMetaAttributeType() {
+            return getSchemaConcept(Label.of(Graql.Token.Type.ATTRIBUTE.toString())).asAttributeType();
         }
 
-        public MetaType.Remote<?, ?> getMetaEntityType() {
-            return getSchemaConcept(Label.of(Graql.Token.Type.ENTITY.toString())).asMetaType();
+        public EntityType.Remote getMetaEntityType() {
+            return getSchemaConcept(Label.of(Graql.Token.Type.ENTITY.toString())).asEntityType();
         }
 
-        public MetaType.Remote<?, ?> getMetaRule() {
-            return getSchemaConcept(Label.of(Graql.Token.Type.RULE.toString())).asMetaType();
+        public Rule.Remote getMetaRule() {
+            return getSchemaConcept(Label.of(Graql.Token.Type.RULE.toString())).asRule();
         }
 
         @Nullable

--- a/test/integration/concept/ConceptIT.java
+++ b/test/integration/concept/ConceptIT.java
@@ -21,10 +21,12 @@ package grakn.client.test.integration.concept;
 
 import grakn.client.GraknClient;
 import grakn.client.concept.Concept;
+import grakn.client.concept.SchemaConcept;
 import grakn.client.concept.ValueType;
 import grakn.client.concept.GraknConceptException;
 import grakn.client.concept.Label;
 import grakn.client.concept.Rule;
+import grakn.client.concept.type.MetaType;
 import grakn.client.concept.type.Role;
 import grakn.client.concept.thing.Attribute;
 import grakn.client.concept.thing.Entity;
@@ -54,6 +56,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static graql.lang.Graql.var;
 import static java.util.stream.Collectors.toList;
@@ -646,7 +649,17 @@ public class ConceptIT {
 
     @Test
     public void subtypes() {
-        List<Concept<?>> subs = tx.getSchemaConcept(Label.of("thing")).subs().collect(Collectors.toList());
-        subs.forEach(System.out::println);
+        Stream<? extends Concept.Remote<?>> subs = tx.getSchemaConcept(Label.of("thing")).subs();
+        assertTrue(subs.count() > 0);
+    }
+
+    @Test
+    public void metatypes() {
+        SchemaConcept.Remote<?> concept = tx.getMetaConcept();
+        AttributeType.Remote<?> attributeType = tx.getMetaAttributeType();
+        RelationType.Remote relationType = tx.getMetaRelationType();
+        EntityType.Remote entityType = tx.getMetaEntityType();
+        Rule.Remote rule = tx.getMetaRule();
+        Role.Remote role = tx.getMetaRole();
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

To fix the basic metatype getters on transaction and add tests to ensure they don't break again in future. This was broken because the API was confused between using metatypes and using the actual types. Here, we can switch properly to using the actual types, as they contain all the methods and are type-compatible with `subs()`.

## What are the changes implemented in this PR?

- Metatype getters now get the actual type class, rather than the special metatype class. This is how the implementation worked and the fact that they didn't would just cause a casting exception, so this is a bug fix.