### PR TITLE
Fix error message missing from async queries on commit

### DIFF
--- a/rpc/Transceiver.java
+++ b/rpc/Transceiver.java
@@ -241,7 +241,7 @@ public class Transceiver implements AutoCloseable {
 
             // Exhaust the queue
             while (currentCollector != null || collectorQueue.peek() != null) {
-                dispatchResponse(Response.completed());
+                dispatchResponse(Response.error((Exception) throwable));
             }
         }
 

--- a/test/integration/answer/AnswerIT.java
+++ b/test/integration/answer/AnswerIT.java
@@ -162,12 +162,10 @@ public class AnswerIT {
                 tx.execute(Graql.parse("define newentity sub entity;").asDefine());
                 tx.commit();
                 fail();
-            } catch (GraknConceptException ex) {
+            } catch (Exception ex) {
                 if (!ex.getMessage().contains("is read only")) {
                     fail();
                 }
-            } catch (Exception ex) {
-                fail();
             }
         }
     }

--- a/test/integration/answer/AnswerIT.java
+++ b/test/integration/answer/AnswerIT.java
@@ -22,6 +22,8 @@ package grakn.client.test.integration.answer;
 import grakn.client.GraknClient;
 import grakn.client.answer.ConceptMap;
 import grakn.client.answer.Explanation;
+import grakn.client.concept.GraknConceptException;
+import grakn.client.exception.GraknClientException;
 import grakn.client.test.setup.GraknProperties;
 import grakn.client.test.setup.GraknSetup;
 import graql.lang.Graql;
@@ -44,6 +46,7 @@ import static graql.lang.Graql.var;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Integration Tests for Answers and Explanations
@@ -148,6 +151,23 @@ public class AnswerIT {
                 ).get()).get();
 
                 assertEquals(answers.size(), 2);
+            }
+        }
+    }
+
+    @Test
+    public void writingInAReadTransactionThrows() {
+        try (GraknClient.Session session = client.session("test")) {
+            try (GraknClient.Transaction tx = session.transaction().read()) {
+                tx.execute(Graql.parse("define newentity sub entity;").asDefine());
+                tx.commit();
+                fail();
+            } catch (GraknConceptException ex) {
+                if (!ex.getMessage().contains("is read only")) {
+                    fail();
+                }
+            } catch (Exception ex) {
+                fail();
             }
         }
     }

--- a/test/integration/answer/AnswerIT.java
+++ b/test/integration/answer/AnswerIT.java
@@ -22,9 +22,6 @@ package grakn.client.test.integration.answer;
 import grakn.client.GraknClient;
 import grakn.client.answer.ConceptMap;
 import grakn.client.answer.Explanation;
-import grakn.client.concept.ValueType;
-import grakn.client.concept.type.EntityType;
-import grakn.client.concept.type.MetaType;
 import grakn.client.test.setup.GraknProperties;
 import grakn.client.test.setup.GraknSetup;
 import graql.lang.Graql;
@@ -46,7 +43,6 @@ import static graql.lang.Graql.type;
 import static graql.lang.Graql.var;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**


### PR DESCRIPTION
## What is the goal of this PR?
Fix an issue where error messages were unclear when committing a transaction with async queries that fail.

## What are the changes implemented in this PR?
- Forward the actual async errors rather than an unexpected completion response.
- add a test to confirm this happens on commit