### PR TITLE
Depend on grakn artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ commands:
   run-grakn:
     steps:
       - run-bazel:
-          command: bazel build @graknlabs_grakn_core//:assemble-linux-targz
+          command: bazel build @graknlabs_grakn_core_artifact//file
       - run: mkdir dist && tar -xvzf bazel-bin/external/graknlabs_grakn_core/grakn-core-all-linux.tar.gz -C ./dist/
       - run: nohup ./dist/grakn-core-all-linux/grakn server start
 jobs:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -175,17 +175,10 @@ graknlabs_grabl_tracing()
 load("@graknlabs_grabl_tracing//dependencies/maven:artifacts.bzl", graknlabs_grabl_tracing_artifacts = "artifacts")
 
 ##############################
-# Load @graknlabs_grakn_core #
+# Load @graknlabs_grakn_core_artifact #
 ##############################
-load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_grakn_core")
-graknlabs_grakn_core()
-
-load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl", "graknlabs_console")
-graknlabs_console()
-
-load("@graknlabs_grakn_core//dependencies/maven:dependencies.bzl",
-graknlabs_grakn_core_maven_dependencies = "maven_dependencies")
-graknlabs_grakn_core_maven_dependencies()
+load("//dependencies/graknlabs:artifacts.bzl", "graknlabs_grakn_core_artifact")
+graknlabs_grakn_core_artifact()
 
 ################################
 # Load @graknlabs_verification #

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+load("@graknlabs_dependencies//distribution/artifact:rules.bzl", "artifact_file")
+
+def graknlabs_grakn_core_artifact():
+    artifact_file(
+        name = "graknlabs_grakn_core_artifact",
+        group_name = "graknlabs_grakn_core",
+        artifact_name = "grakn-core-all-linux.tar.gz",
+        commit = "787079dbcca5bc28e7bd030aa5229d136cf3a04d",
+    )

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -24,5 +24,5 @@ def graknlabs_grakn_core_artifact():
         name = "graknlabs_grakn_core_artifact",
         group_name = "graknlabs_grakn_core",
         artifact_name = "grakn-core-all-linux-{version}.tar.gz",
-        commit = "f909b777efd515e5154daff836484e19de709b0d",
+        commit = "7cc0fcc8e44eb419f540b5ccedb4fcfe23c26e32",
     )

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -23,6 +23,6 @@ def graknlabs_grakn_core_artifact():
     artifact_file(
         name = "graknlabs_grakn_core_artifact",
         group_name = "graknlabs_grakn_core",
-        artifact_name = "grakn-core-all-linux.tar.gz",
-        commit = "787079dbcca5bc28e7bd030aa5229d136cf3a04d",
+        artifact_name = "grakn-core-all-linux-{version}.tar.gz",
+        commit = "f909b777efd515e5154daff836484e19de709b0d",
     )

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -40,13 +40,6 @@ def graknlabs_dependencies():
         commit = "61fe8156b640196b4673fdf4f84075655bc0bc61", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
-def graknlabs_grakn_core():
-    git_repository(
-        name = "graknlabs_grakn_core",
-        remote = "https://github.com/graknlabs/grakn",
-        commit = "553cde5dda0d714a86c07b55c5c801a3d315838a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
-    )
-
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -37,7 +37,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "61fe8156b640196b4673fdf4f84075655bc0bc61", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "2e7638f266703fa674f6d5f9eca1f39480fd7f99", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_protocol():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -37,7 +37,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "2e7638f266703fa674f6d5f9eca1f39480fd7f99", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "c921c9468468249764eebafa9940a487f577c3f8", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_protocol():

--- a/test/assembly/BUILD
+++ b/test/assembly/BUILD
@@ -40,10 +40,10 @@ java_test(
         "@maven//:org_zeroturnaround_zt_exec",
         "@maven//:org_slf4j_slf4j_api",
     ],
-    data = ["@graknlabs_grakn_core//:assemble-linux-targz"],
+    data = ["@graknlabs_grakn_core_artifact//file"],
     args = [ # The order of the arguments matter
         "grakn-core", # Keep at index 0, will be accessible at args[1]
-        "$(location @graknlabs_grakn_core//:assemble-linux-targz)", # Keep at index 1, will be accessible at args[2]
+        "$(locations @graknlabs_grakn_core_artifact//file)", # Keep at index 1, will be accessible at args[2]
     ],
     classpath_resources = ["//test/setup:logback"],
 )

--- a/test/behaviour/connection/keyspace/BUILD
+++ b/test/behaviour/connection/keyspace/BUILD
@@ -56,11 +56,11 @@ java_test(
     ],
     data = [
         "@graknlabs_verification//behaviour/connection:keyspace.feature",
-        "@graknlabs_grakn_core//:assemble-linux-targz", # Make sure to pass the path in args below
+        "@graknlabs_grakn_core_artifact//file", # Make sure to pass the path in args below
     ],
     args = [ # The order of the arguments matter
         "grakn-core", # Keep at index 0, will be accessible at args[1]
-        "$(location @graknlabs_grakn_core//:assemble-linux-targz)", # Keep at index 1, will be accessible at args[2]
+        "$(locations @graknlabs_grakn_core_artifact//file)", # Keep at index 1, will be accessible at args[2]
     ],
     classpath_resources = ["//test/setup:logback"],
     size = "large",

--- a/test/behaviour/connection/session/BUILD
+++ b/test/behaviour/connection/session/BUILD
@@ -59,11 +59,11 @@ java_test(
     ],
     data = [
         "@graknlabs_verification//behaviour/connection:session.feature",
-        "@graknlabs_grakn_core//:assemble-linux-targz", # Make sure to pass the path in args below
+        "@graknlabs_grakn_core_artifact//file", # Make sure to pass the path in args below
     ],
     args = [ # The order of the arguments matter
         "grakn-core", # Keep at index 0, will be accessible at args[1]
-        "$(location @graknlabs_grakn_core//:assemble-linux-targz)", # Keep at index 1, will be accessible at args[2]
+        "$(locations @graknlabs_grakn_core_artifact//file)", # Keep at index 1, will be accessible at args[2]
     ],
     classpath_resources = ["//test/setup:logback"],
     size = "medium",

--- a/test/behaviour/connection/transaction/BUILD
+++ b/test/behaviour/connection/transaction/BUILD
@@ -61,11 +61,11 @@ java_test(
     ],
     data = [
         "@graknlabs_verification//behaviour/connection:transaction.feature",
-        "@graknlabs_grakn_core//:assemble-linux-targz", # Make sure to pass the path in args below
+        "@graknlabs_grakn_core_artifact//file", # Make sure to pass the path in args below
     ],
     args = [ # The order of the arguments matter
         "grakn-core", # Keep at index 0, will be accessible at args[1]
-        "$(location @graknlabs_grakn_core//:assemble-linux-targz)", # Keep at index 1, will be accessible at args[2]
+        "$(locations @graknlabs_grakn_core_artifact//file)", # Keep at index 1, will be accessible at args[2]
     ],
     classpath_resources = ["//test/setup:logback"],
     size = "large",

--- a/test/behaviour/connection/transaction/TransactionSteps.java
+++ b/test/behaviour/connection/transaction/TransactionSteps.java
@@ -95,7 +95,7 @@ public class TransactionSteps {
     }
 
     @Then("for each session, transaction(s) commit(s); throws exception")
-    public void for_each_session_transactions_commits_throws_exception(boolean successfully) {
+    public void for_each_session_transactions_commits_throws_exception() {
         for (GraknClient.Session session : sessions) {
             for (GraknClient.Transaction transaction : sessionsToTransactions.get(session)) {
                 assertThrows(transaction::commit);

--- a/test/behaviour/debug/BUILD
+++ b/test/behaviour/debug/BUILD
@@ -45,11 +45,11 @@ java_test(
     ],
     data = [
         ":debug.feature",
-        "@graknlabs_grakn_core//:assemble-linux-targz", # Make sure to pass the path in args below
+        "@graknlabs_grakn_core_artifact//file", # Make sure to pass the path in args below
     ],
     args = [ # The order of the arguments matter
         "grakn-core", # Keep at index 0, will be accessible at args[1]
-        "$(location @graknlabs_grakn_core//:assemble-linux-targz)", # Keep at index 1, will be accessible at args[2]
+        "$(locations @graknlabs_grakn_core_artifact//file)", # Keep at index 1, will be accessible at args[2]
     ],
     classpath_resources = ["//test/setup:logback"],
     size = "medium",

--- a/test/behaviour/graql/language/define/BUILD
+++ b/test/behaviour/graql/language/define/BUILD
@@ -41,11 +41,11 @@ java_test(
     ],
     data = [
         "@graknlabs_verification//behaviour/graql/language:define.feature",
-        "@graknlabs_grakn_core//:assemble-linux-targz", # Make sure to pass the path in args below
+        "@graknlabs_grakn_core_artifact//file", # Make sure to pass the path in args below
     ],
     args = [ # The order of the arguments matter
         "grakn-core", # Keep at index 0, will be accessible at args[1]
-        "$(location @graknlabs_grakn_core//:assemble-linux-targz)", # Keep at index 1, will be accessible at args[2]
+        "$(locations @graknlabs_grakn_core_artifact//file)", # Keep at index 1, will be accessible at args[2]
     ],
     classpath_resources = ["//test/setup:logback"],
     size = "enormous",

--- a/test/behaviour/graql/language/delete/BUILD
+++ b/test/behaviour/graql/language/delete/BUILD
@@ -41,11 +41,11 @@ java_test(
     ],
     data = [
         "@graknlabs_verification//behaviour/graql/language:delete.feature",
-        "@graknlabs_grakn_core//:assemble-linux-targz", # Make sure to pass the path in args below
+        "@graknlabs_grakn_core_artifact//file", # Make sure to pass the path in args below
     ],
     args = [ # The order of the arguments matter
         "grakn-core", # Keep at index 0, will be accessible at args[1]
-        "$(location @graknlabs_grakn_core//:assemble-linux-targz)", # Keep at index 1, will be accessible at args[2]
+        "$(locations @graknlabs_grakn_core_artifact//file)", # Keep at index 1, will be accessible at args[2]
     ],
     classpath_resources = ["//test/setup:logback"],
     size = "large",

--- a/test/behaviour/graql/language/get/BUILD
+++ b/test/behaviour/graql/language/get/BUILD
@@ -41,11 +41,11 @@ java_test(
     ],
     data = [
         "@graknlabs_verification//behaviour/graql/language:get.feature",
-        "@graknlabs_grakn_core//:assemble-linux-targz", # Make sure to pass the path in args below
+        "@graknlabs_grakn_core_artifact//file", # Make sure to pass the path in args below
     ],
     args = [ # The order of the arguments matter
         "grakn-core", # Keep at index 0, will be accessible at args[1]
-        "$(location @graknlabs_grakn_core//:assemble-linux-targz)", # Keep at index 1, will be accessible at args[2]
+        "$(locations @graknlabs_grakn_core_artifact//file)", # Keep at index 1, will be accessible at args[2]
     ],
     classpath_resources = ["//test/setup:logback"],
     size = "large",

--- a/test/behaviour/graql/language/insert/BUILD
+++ b/test/behaviour/graql/language/insert/BUILD
@@ -41,11 +41,11 @@ java_test(
     ],
     data = [
         "@graknlabs_verification//behaviour/graql/language:insert.feature",
-        "@graknlabs_grakn_core//:assemble-linux-targz", # Make sure to pass the path in args below
+        "@graknlabs_grakn_core_artifact//file", # Make sure to pass the path in args below
     ],
     args = [ # The order of the arguments matter
         "grakn-core", # Keep at index 0, will be accessible at args[1]
-        "$(location @graknlabs_grakn_core//:assemble-linux-targz)", # Keep at index 1, will be accessible at args[2]
+        "$(locations @graknlabs_grakn_core_artifact//file)", # Keep at index 1, will be accessible at args[2]
     ],
     classpath_resources = ["//test/setup:logback"],
     size = "enormous",

--- a/test/behaviour/graql/language/match/BUILD
+++ b/test/behaviour/graql/language/match/BUILD
@@ -41,11 +41,11 @@ java_test(
     ],
     data = [
         "@graknlabs_verification//behaviour/graql/language:match.feature",
-        "@graknlabs_grakn_core//:assemble-linux-targz", # Make sure to pass the path in args below
+        "@graknlabs_grakn_core_artifact//file", # Make sure to pass the path in args below
     ],
     args = [ # The order of the arguments matter
         "grakn-core", # Keep at index 0, will be accessible at args[1]
-        "$(location @graknlabs_grakn_core//:assemble-linux-targz)", # Keep at index 1, will be accessible at args[2]
+        "$(locations @graknlabs_grakn_core_artifact//file)", # Keep at index 1, will be accessible at args[2]
     ],
     classpath_resources = ["//test/setup:logback"],
     size = "large",

--- a/test/behaviour/graql/language/undefine/BUILD
+++ b/test/behaviour/graql/language/undefine/BUILD
@@ -41,11 +41,11 @@ java_test(
     ],
     data = [
         "@graknlabs_verification//behaviour/graql/language:undefine.feature",
-        "@graknlabs_grakn_core//:assemble-linux-targz", # Make sure to pass the path in args below
+        "@graknlabs_grakn_core_artifact//file", # Make sure to pass the path in args below
     ],
     args = [ # The order of the arguments matter
         "grakn-core", # Keep at index 0, will be accessible at args[1]
-        "$(location @graknlabs_grakn_core//:assemble-linux-targz)", # Keep at index 1, will be accessible at args[2]
+        "$(locations @graknlabs_grakn_core_artifact//file)", # Keep at index 1, will be accessible at args[2]
     ],
     classpath_resources = ["//test/setup:logback"],
     size = "large",

--- a/test/integration/answer/BUILD
+++ b/test/integration/answer/BUILD
@@ -45,11 +45,11 @@ java_test(
         "//test/setup:logback",
     ],
     data = [
-        "@graknlabs_grakn_core//:assemble-linux-targz", # Make sure to pass the path in args below
+        "@graknlabs_grakn_core_artifact//file", # Make sure to pass the path in args below
     ],
     args = [ # The order of the arguments matter
         "grakn-core", # Keep at index 0, will be accessible at args[1]
-        "$(location @graknlabs_grakn_core//:assemble-linux-targz)", # Keep at index 1, will be accessible at args[2]
+        "$(locations @graknlabs_grakn_core_artifact//file)", # Keep at index 1, will be accessible at args[2]
     ],
 )
 

--- a/test/integration/concept/BUILD
+++ b/test/integration/concept/BUILD
@@ -46,11 +46,11 @@ java_test(
         "//test/setup:logback",
     ],
     data = [
-        "@graknlabs_grakn_core//:assemble-linux-targz", # Make sure to pass the path in args below
+        "@graknlabs_grakn_core_artifact//file", # Make sure to pass the path in args below
     ],
     args = [ # The order of the arguments matter
         "grakn-core", # Keep at index 0, will be accessible at args[1]
-        "$(location @graknlabs_grakn_core//:assemble-linux-targz)", # Keep at index 1, will be accessible at args[2]
+        "$(locations @graknlabs_grakn_core_artifact//file)", # Keep at index 1, will be accessible at args[2]
     ],
 )
 

--- a/test/integration/tracing/BUILD
+++ b/test/integration/tracing/BUILD
@@ -46,11 +46,11 @@ java_test(
         "//test/setup:logback",
     ],
     data = [
-        "@graknlabs_grakn_core//:assemble-linux-targz", # Make sure to pass the path in args below
+        "@graknlabs_grakn_core_artifact//file", # Make sure to pass the path in args below
     ],
     args = [ # The order of the arguments matter
         "grakn-core", # Keep at index 0, will be accessible at args[1]
-        "$(location @graknlabs_grakn_core//:assemble-linux-targz)", # Keep at index 1, will be accessible at args[2]
+        "$(locations @graknlabs_grakn_core_artifact//file)", # Keep at index 1, will be accessible at args[2]
     ],
 )
 


### PR DESCRIPTION
## What is the goal of this PR?

To depend on the artifact of grakn for tests instead of depending on it through source. This should cut down issues where the version of grakn core being tested against is incorrect due to dependency leakage from this repository.

## What are the changes implemented in this PR?

- Removed dependency on grakn core code
- Added dependency on grakn core artifact