### PR TITLE
Update to new structure for explanation tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
       - run-bazel:
           command: bazel test //test/behaviour/graql/language/undefine:test-core --test_output=errors
 
-  test-behaviour-graql-reasoner:
+  test-behaviour-graql-explanation:
     machine: 
       image: ubuntu-1604:201903-01
     working_directory: ~/client-java
@@ -174,7 +174,9 @@ jobs:
       - install-bazel
       - checkout
       - run-bazel:
-          command: bazel test //test/behaviour/graql/reasoner/explanation:test-core --test_output=errors
+          command: bazel test //test/behaviour/graql/explanation/language:test-core --test_output=errors
+      - run-bazel:
+          command: bazel test //test/behaviour/graql/explanation/reasoner:test-core --test_output=errors
 
   deploy-maven-snapshot:
     machine: 
@@ -342,10 +344,10 @@ workflows:
           filters:
             branches:
               ignore: client-java-release-branch
-#      - test-behaviour-graql-reasoner:
-#          filters:
-#            branches:
-#              ignore: client-java-release-branch
+      - test-behaviour-graql-explanation:
+          filters:
+            branches:
+              ignore: client-java-release-branch
       - test-assembly-query:
           filters:
             branches:
@@ -368,7 +370,7 @@ workflows:
             - test-behaviour-graql-insert
             - test-behaviour-graql-match
             - test-behaviour-graql-undefine
-#            - test-behaviour-graql-reasoner
+            - test-behaviour-graql-explanation
       - test-deployment-maven:
           filters:
             branches:

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -58,7 +58,7 @@ def graknlabs_verification():
     git_repository(
         name = "graknlabs_verification",
         remote = "https://github.com/graknlabs/verification",
-        commit = "4530de873599c5d0dded6d81393fbe57816ef57c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
+        commit = "7ebb27486bb333b15dee0ca46e547276d0368e37", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
     )
 
 def graknlabs_grabl_tracing():

--- a/test/behaviour/graql/explanation/language/BUILD
+++ b/test/behaviour/graql/explanation/language/BUILD
@@ -1,0 +1,96 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+package(default_visibility = ["//visibility:__subpackages__"])
+load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+
+java_test(
+    name = "test-core",
+    srcs = [
+        "LanguageTest.java",
+    ],
+    test_class = "grakn.client.test.behaviour.graql.explanation.language.LanguageTest",
+    deps = [
+        # Package dependencies
+        "//test/setup:grakn-setup",
+
+        # External dependencies from Maven
+        "@maven//:io_cucumber_cucumber_junit",
+    ],
+    runtime_deps = [
+        "//test/behaviour/graql:steps",
+        "//test/behaviour/connection:steps",
+        "//test/behaviour/connection/session:steps",
+        "//test/behaviour/config:parameters",
+    ],
+    data = [
+        "@graknlabs_verification//behaviour/graql/explanation:language.feature",
+        "@graknlabs_grakn_core//:assemble-linux-targz", # Make sure to pass the path in args below
+    ],
+    args = [ # The order of the arguments matter
+        "grakn-core", # Keep at index 0, will be accessible at args[1]
+        "$(location @graknlabs_grakn_core//:assemble-linux-targz)", # Keep at index 1, will be accessible at args[2]
+    ],
+    classpath_resources = ["//test/setup:logback"],
+    size = "medium",
+    visibility = ["//visibility:public"]
+)
+
+# To run this test, you need to provide environment variables:
+# --test_env GRAKN_KGMS_ADDRESS=***
+# --test_env GRAKN_KGMS_USERNAME=****
+# --test_env GRAKN_KGMS_PASSWORD=****
+java_test(
+    name = "test-kgms",
+    srcs = [
+        "LanguageTest.java",
+    ],
+    test_class = "grakn.client.test.behaviour.graql.explanation.language.LanguageTest",
+    deps = [
+        # Package dependencies
+        "//test/setup:grakn-setup",
+
+        # External dependencies from Maven
+        "@maven//:io_cucumber_cucumber_junit",
+    ],
+    runtime_deps = [
+        "//test/behaviour/graql:steps",
+        "//test/behaviour/connection:steps",
+        "//test/behaviour/connection/session:steps",
+        "//test/behaviour/config:parameters",
+    ],
+    data = [
+        "@graknlabs_verification//behaviour/graql/explanation:language.feature"
+    ],
+    args = [ # The order of the arguments matter
+        "grakn-kgms", # Keep at index 0, will be accessible at args[1]
+    ],
+    classpath_resources = ["//test/setup:logback"],
+    size = "large",
+)
+
+
+checkstyle_test(
+    name = "checkstyle",
+    targets = [
+        ":test-core",
+        ":test-kgms",
+    ],
+    license_type = "apache"
+)

--- a/test/behaviour/graql/explanation/language/LanguageTest.java
+++ b/test/behaviour/graql/explanation/language/LanguageTest.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package grakn.client.test.behaviour.graql.reasoner.explanation;
+package grakn.client.test.behaviour.graql.explanation.language;
 
 import grakn.client.test.setup.GraknSetup;
 import io.cucumber.junit.Cucumber;
@@ -35,17 +35,17 @@ import java.util.concurrent.TimeoutException;
         strict = true,
         plugin = "pretty",
         glue = "grakn.client.test.behaviour",
-        features = "external/graknlabs_verification/behaviour/graql/reasoner/explanation.feature",
+        features = "external/graknlabs_verification/behaviour/graql/explanation/language.feature",
         tags = "not @ignore and not @ignore-client-java"
 )
-public class ExplanationTest {
+public class LanguageTest {
     // ATTENTION:
     // When you click RUN from within this class through Intellij IDE, it will fail.
     // You can fix it by doing:
     //
     // 1) Go to 'Run'
     // 2) Select 'Edit Configurations...'
-    // 3) Select 'Bazel test ExplanationTest'
+    // 3) Select 'Bazel test ReasonerTest'
     //
     // 4) Ensure 'Target Expression' is set correctly:
     //    a) Use '//<this>/<package>/<name>:test-core' to test against grakn-core

--- a/test/behaviour/graql/explanation/reasoner/BUILD
+++ b/test/behaviour/graql/explanation/reasoner/BUILD
@@ -23,9 +23,9 @@ load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 java_test(
     name = "test-core",
     srcs = [
-        "ExplanationTest.java",
+        "ReasonerTest.java",
     ],
-    test_class = "grakn.client.test.behaviour.graql.reasoner.explanation.ExplanationTest",
+    test_class = "grakn.client.test.behaviour.graql.explanation.reasoner.ReasonerTest",
     deps = [
         # Package dependencies
         "//test/setup:grakn-setup",
@@ -40,7 +40,7 @@ java_test(
         "//test/behaviour/config:parameters",
     ],
     data = [
-        "@graknlabs_verification//behaviour/graql/reasoner:explanation.feature",
+        "@graknlabs_verification//behaviour/graql/explanation:reasoner.feature",
         "@graknlabs_grakn_core//:assemble-linux-targz", # Make sure to pass the path in args below
     ],
     args = [ # The order of the arguments matter
@@ -59,9 +59,9 @@ java_test(
 java_test(
     name = "test-kgms",
     srcs = [
-        "ExplanationTest.java",
+        "ReasonerTest.java",
     ],
-    test_class = "grakn.client.test.behaviour.graql.reasoner.explanation.ExplanationTest",
+    test_class = "grakn.client.test.behaviour.graql.explanation.reasoner.ReasonerTest",
     deps = [
         # Package dependencies
         "//test/setup:grakn-setup",
@@ -76,7 +76,7 @@ java_test(
         "//test/behaviour/config:parameters",
     ],
     data = [
-        "@graknlabs_verification//behaviour/graql/reasoner:explanation.feature"
+        "@graknlabs_verification//behaviour/graql/explanation:reasoner.feature"
     ],
     args = [ # The order of the arguments matter
         "grakn-kgms", # Keep at index 0, will be accessible at args[1]

--- a/test/behaviour/graql/explanation/reasoner/ReasonerTest.java
+++ b/test/behaviour/graql/explanation/reasoner/ReasonerTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package grakn.client.test.behaviour.graql.explanation.reasoner;
+
+import grakn.client.test.setup.GraknSetup;
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        plugin = "pretty",
+        glue = "grakn.client.test.behaviour",
+        features = "external/graknlabs_verification/behaviour/graql/explanation/reasoner.feature",
+        tags = "not @ignore and not @ignore-client-java"
+)
+public class ReasonerTest {
+    // ATTENTION:
+    // When you click RUN from within this class through Intellij IDE, it will fail.
+    // You can fix it by doing:
+    //
+    // 1) Go to 'Run'
+    // 2) Select 'Edit Configurations...'
+    // 3) Select 'Bazel test ReasonerTest'
+    //
+    // 4) Ensure 'Target Expression' is set correctly:
+    //    a) Use '//<this>/<package>/<name>:test-core' to test against grakn-core
+    //    b) Use '//<this>/<package>/<name>:test-kgms' to test against grakn-kgms
+    //
+    // 5) Update 'Bazel Flags':
+    //    a) Remove the line that says: '--test_filter=grakn.client.*'
+    //    b) Use the following Bazel flags:
+    //       --cache_test_results=no : to make sure you're not using cache
+    //       --test_output=streamed : to make sure all output is printed
+    //       --subcommands : to print the low-level commands and execution paths
+    //       --sandbox_debug : to keep the sandbox not deleted after test runs
+    //       --spawn_strategy=standalone : if you're on Mac, tests need permission to access filesystem (to run Grakn)
+    //
+    // 6) Hit the RUN button by selecting the test from the dropdown menu on the top bar
+
+    private static final String[] args = System.getProperty("sun.java.command").split(" ");
+    private static final GraknSetup.GraknType graknType = GraknSetup.GraknType.of(args[1]);
+    private static final File graknDistributionFile = new File(args[2]);
+
+    @BeforeClass
+    public static void beforeClass() throws InterruptedException, TimeoutException, IOException {
+        GraknSetup.bootup(graknType, graknDistributionFile);
+    }
+
+    @AfterClass
+    public static void afterClass() throws InterruptedException, IOException, TimeoutException {
+        GraknSetup.shutdown(graknType);
+    }
+}


### PR DESCRIPTION
## What is the goal of this PR?

We bring the structure of tests for explanations in line with that of `graknlabs/grakn` and `graknlabs/verification`.

## What are the changes implemented in this PR?

- Moves explanation tests to their own module
- Within the module, we have one Feature with reasoning and one without
- Updates CI to run these two test Features