### PR TITLE
Remove sync-dependencies from workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,18 +243,12 @@ workflows:
               only: master
           requires:
             - deploy-maven-snapshot
-      - sync-dependencies-snapshot:
-          filters:
-            branches:
-              only: master
-          requires:
-            - test-deployment-maven
       - release-approval:
           filters:
             branches:
               only: master
           requires:
-            - sync-dependencies-snapshot
+            - test-deployment-maven
   client-java-release:
     jobs:
       - release-validate:
@@ -277,15 +271,9 @@ workflows:
               only: client-java-release-branch
           requires:
             - deploy-approval
-      - sync-dependencies-release:
-          filters:
-            branches:
-              only: client-java-release-branch
-          requires:
-            - deploy-maven-release
       - release-cleanup:
           filters:
             branches:
               only: client-java-release-branch
           requires:
-            - sync-dependencies-release
+            - deploy-maven-release


### PR DESCRIPTION
## What is the goal of this PR?

We have removed sync-dependencies completely. It will be replaced by Grabl 2.0's sync pipeline soon.