### PR TITLE
Collapse all behavour and integration tests into one CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
       - run-bazel:
           command: bazel test $(bazel query 'kind(checkstyle_test, //...)')
 
-  test-integration-concept:
+  test-integration:
     machine: 
       image: ubuntu-1604:201903-01
     working_directory: ~/client-java
@@ -77,9 +77,9 @@ jobs:
       - install-bazel
       - checkout
       - run-bazel:
-          command: bazel test //test/integration/concept:concept-it --test_output=errors
+          command: bazel test //test/integration/... --test_output=errors
 
-  test-integration-answer:
+  test-behaviour:
     machine: 
       image: ubuntu-1604:201903-01
     working_directory: ~/client-java
@@ -87,101 +87,7 @@ jobs:
       - install-bazel
       - checkout
       - run-bazel:
-          command: bazel test //test/integration/answer:answer-it --test_output=errors
-
-  test-integration-tracing:
-    machine: 
-      image: ubuntu-1604:201903-01
-    working_directory: ~/client-java
-    steps:
-      - install-bazel
-      - checkout
-      - run-bazel:
-          command: bazel test //test/integration/tracing:tracing-it --test_output=errors
-
-  test-behaviour-connection:
-    machine: 
-      image: ubuntu-1604:201903-01
-    working_directory: ~/client-java
-    steps:
-      - install-bazel
-      - checkout
-      - run-bazel:
-          command: bazel test //test/behaviour/connection/keyspace:test-core --test_output=errors
-      - run-bazel:
-          command: bazel test //test/behaviour/connection/session:test-core --test_output=errors
-      - run-bazel:
-          command: bazel test //test/behaviour/connection/transaction:test-core --test_output=errors
-
-  test-behaviour-graql-define:
-    machine: 
-      image: ubuntu-1604:201903-01
-    working_directory: ~/client-java
-    steps:
-      - install-bazel
-      - checkout
-      - run-bazel:
-          command: bazel test //test/behaviour/graql/language/define:test-core --test_output=errors
-
-  test-behaviour-graql-delete:
-    machine: 
-      image: ubuntu-1604:201903-01
-    working_directory: ~/client-java
-    steps:
-      - install-bazel
-      - checkout
-      - run-bazel:
-          command: bazel test //test/behaviour/graql/language/delete:test-core --test_output=errors
-
-  test-behaviour-graql-get:
-    machine: 
-      image: ubuntu-1604:201903-01
-    working_directory: ~/client-java
-    steps:
-      - install-bazel
-      - checkout
-      - run-bazel:
-          command: bazel test //test/behaviour/graql/language/get:test-core --test_output=errors
-
-  test-behaviour-graql-insert:
-    machine: 
-      image: ubuntu-1604:201903-01
-    working_directory: ~/client-java
-    steps:
-      - install-bazel
-      - checkout
-      - run-bazel:
-          command: bazel test //test/behaviour/graql/language/insert:test-core --test_output=errors
-
-  test-behaviour-graql-match:
-    machine: 
-      image: ubuntu-1604:201903-01
-    working_directory: ~/client-java
-    steps:
-      - install-bazel
-      - checkout
-      - run-bazel:
-          command: bazel test //test/behaviour/graql/language/match:test-core --test_output=errors
-
-  test-behaviour-graql-undefine:
-    machine: 
-      image: ubuntu-1604:201903-01
-    working_directory: ~/client-java
-    steps:
-      - install-bazel
-      - checkout
-      - run-bazel:
-          command: bazel test //test/behaviour/graql/language/undefine:test-core --test_output=errors
-
-  test-behaviour-graql-reasoner:
-    machine: 
-      image: ubuntu-1604:201903-01
-    working_directory: ~/client-java
-    steps:
-      - install-bazel
-      - checkout
-      - run-bazel:
-          command: bazel test //test/behaviour/graql/reasoner/explanation:test-core --test_output=errors
+          command: bazel test //test/behaviour/... --test_output=errors
 
   deploy-maven-snapshot:
     machine: 
@@ -309,50 +215,14 @@ workflows:
           filters:
             branches:
               ignore: client-java-release-branch
-      - test-integration-concept:
+      - test-integration:
           filters:
             branches:
               ignore: client-java-release-branch
-      - test-integration-answer:
+      - test-behaviour:
           filters:
             branches:
               ignore: client-java-release-branch
-      - test-integration-tracing:
-          filters:
-            branches:
-              ignore: client-java-release-branch
-      - test-behaviour-connection:
-          filters:
-            branches:
-              ignore: client-java-release-branch
-      - test-behaviour-graql-define:
-          filters:
-            branches:
-              ignore: client-java-release-branch
-      - test-behaviour-graql-delete:
-          filters:
-            branches:
-              ignore: client-java-release-branch
-      - test-behaviour-graql-get:
-          filters:
-            branches:
-              ignore: client-java-release-branch
-      - test-behaviour-graql-insert:
-          filters:
-            branches:
-              ignore: client-java-release-branch
-      - test-behaviour-graql-match:
-          filters:
-            branches:
-              ignore: client-java-release-branch
-      - test-behaviour-graql-undefine:
-          filters:
-            branches:
-              ignore: client-java-release-branch
-#      - test-behaviour-graql-reasoner:
-#          filters:
-#            branches:
-#              ignore: client-java-release-branch
       - test-assembly-query:
           filters:
             branches:
@@ -365,17 +235,8 @@ workflows:
             - build
             - build-checkstyle
             - test-assembly-query
-            - test-integration-concept
-            - test-integration-answer
-            - test-integration-tracing
-            - test-behaviour-connection
-            - test-behaviour-graql-define
-            - test-behaviour-graql-delete
-            - test-behaviour-graql-get
-            - test-behaviour-graql-insert
-            - test-behaviour-graql-match
-            - test-behaviour-graql-undefine
-#            - test-behaviour-graql-reasoner
+            - test-integration
+            - test-behaviour
       - test-deployment-maven:
           filters:
             branches:

--- a/test/behaviour/connection/keyspace/BUILD
+++ b/test/behaviour/connection/keyspace/BUILD
@@ -82,6 +82,7 @@ grakn_test(
     type = "grakn-kgms",
     grakn_artifact = "@graknlabs_grakn_core_artifact//file",
     size = "large",
+    tags = ["manual"]
 )
 
 checkstyle_test(

--- a/test/behaviour/connection/session/BUILD
+++ b/test/behaviour/connection/session/BUILD
@@ -86,6 +86,7 @@ grakn_test(
     ],
     type = "grakn-kgms",
     size = "medium",
+    tags = ["manual"]
 )
 
 checkstyle_test(

--- a/test/behaviour/connection/transaction/BUILD
+++ b/test/behaviour/connection/transaction/BUILD
@@ -89,6 +89,7 @@ grakn_test(
     ],
     type = "grakn-kgms",
     size = "large",
+    tags = ["manual"]
 )
 
 checkstyle_test(

--- a/test/behaviour/debug/BUILD
+++ b/test/behaviour/debug/BUILD
@@ -46,6 +46,7 @@ grakn_test(
     ],
     grakn_artifact = "@graknlabs_grakn_core_artifact//file",
     size = "medium",
+    tags = ["manual"]
 )
 
 checkstyle_test(

--- a/test/behaviour/graql/language/define/BUILD
+++ b/test/behaviour/graql/language/define/BUILD
@@ -70,6 +70,7 @@ grakn_test(
     ],
     type = "grakn-kgms",
     size = "large",
+    tags = ["manual"]
 )
 
 

--- a/test/behaviour/graql/language/delete/BUILD
+++ b/test/behaviour/graql/language/delete/BUILD
@@ -70,6 +70,7 @@ grakn_test(
     ],
     type = "grakn-kgms",
     size = "large",
+    tags = ["manual"]
 )
 
 

--- a/test/behaviour/graql/language/get/BUILD
+++ b/test/behaviour/graql/language/get/BUILD
@@ -70,6 +70,7 @@ grakn_test(
     ],
     type = "grakn-kgms",
     size = "large",
+    tags = ["manual"]
 )
 
 

--- a/test/behaviour/graql/language/insert/BUILD
+++ b/test/behaviour/graql/language/insert/BUILD
@@ -73,6 +73,7 @@ grakn_test(
     ],
     type = "grakn-kgms",
     size = "enormous",
+    tags = ["manual"]
 )
 
 

--- a/test/behaviour/graql/language/match/BUILD
+++ b/test/behaviour/graql/language/match/BUILD
@@ -70,6 +70,7 @@ grakn_test(
     ],
     type = "grakn-kgms",
     size = "large",
+    tags = ["manual"]
 )
 
 

--- a/test/behaviour/graql/language/undefine/BUILD
+++ b/test/behaviour/graql/language/undefine/BUILD
@@ -70,6 +70,7 @@ grakn_test(
     ],
     type = "grakn-kgms",
     size = "large",
+    tags = ["manual"]
 )
 
 


### PR DESCRIPTION
## What is the goal of this PR?

In order to save up on CircleCI jobs and increase parallelization (given all jobs are ran remotely anyway), we're collapsing all `test-behaviour-*` and `test-integration-*` into one

## What are the changes implemented in this PR?

Collapse all behaviour and integration testing jobs into one