### PR TITLE
Fix broken master due to bad grakn extract step in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ commands:
   run-grakn:
     steps:
       - run-bazel:
-          command: bazel run //test:grakn-extractor dist/grakn-core-all-linux
+          command: bazel run //test:grakn-extractor -- dist/grakn-core-all-linux
       - run: nohup ./dist/grakn-core-all-linux/grakn server start
 
 jobs:


### PR DESCRIPTION
The grakn extract step use `bazel run //:target args` instead of `bazel run //:target -- args`.