### PR TITLE
More cleanup and bugfixes

### DIFF
--- a/Grakn.java
+++ b/Grakn.java
@@ -29,7 +29,6 @@ import grakn.client.concept.answer.ConceptSetMeasure;
 import grakn.client.concept.answer.Explanation;
 import grakn.client.concept.answer.Numeric;
 import grakn.client.concept.answer.Void;
-import grakn.client.rpc.RPCClient;
 import graql.lang.query.GraqlCompute;
 import graql.lang.query.GraqlDefine;
 import graql.lang.query.GraqlDelete;
@@ -48,14 +47,6 @@ import java.util.stream.Stream;
 import static grakn.client.Grakn.Session.Type.DATA;
 
 public interface Grakn {
-
-    static Client client() {
-        return new RPCClient();
-    }
-
-    static Client client(String address) {
-        return new RPCClient(address);
-    }
 
     interface Client extends AutoCloseable {
 

--- a/GraknOptions.java
+++ b/GraknOptions.java
@@ -19,11 +19,11 @@
 
 package grakn.client;
 
-import grakn.client.common.exception.GraknException;
+import grakn.client.common.exception.GraknClientException;
 
 import java.util.Optional;
 
-import static grakn.client.common.exception.ErrorMessage.Connection.NEGATIVE_BATCH_SIZE;
+import static grakn.client.common.exception.ErrorMessage.Client.NEGATIVE_BATCH_SIZE;
 
 public class GraknOptions {
 
@@ -55,7 +55,7 @@ public class GraknOptions {
 
     public GraknOptions batchSize(final int batchSize) {
         if (batchSize < 1) {
-            throw new GraknException(NEGATIVE_BATCH_SIZE.message(batchSize));
+            throw new GraknClientException(NEGATIVE_BATCH_SIZE.message(batchSize));
         }
         this.batchSize = batchSize;
         return this;

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -25,55 +25,39 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
         super(codePrefix, codeNumber, messagePrefix, messageBody);
     }
 
-    public static class ClientInternal extends ErrorMessage {
-        public static final ClientInternal UNRECOGNISED_VALUE =
-                new ClientInternal(1, "Unrecognised schema value!");
+    public static class Client extends ErrorMessage {
+        public static final Client CONNECTION_CLOSED =
+                new Client(1, "The connection to the database is closed.");
+        public static final Client TRANSACTION_LISTENER_TERMINATED =
+                new Client(2, "Transaction listener was terminated");
+        public static final Client NEGATIVE_BATCH_SIZE =
+                new Client(3, "Batch size cannot be less than 1, was: '%d'.");
+        public static final Client MISSING_DB_NAME =
+                new Client(4, "Database name cannot be null or empty.");
+        public static final Client MISSING_RESPONSE =
+                new Client(5, "The required field 'res' of type '%s' was not set.");
 
-        private static final String codePrefix = "CIN";
-        private static final String messagePrefix = "Invalid Internal State (Client)";
+        private static final String codePrefix = "CLI";
+        private static final String messagePrefix = "Illegal Client State";
 
-        ClientInternal(int number, String message) {
-            super(codePrefix, number, messagePrefix, message);
-        }
-    }
-
-    public static class Connection extends ErrorMessage {
-        public static final Connection CONNECTION_CLOSED =
-                new Connection(1, "The connection to the database is closed.");
-        public static final Connection TRANSACTION_LISTENER_TERMINATED =
-                new Connection(2, "Transaction listener was terminated");
-        public static final Connection NEGATIVE_BATCH_SIZE =
-                new Connection(3, "Batch size cannot be less than 1, was: '%d'.");
-
-        private static final String codePrefix = "CNN";
-        private static final String messagePrefix = "Database Connection Error";
-
-        Connection(int number, String message) {
-            super(codePrefix, number, messagePrefix, message);
-        }
-    }
-
-    public static class DatabaseManager extends ErrorMessage {
-        public static final DatabaseManager NULL_OR_EMPTY_DB_NAME =
-                new DatabaseManager(1, "Database name cannot be null or empty.");
-
-        private static final String codePrefix = "CDB";
-        private static final String messagePrefix = "Invalid Database Operations (Client)";
-
-        DatabaseManager(int number, String message) {
+        Client(int number, String message) {
             super(codePrefix, number, messagePrefix, message);
         }
     }
 
     public static class Concept extends ErrorMessage {
-        public static final Concept UNRECOGNISED_CONCEPT =
-                new Concept(1, "The %s '%s' was not recognised.");
         public static final Concept INVALID_CONCEPT_CASTING =
-                new Concept(2, "Invalid concept conversion from '%s' to '%s'.");
-        public static final Concept NULL_TRANSACTION =
-                new Concept(3, "Transaction can not be null.");
-        public static final Concept NULL_OR_EMPTY_IID =
-                new Concept(4, "IID cannot be null or empty.");
+                new Concept(1, "Invalid concept conversion from '%s' to '%s'.");
+        public static final Concept MISSING_TRANSACTION =
+                new Concept(2, "Transaction can not be null.");
+        public static final Concept MISSING_IID =
+                new Concept(3, "IID cannot be null or empty.");
+        public static final Concept BAD_ENCODING =
+                new Concept(4, "The encoding '%s' was not recognised.");
+        public static final Concept BAD_VALUE_TYPE =
+                new Concept(5, "The value type '%s' was not recognised.");
+        public static final Concept BAD_ATTRIBUTE_VALUE =
+                new Concept(6, "The attribute value '%s' was not recognised.");
 
         private static final String codePrefix = "CON";
         private static final String messagePrefix = "Concept Error";
@@ -88,33 +72,17 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
                 new Query(1, "The variable '%s' does not exist.");
         public static final Query NO_EXPLANATION =
                 new Query(2, "No explanation was found.");
-        public static final Query UNRECOGNISED_QUERY_OBJECT =
+        public static final Query BAD_QUERY_OBJECT =
                 new Query(3, "The query object '%s' was not recognised.");
+        public static final Query BAD_ANSWER_TYPE =
+                new Query(4, "The answer type '%s' was not recognised.");
+        public static final Query MISSING_ANSWER =
+                new Query(5, "The required field 'answer' of type '%s' was not set.");
 
         private static final String codePrefix = "QRY";
         private static final String messagePrefix = "Query Error";
 
         Query(int number, String message) {
-            super(codePrefix, number, messagePrefix, message);
-        }
-    }
-
-    public static class Protocol extends ErrorMessage {
-        public static final Protocol BAD_VALUE_TYPE =
-                new Protocol(1, "The value type '%s' was not recognised.");
-        public static final Protocol BAD_ANSWER_TYPE =
-                new Protocol(2, "The answer type '%s' was not recognised.");
-        public static final Protocol BAD_ENCODING =
-                new Protocol(3, "The encoding '%s' was not recognised.");
-        public static final Protocol MISSING_RESPONSE =
-                new Protocol(4, "The required field 'res' of type '%s' was not set.");
-        public static final Protocol MISSING_ANSWER =
-                new Protocol(5, "The required field 'answer' of type '%s' was not set.");
-
-        private static final String codePrefix = "PRO";
-        private static final String messagePrefix = "Protocol Error";
-
-        Protocol(int number, String message) {
             super(codePrefix, number, messagePrefix, message);
         }
     }

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -100,10 +100,16 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
     }
 
     public static class Protocol extends ErrorMessage {
-        public static final Protocol UNRECOGNISED_FIELD =
-                new Protocol(1, "The %s '%s' was not recognised.");
-        public static final Protocol REQUIRED_FIELD_NOT_SET =
-                new Protocol(2, "The required field '%s' was not set.");
+        public static final Protocol BAD_VALUE_TYPE =
+                new Protocol(1, "The value type '%s' was not recognised.");
+        public static final Protocol BAD_ANSWER_TYPE =
+                new Protocol(2, "The answer type '%s' was not recognised.");
+        public static final Protocol BAD_ENCODING =
+                new Protocol(3, "The encoding '%s' was not recognised.");
+        public static final Protocol MISSING_RESPONSE =
+                new Protocol(4, "The required field 'res' of type '%s' was not set.");
+        public static final Protocol MISSING_ANSWER =
+                new Protocol(5, "The required field 'answer' of type '%s' was not set.");
 
         private static final String codePrefix = "PRO";
         private static final String messagePrefix = "Protocol Error";

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -104,8 +104,6 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
                 new Protocol(1, "The %s '%s' was not recognised.");
         public static final Protocol REQUIRED_FIELD_NOT_SET =
                 new Protocol(2, "The required field '%s' was not set.");
-        public static final Protocol ILLEGAL_COMBINATION_OF_FIELDS =
-                new Protocol(3, "'%s' cannot be [%s] while '%s' is [%s].");
 
         private static final String codePrefix = "PRO";
         private static final String messagePrefix = "Protocol Error";

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -28,9 +28,6 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
     public static class ClientInternal extends ErrorMessage {
         public static final ClientInternal UNRECOGNISED_VALUE =
                 new ClientInternal(1, "Unrecognised schema value!");
-        // TODO: variable error messages like this (below) is not good as the error code no longer uniquely identifies the problem for users
-        public static final ClientInternal MISSING_ARGUMENT =
-                new ClientInternal(2, "'%s' can not be null or empty.");
 
         private static final String codePrefix = "CIN";
         private static final String messagePrefix = "Invalid Internal State (Client)";
@@ -56,11 +53,27 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
         }
     }
 
+    public static class DatabaseManager extends ErrorMessage {
+        public static final DatabaseManager NULL_OR_EMPTY_DB_NAME =
+                new DatabaseManager(1, "Database name cannot be null or empty.");
+
+        private static final String codePrefix = "CDB";
+        private static final String messagePrefix = "Invalid Database Operations (Client)";
+
+        DatabaseManager(int number, String message) {
+            super(codePrefix, number, messagePrefix, message);
+        }
+    }
+
     public static class Concept extends ErrorMessage {
         public static final Concept UNRECOGNISED_CONCEPT =
                 new Concept(1, "The %s '%s' was not recognised.");
         public static final Concept INVALID_CONCEPT_CASTING =
                 new Concept(2, "Invalid concept conversion from '%s' to '%s'.");
+        public static final Concept NULL_TRANSACTION =
+                new Concept(3, "Transaction can not be null.");
+        public static final Concept NULL_OR_EMPTY_IID =
+                new Concept(4, "IID cannot be null or empty.");
 
         private static final String codePrefix = "CON";
         private static final String messagePrefix = "Concept Error";

--- a/common/exception/GraknClientException.java
+++ b/common/exception/GraknClientException.java
@@ -23,25 +23,25 @@ import io.grpc.StatusRuntimeException;
 
 import javax.annotation.Nullable;
 
-public class GraknException extends RuntimeException {
+public class GraknClientException extends RuntimeException {
 
     private String statusCode;
 
-    public GraknException(String error) {
+    public GraknClientException(final String error) {
         super(error);
     }
 
-    public GraknException(ErrorMessage error) {
+    public GraknClientException(final ErrorMessage error) {
         super(error.toString());
         assert !getMessage().contains("%s");
     }
 
-    public GraknException(StatusRuntimeException statusRuntimeException) {
+    public GraknClientException(final StatusRuntimeException statusRuntimeException) {
         super(statusRuntimeException.getMessage(), statusRuntimeException);
         this.statusCode = statusRuntimeException.getStatus().getCode().name();
     }
 
-    public GraknException(Exception e) {
+    public GraknClientException(final Exception e) {
         super(e);
     }
 

--- a/concept/Concept.java
+++ b/concept/Concept.java
@@ -20,7 +20,7 @@
 package grakn.client.concept;
 
 import grakn.client.Grakn;
-import grakn.client.common.exception.GraknException;
+import grakn.client.common.exception.GraknClientException;
 import grakn.client.concept.thing.Thing;
 import grakn.client.concept.thing.impl.ThingImpl;
 import grakn.client.concept.type.Rule;
@@ -48,17 +48,17 @@ public interface Concept {
 
         @Override
         default Type.Local asType() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, Type.class.getSimpleName()));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, Type.class.getSimpleName()));
         }
 
         @Override
         default Thing.Local asThing() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, Thing.class.getSimpleName()));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, Thing.class.getSimpleName()));
         }
 
         @Override
         default Rule.Local asRule() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, Rule.class.getSimpleName()));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, Rule.class.getSimpleName()));
         }
     }
 
@@ -78,17 +78,17 @@ public interface Concept {
 
         @Override
         default Type.Remote asType() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, Type.class.getSimpleName()));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, Type.class.getSimpleName()));
         }
 
         @Override
         default Thing.Remote asThing() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, Thing.class.getSimpleName()));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, Thing.class.getSimpleName()));
         }
 
         @Override
         default Rule.Remote asRule() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, Rule.class.getSimpleName()));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, Rule.class.getSimpleName()));
         }
 
         @Override

--- a/concept/Concepts.java
+++ b/concept/Concepts.java
@@ -19,7 +19,7 @@
 
 package grakn.client.concept;
 
-import grakn.client.common.exception.GraknException;
+import grakn.client.common.exception.GraknClientException;
 import grakn.client.concept.thing.Thing;
 import grakn.client.concept.thing.impl.ThingImpl;
 import grakn.client.concept.type.AttributeType;
@@ -127,7 +127,7 @@ public final class Concepts {
     }
 
     public Rule.Local putRule(final String label, final Pattern when, final Pattern then) {
-        throw new GraknException(new UnsupportedOperationException());
+        throw new GraknClientException(new UnsupportedOperationException());
         /*final TransactionProto.Transaction.Req req = TransactionProto.Transaction.Req.newBuilder()
                 .putAllMetadata(tracingData())
                 .setPutRuleReq(TransactionProto.Transaction.PutRule.Req.newBuilder()

--- a/concept/Concepts.java
+++ b/concept/Concepts.java
@@ -76,14 +76,14 @@ public final class Concepts {
         return getType(GraqlToken.Type.RULE.toString()).asRule();
     }
 
-    public EntityType.Remote putEntityType(final String label) {
+    public EntityType.Local putEntityType(final String label) {
         final TransactionProto.Transaction.Req req = TransactionProto.Transaction.Req.newBuilder()
                 .putAllMetadata(tracingData())
                 .setPutEntityTypeReq(TransactionProto.Transaction.PutEntityType.Req.newBuilder()
                                              .setLabel(label)).build();
 
         final TransactionProto.Transaction.Res res = transaction.transceiver().sendAndReceiveOrThrow(req);
-        return TypeImpl.Remote.of(transaction, res.getPutEntityTypeRes().getEntityType()).asEntityType();
+        return TypeImpl.Local.of(res.getPutEntityTypeRes().getEntityType()).asEntityType();
     }
 
     @Nullable
@@ -93,13 +93,13 @@ public final class Concepts {
         else return null;
     }
 
-    public RelationType.Remote putRelationType(final String label) {
+    public RelationType.Local putRelationType(final String label) {
         final TransactionProto.Transaction.Req req = TransactionProto.Transaction.Req.newBuilder()
                 .putAllMetadata(tracingData())
                 .setPutRelationTypeReq(TransactionProto.Transaction.PutRelationType.Req.newBuilder()
                                                .setLabel(label)).build();
         final TransactionProto.Transaction.Res res = transaction.transceiver().sendAndReceiveOrThrow(req);
-        return TypeImpl.Remote.of(transaction, res.getPutRelationTypeRes().getRelationType()).asRelationType();
+        return TypeImpl.Local.of(res.getPutRelationTypeRes().getRelationType()).asRelationType();
     }
 
     @Nullable
@@ -126,7 +126,7 @@ public final class Concepts {
         else return null;
     }
 
-    public Rule.Remote putRule(final String label, final Pattern when, final Pattern then) {
+    public Rule.Local putRule(final String label, final Pattern when, final Pattern then) {
         throw new GraknException(new UnsupportedOperationException());
         /*final TransactionProto.Transaction.Req req = TransactionProto.Transaction.Req.newBuilder()
                 .putAllMetadata(tracingData())

--- a/concept/answer/Answer.java
+++ b/concept/answer/Answer.java
@@ -25,6 +25,7 @@ import grakn.protocol.AnswerProto;
 
 import static grakn.client.common.exception.ErrorMessage.Protocol.REQUIRED_FIELD_NOT_SET;
 import static grakn.client.common.exception.ErrorMessage.Protocol.UNRECOGNISED_FIELD;
+import static grakn.common.util.Objects.className;
 
 public interface Answer {
 
@@ -47,9 +48,9 @@ public interface Answer {
             case VOID:
                 return Void.of(res.getVoid());
             case ANSWER_NOT_SET:
-                throw new GraknException(REQUIRED_FIELD_NOT_SET.message(AnswerProto.Answer.AnswerCase.class.getCanonicalName()));
+                throw new GraknException(REQUIRED_FIELD_NOT_SET.message(className(AnswerProto.Answer.AnswerCase.class)));
             default:
-                throw new GraknException(UNRECOGNISED_FIELD.message(AnswerProto.Answer.AnswerCase.class.getCanonicalName(), res.getAnswerCase()));
+                throw new GraknException(UNRECOGNISED_FIELD.message(className(AnswerProto.Answer.AnswerCase.class), res.getAnswerCase()));
         }
     }
 }

--- a/concept/answer/Answer.java
+++ b/concept/answer/Answer.java
@@ -23,8 +23,8 @@ import grakn.client.Grakn.Transaction;
 import grakn.client.common.exception.GraknException;
 import grakn.protocol.AnswerProto;
 
-import static grakn.client.common.exception.ErrorMessage.Protocol.REQUIRED_FIELD_NOT_SET;
-import static grakn.client.common.exception.ErrorMessage.Protocol.UNRECOGNISED_FIELD;
+import static grakn.client.common.exception.ErrorMessage.Protocol.BAD_ANSWER_TYPE;
+import static grakn.client.common.exception.ErrorMessage.Protocol.MISSING_ANSWER;
 import static grakn.common.util.Objects.className;
 
 public interface Answer {
@@ -48,9 +48,9 @@ public interface Answer {
             case VOID:
                 return Void.of(res.getVoid());
             case ANSWER_NOT_SET:
-                throw new GraknException(REQUIRED_FIELD_NOT_SET.message(className(AnswerProto.Answer.AnswerCase.class)));
+                throw new GraknException(MISSING_ANSWER.message(className(AnswerProto.Answer.AnswerCase.class)));
             default:
-                throw new GraknException(UNRECOGNISED_FIELD.message(className(AnswerProto.Answer.AnswerCase.class), res.getAnswerCase()));
+                throw new GraknException(BAD_ANSWER_TYPE.message(res.getAnswerCase()));
         }
     }
 }

--- a/concept/answer/Answer.java
+++ b/concept/answer/Answer.java
@@ -20,11 +20,11 @@
 package grakn.client.concept.answer;
 
 import grakn.client.Grakn.Transaction;
-import grakn.client.common.exception.GraknException;
+import grakn.client.common.exception.GraknClientException;
 import grakn.protocol.AnswerProto;
 
-import static grakn.client.common.exception.ErrorMessage.Protocol.BAD_ANSWER_TYPE;
-import static grakn.client.common.exception.ErrorMessage.Protocol.MISSING_ANSWER;
+import static grakn.client.common.exception.ErrorMessage.Query.BAD_ANSWER_TYPE;
+import static grakn.client.common.exception.ErrorMessage.Query.MISSING_ANSWER;
 import static grakn.common.util.Objects.className;
 
 public interface Answer {
@@ -48,9 +48,9 @@ public interface Answer {
             case VOID:
                 return Void.of(res.getVoid());
             case ANSWER_NOT_SET:
-                throw new GraknException(MISSING_ANSWER.message(className(AnswerProto.Answer.AnswerCase.class)));
+                throw new GraknClientException(MISSING_ANSWER.message(className(AnswerProto.Answer.AnswerCase.class)));
             default:
-                throw new GraknException(BAD_ANSWER_TYPE.message(res.getAnswerCase()));
+                throw new GraknClientException(BAD_ANSWER_TYPE.message(res.getAnswerCase()));
         }
     }
 }

--- a/concept/answer/AnswerProtoReader.java
+++ b/concept/answer/AnswerProtoReader.java
@@ -20,7 +20,7 @@
 package grakn.client.concept.answer;
 
 import com.google.protobuf.ByteString;
-import grakn.client.common.exception.GraknException;
+import grakn.client.common.exception.GraknClientException;
 import grakn.protocol.AnswerProto;
 
 import java.text.NumberFormat;
@@ -38,7 +38,7 @@ abstract class AnswerProtoReader {
         try {
             return NumberFormat.getInstance().parse(res.getValue());
         } catch (ParseException e) {
-            throw new GraknException(e);
+            throw new GraknClientException(e);
         }
     }
 }

--- a/concept/answer/ConceptMap.java
+++ b/concept/answer/ConceptMap.java
@@ -20,7 +20,7 @@
 package grakn.client.concept.answer;
 
 import grakn.client.Grakn.Transaction;
-import grakn.client.common.exception.GraknException;
+import grakn.client.common.exception.GraknClientException;
 import grakn.client.concept.Concept;
 import grakn.client.concept.thing.impl.ThingImpl;
 import grakn.client.concept.type.impl.TypeImpl;
@@ -86,7 +86,7 @@ public class ConceptMap implements Answer {
         if (hasExplanation) {
             return tx.getExplanation(this);
         } else {
-            throw new GraknException(NO_EXPLANATION);
+            throw new GraknClientException(NO_EXPLANATION);
         }
     }
 
@@ -109,7 +109,7 @@ public class ConceptMap implements Answer {
 
     public Concept get(String variable) {
         Concept concept = map.get(variable);
-        if (concept == null) throw new GraknException(VARIABLE_DOES_NOT_EXIST.message(variable));
+        if (concept == null) throw new GraknClientException(VARIABLE_DOES_NOT_EXIST.message(variable));
         return concept;
     }
 

--- a/concept/proto/ConceptProtoBuilder.java
+++ b/concept/proto/ConceptProtoBuilder.java
@@ -59,14 +59,14 @@ public abstract class ConceptProtoBuilder {
     public static ConceptProto.Thing thing(Thing thing) {
         return ConceptProto.Thing.newBuilder()
                 .setIid(iid(thing.getIID()))
-                .setSchema(schema(thing))
+                .setEncoding(encoding(thing))
                 .build();
     }
 
     public static ConceptProto.Type type(Type type) {
         final ConceptProto.Type.Builder builder = ConceptProto.Type.newBuilder()
                 .setLabel(type.getLabel())
-                .setSchema(schema(type));
+                .setEncoding(encoding(type));
 
         if (type instanceof RoleType) {
             builder.setScope(type.asRoleType().getScope());
@@ -120,33 +120,33 @@ public abstract class ConceptProtoBuilder {
         return ByteString.copyFrom(hexStringToBytes(iid));
     }
 
-    private static ConceptProto.Thing.SCHEMA schema(final Thing thing) {
+    private static ConceptProto.Thing.ENCODING encoding(final Thing thing) {
         if (thing instanceof Entity) {
-            return ConceptProto.Thing.SCHEMA.ENTITY;
+            return ConceptProto.Thing.ENCODING.ENTITY;
         } else if (thing instanceof Relation) {
-            return ConceptProto.Thing.SCHEMA.RELATION;
+            return ConceptProto.Thing.ENCODING.RELATION;
         } else if (thing instanceof Attribute) {
-            return ConceptProto.Thing.SCHEMA.ATTRIBUTE;
+            return ConceptProto.Thing.ENCODING.ATTRIBUTE;
         } else {
-            return ConceptProto.Thing.SCHEMA.UNRECOGNIZED;
+            return ConceptProto.Thing.ENCODING.UNRECOGNIZED;
         }
     }
 
-    private static ConceptProto.Type.SCHEMA schema(final Type type) {
+    private static ConceptProto.Type.ENCODING encoding(final Type type) {
         if (type instanceof EntityType) {
-            return ConceptProto.Type.SCHEMA.ENTITY_TYPE;
+            return ConceptProto.Type.ENCODING.ENTITY_TYPE;
         } else if (type instanceof RelationType) {
-            return ConceptProto.Type.SCHEMA.RELATION_TYPE;
+            return ConceptProto.Type.ENCODING.RELATION_TYPE;
         } else if (type instanceof AttributeType) {
-            return ConceptProto.Type.SCHEMA.ATTRIBUTE_TYPE;
+            return ConceptProto.Type.ENCODING.ATTRIBUTE_TYPE;
         } else if (type instanceof RoleType) {
-            return ConceptProto.Type.SCHEMA.ROLE_TYPE;
+            return ConceptProto.Type.ENCODING.ROLE_TYPE;
         } else if (type instanceof Rule) {
-            return ConceptProto.Type.SCHEMA.RULE;
+            return ConceptProto.Type.ENCODING.RULE;
         } else if (type instanceof ThingType) {
-            return ConceptProto.Type.SCHEMA.THING_TYPE;
+            return ConceptProto.Type.ENCODING.THING_TYPE;
         } else {
-            return ConceptProto.Type.SCHEMA.UNRECOGNIZED;
+            return ConceptProto.Type.ENCODING.UNRECOGNIZED;
         }
     }
 }

--- a/concept/proto/ConceptProtoBuilder.java
+++ b/concept/proto/ConceptProtoBuilder.java
@@ -20,7 +20,7 @@
 package grakn.client.concept.proto;
 
 import com.google.protobuf.ByteString;
-import grakn.client.common.exception.GraknException;
+import grakn.client.common.exception.GraknClientException;
 import grakn.client.concept.Concept;
 import grakn.client.concept.thing.Attribute;
 import grakn.client.concept.thing.Entity;
@@ -40,7 +40,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Collection;
 
-import static grakn.client.common.exception.ErrorMessage.Concept.UNRECOGNISED_CONCEPT;
+import static grakn.client.common.exception.ErrorMessage.Concept.BAD_ATTRIBUTE_VALUE;
 import static grakn.common.collection.Bytes.hexStringToBytes;
 import static java.util.stream.Collectors.toList;
 
@@ -92,7 +92,7 @@ public abstract class ConceptProtoBuilder {
         } else if (value instanceof LocalDateTime) {
             builder.setDatetime(((LocalDateTime) value).atZone(ZoneId.of("Z")).toInstant().toEpochMilli());
         } else {
-            throw new GraknException(UNRECOGNISED_CONCEPT.message("attribute value", value));
+            throw new GraknClientException(BAD_ATTRIBUTE_VALUE.message(value));
         }
         return builder.build();
     }

--- a/concept/thing/Attribute.java
+++ b/concept/thing/Attribute.java
@@ -28,6 +28,7 @@ import java.time.LocalDateTime;
 import java.util.stream.Stream;
 
 import static grakn.client.common.exception.ErrorMessage.Concept.INVALID_CONCEPT_CASTING;
+import static grakn.common.util.Objects.className;
 
 public interface Attribute<VALUE> extends Thing {
 
@@ -55,27 +56,27 @@ public interface Attribute<VALUE> extends Thing {
 
         @Override
         default Attribute.Boolean.Local asBoolean() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, Attribute.Boolean.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.Boolean.class)));
         }
 
         @Override
         default Attribute.Long.Local asLong() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, Attribute.Long.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.Long.class)));
         }
 
         @Override
         default Attribute.Double.Local asDouble() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, Attribute.Double.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.Double.class)));
         }
 
         @Override
         default Attribute.String.Local asString() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, Attribute.String.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.String.class)));
         }
 
         @Override
         default Attribute.DateTime.Local asDateTime() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, Attribute.DateTime.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.DateTime.class)));
         }
     }
 
@@ -95,27 +96,27 @@ public interface Attribute<VALUE> extends Thing {
 
         @Override
         default Attribute.Boolean.Remote asBoolean() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, Attribute.Boolean.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.Boolean.class)));
         }
 
         @Override
         default Attribute.Long.Remote asLong() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, Attribute.Long.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.Long.class)));
         }
 
         @Override
         default Attribute.Double.Remote asDouble() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, Attribute.Double.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.Double.class)));
         }
 
         @Override
         default Attribute.String.Remote asString() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, Attribute.String.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.String.class)));
         }
 
         @Override
         default Attribute.DateTime.Remote asDateTime() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, Attribute.DateTime.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.DateTime.class)));
         }
     }
 

--- a/concept/thing/Attribute.java
+++ b/concept/thing/Attribute.java
@@ -20,7 +20,7 @@
 package grakn.client.concept.thing;
 
 import grakn.client.Grakn;
-import grakn.client.common.exception.GraknException;
+import grakn.client.common.exception.GraknClientException;
 import grakn.client.concept.type.AttributeType;
 import grakn.client.concept.type.ThingType;
 
@@ -56,27 +56,27 @@ public interface Attribute<VALUE> extends Thing {
 
         @Override
         default Attribute.Boolean.Local asBoolean() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.Boolean.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.Boolean.class)));
         }
 
         @Override
         default Attribute.Long.Local asLong() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.Long.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.Long.class)));
         }
 
         @Override
         default Attribute.Double.Local asDouble() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.Double.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.Double.class)));
         }
 
         @Override
         default Attribute.String.Local asString() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.String.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.String.class)));
         }
 
         @Override
         default Attribute.DateTime.Local asDateTime() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.DateTime.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.DateTime.class)));
         }
     }
 
@@ -96,27 +96,27 @@ public interface Attribute<VALUE> extends Thing {
 
         @Override
         default Attribute.Boolean.Remote asBoolean() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.Boolean.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.Boolean.class)));
         }
 
         @Override
         default Attribute.Long.Remote asLong() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.Long.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.Long.class)));
         }
 
         @Override
         default Attribute.Double.Remote asDouble() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.Double.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.Double.class)));
         }
 
         @Override
         default Attribute.String.Remote asString() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.String.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.String.class)));
         }
 
         @Override
         default Attribute.DateTime.Remote asDateTime() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.DateTime.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(Attribute.DateTime.class)));
         }
     }
 

--- a/concept/thing/Thing.java
+++ b/concept/thing/Thing.java
@@ -20,7 +20,7 @@
 package grakn.client.concept.thing;
 
 import grakn.client.Grakn;
-import grakn.client.common.exception.GraknException;
+import grakn.client.common.exception.GraknClientException;
 import grakn.client.concept.Concept;
 import grakn.client.concept.type.AttributeType;
 import grakn.client.concept.type.RoleType;
@@ -52,17 +52,17 @@ public interface Thing extends Concept {
 
         @Override
         default Entity.Local asEntity() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, Entity.class.getSimpleName()));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, Entity.class.getSimpleName()));
         }
 
         @Override
         default Attribute.Local<?> asAttribute() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, Attribute.class.getSimpleName()));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, Attribute.class.getSimpleName()));
         }
 
         @Override
         default Relation.Local asRelation() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, Relation.class.getSimpleName()));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, Relation.class.getSimpleName()));
         }
     }
 
@@ -101,17 +101,17 @@ public interface Thing extends Concept {
 
         @Override
         default Entity.Remote asEntity() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, Entity.class.getSimpleName()));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, Entity.class.getSimpleName()));
         }
 
         @Override
         default Relation.Remote asRelation() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, Relation.class.getSimpleName()));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, Relation.class.getSimpleName()));
         }
 
         @Override
         default Attribute.Remote<?> asAttribute() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, Attribute.class.getSimpleName()));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, Attribute.class.getSimpleName()));
         }
     }
 }

--- a/concept/thing/Thing.java
+++ b/concept/thing/Thing.java
@@ -92,7 +92,7 @@ public interface Thing extends Concept {
 
         Stream<? extends RoleType.Local> getPlays();
 
-        Stream<? extends Relation> getRelations(RoleType... roleTypes);
+        Stream<? extends Relation.Local> getRelations(RoleType... roleTypes);
 
         @Override
         default Thing.Remote asThing() {

--- a/concept/thing/impl/AttributeImpl.java
+++ b/concept/thing/impl/AttributeImpl.java
@@ -37,6 +37,7 @@ import java.util.stream.Stream;
 import static grakn.client.common.exception.ErrorMessage.Protocol.UNRECOGNISED_FIELD;
 import static grakn.client.concept.proto.ConceptProtoBuilder.type;
 import static grakn.common.collection.Bytes.bytesToHexString;
+import static grakn.common.util.Objects.className;
 
 public abstract class AttributeImpl {
 
@@ -46,22 +47,22 @@ public abstract class AttributeImpl {
             super(iid);
         }
 
-        public static AttributeImpl.Local<?> of(ConceptProto.Thing thing) {
-            switch (thing.getValueType()) {
+        public static AttributeImpl.Local<?> of(ConceptProto.Thing thingProto) {
+            switch (thingProto.getValueType()) {
                 case BOOLEAN:
-                    return AttributeImpl.Boolean.Local.of(thing);
+                    return AttributeImpl.Boolean.Local.of(thingProto);
                 case LONG:
-                    return AttributeImpl.Long.Local.of(thing);
+                    return AttributeImpl.Long.Local.of(thingProto);
                 case DOUBLE:
-                    return AttributeImpl.Double.Local.of(thing);
+                    return AttributeImpl.Double.Local.of(thingProto);
                 case STRING:
-                    return AttributeImpl.String.Local.of(thing);
+                    return AttributeImpl.String.Local.of(thingProto);
                 case DATETIME:
-                    return AttributeImpl.DateTime.Local.of(thing);
+                    return AttributeImpl.DateTime.Local.of(thingProto);
                 case UNRECOGNIZED:
                 default:
                     throw new GraknException(UNRECOGNISED_FIELD.message(
-                            ConceptProto.AttributeType.VALUE_TYPE.class.getSimpleName(), thing.getValueType())
+                            className(ConceptProto.AttributeType.VALUE_TYPE.class), thingProto.getValueType())
                     );
             }
         }
@@ -75,7 +76,7 @@ public abstract class AttributeImpl {
             super(transaction, iid);
         }
 
-        public static AttributeImpl.Remote of(Grakn.Transaction transaction, ConceptProto.Thing thingProto) {
+        public static AttributeImpl.Remote<?> of(final Grakn.Transaction transaction, final ConceptProto.Thing thingProto) {
             switch (thingProto.getValueType()) {
                 case BOOLEAN:
                     return AttributeImpl.Boolean.Remote.of(transaction, thingProto);
@@ -127,7 +128,7 @@ public abstract class AttributeImpl {
 
             private final java.lang.Boolean value;
 
-            Local(final java.lang.String iid, boolean value) {
+            Local(final java.lang.String iid, final boolean value) {
                 super(iid);
                 this.value = value;
             }
@@ -151,31 +152,31 @@ public abstract class AttributeImpl {
 
             @Override
             public AttributeImpl.Boolean.Remote asRemote(Grakn.Transaction transaction) {
-                return new AttributeImpl.Boolean.Remote(transaction, getIID());
+                return new AttributeImpl.Boolean.Remote(transaction, getIID(), value);
             }
         }
 
         public static class Remote extends AttributeImpl.Remote<java.lang.Boolean> implements Attribute.Boolean.Remote {
 
-            Remote(final Grakn.Transaction transaction, final java.lang.String iid) {
+            private final java.lang.Boolean value;
+
+            Remote(final Grakn.Transaction transaction, final java.lang.String iid, final java.lang.Boolean value) {
                 super(transaction, iid);
+                this.value = value;
             }
 
             public static AttributeImpl.Boolean.Remote of(final Grakn.Transaction transaction, final ConceptProto.Thing thingProto) {
-                return new AttributeImpl.Boolean.Remote(transaction, bytesToHexString(thingProto.getIid().toByteArray()));
+                return new AttributeImpl.Boolean.Remote(transaction, bytesToHexString(thingProto.getIid().toByteArray()), thingProto.getValue().getBoolean());
             }
 
             @Override
             public Attribute.Boolean.Remote asRemote(Grakn.Transaction transaction) {
-                return new AttributeImpl.Boolean.Remote(transaction, iid);
+                return new AttributeImpl.Boolean.Remote(transaction, iid, value);
             }
 
             @Override
             public final java.lang.Boolean getValue() {
-                final ThingMethod.Req method = ThingMethod.Req.newBuilder()
-                        .setAttributeGetValueReq(ConceptProto.Attribute.GetValue.Req.getDefaultInstance()).build();
-
-                return execute(method).getAttributeGetValueRes().getValue().getBoolean();
+                return value;
             }
 
             @Override
@@ -191,7 +192,7 @@ public abstract class AttributeImpl {
 
             private final long value;
 
-            Local(final java.lang.String iid, long value) {
+            Local(final java.lang.String iid, final long value) {
                 super(iid);
                 this.value = value;
             }
@@ -205,7 +206,7 @@ public abstract class AttributeImpl {
 
             @Override
             public AttributeImpl.Long.Remote asRemote(Grakn.Transaction transaction) {
-                return new AttributeImpl.Long.Remote(transaction, getIID());
+                return new AttributeImpl.Long.Remote(transaction, getIID(), value);
             }
 
             @Override
@@ -221,25 +222,25 @@ public abstract class AttributeImpl {
 
         public static class Remote extends AttributeImpl.Remote<java.lang.Long> implements Attribute.Long.Remote {
 
-            Remote(final Grakn.Transaction transaction, final java.lang.String iid) {
+            private final long value;
+
+            Remote(final Grakn.Transaction transaction, final java.lang.String iid, final long value) {
                 super(transaction, iid);
+                this.value = value;
             }
 
             public static AttributeImpl.Long.Remote of(final Grakn.Transaction transaction, final ConceptProto.Thing thingProto) {
-                return new AttributeImpl.Long.Remote(transaction, bytesToHexString(thingProto.getIid().toByteArray()));
+                return new AttributeImpl.Long.Remote(transaction, bytesToHexString(thingProto.getIid().toByteArray()), thingProto.getValue().getLong());
             }
 
             @Override
             public Attribute.Long.Remote asRemote(Grakn.Transaction transaction) {
-                return new AttributeImpl.Long.Remote(transaction, iid);
+                return new AttributeImpl.Long.Remote(transaction, iid, value);
             }
 
             @Override
             public final java.lang.Long getValue() {
-                final ThingMethod.Req method = ThingMethod.Req.newBuilder()
-                        .setAttributeGetValueReq(ConceptProto.Attribute.GetValue.Req.getDefaultInstance()).build();
-
-                return execute(method).getAttributeGetValueRes().getValue().getLong();
+                return value;
             }
 
             @Override
@@ -255,7 +256,7 @@ public abstract class AttributeImpl {
 
             private final double value;
 
-            Local(final java.lang.String iid, double value) {
+            Local(final java.lang.String iid, final double value) {
                 super(iid);
                 this.value = value;
             }
@@ -269,7 +270,7 @@ public abstract class AttributeImpl {
 
             @Override
             public AttributeImpl.Double.Remote asRemote(Grakn.Transaction transaction) {
-                return new AttributeImpl.Double.Remote(transaction, getIID());
+                return new AttributeImpl.Double.Remote(transaction, getIID(), value);
             }
 
             @Override
@@ -285,25 +286,25 @@ public abstract class AttributeImpl {
 
         public static class Remote extends AttributeImpl.Remote<java.lang.Double> implements Attribute.Double.Remote {
 
-            Remote(final Grakn.Transaction transaction, final java.lang.String iid) {
+            private final double value;
+
+            Remote(final Grakn.Transaction transaction, final java.lang.String iid, final double value) {
                 super(transaction, iid);
+                this.value = value;
             }
 
             public static AttributeImpl.Double.Remote of(final Grakn.Transaction transaction, final ConceptProto.Thing thingProto) {
-                return new AttributeImpl.Double.Remote(transaction, bytesToHexString(thingProto.getIid().toByteArray()));
+                return new AttributeImpl.Double.Remote(transaction, bytesToHexString(thingProto.getIid().toByteArray()), thingProto.getValue().getDouble());
             }
 
             @Override
             public Attribute.Double.Remote asRemote(Grakn.Transaction transaction) {
-                return new AttributeImpl.Double.Remote(transaction, iid);
+                return new AttributeImpl.Double.Remote(transaction, iid, value);
             }
 
             @Override
             public final java.lang.Double getValue() {
-                final ThingMethod.Req method = ThingMethod.Req.newBuilder()
-                        .setAttributeGetValueReq(ConceptProto.Attribute.GetValue.Req.getDefaultInstance()).build();
-
-                return execute(method).getAttributeGetValueRes().getValue().getDouble();
+                return value;
             }
 
             @Override
@@ -319,7 +320,7 @@ public abstract class AttributeImpl {
 
             private final java.lang.String value;
 
-            Local(final java.lang.String iid, java.lang.String value) {
+            Local(final java.lang.String iid, final java.lang.String value) {
                 super(iid);
                 this.value = value;
             }
@@ -333,7 +334,7 @@ public abstract class AttributeImpl {
 
             @Override
             public AttributeImpl.String.Remote asRemote(Grakn.Transaction transaction) {
-                return new AttributeImpl.String.Remote(transaction, getIID());
+                return new AttributeImpl.String.Remote(transaction, getIID(), value);
             }
 
             @Override
@@ -349,25 +350,25 @@ public abstract class AttributeImpl {
 
         public static class Remote extends AttributeImpl.Remote<java.lang.String> implements Attribute.String.Remote {
 
-            Remote(final Grakn.Transaction transaction, final java.lang.String iid) {
+            private final java.lang.String value;
+
+            Remote(final Grakn.Transaction transaction, final java.lang.String iid, final java.lang.String value) {
                 super(transaction, iid);
+                this.value = value;
             }
 
             public static AttributeImpl.String.Remote of(final Grakn.Transaction transaction, final ConceptProto.Thing thingProto) {
-                return new AttributeImpl.String.Remote(transaction, bytesToHexString(thingProto.getIid().toByteArray()));
+                return new AttributeImpl.String.Remote(transaction, bytesToHexString(thingProto.getIid().toByteArray()), thingProto.getValue().getString());
             }
 
             @Override
             public final java.lang.String getValue() {
-                final ThingMethod.Req method = ThingMethod.Req.newBuilder()
-                        .setAttributeGetValueReq(ConceptProto.Attribute.GetValue.Req.getDefaultInstance()).build();
-
-                return execute(method).getAttributeGetValueRes().getValue().getString();
+                return value;
             }
 
             @Override
             public Attribute.String.Remote asRemote(Grakn.Transaction transaction) {
-                return new AttributeImpl.String.Remote(transaction, iid);
+                return new AttributeImpl.String.Remote(transaction, iid, value);
             }
 
             @Override
@@ -387,7 +388,7 @@ public abstract class AttributeImpl {
 
             private final LocalDateTime value;
 
-            Local(final java.lang.String iid, LocalDateTime value) {
+            Local(final java.lang.String iid, final LocalDateTime value) {
                 super(iid);
                 this.value = value;
             }
@@ -401,7 +402,7 @@ public abstract class AttributeImpl {
 
             @Override
             public AttributeImpl.DateTime.Remote asRemote(Grakn.Transaction transaction) {
-                return new AttributeImpl.DateTime.Remote(transaction, getIID());
+                return new AttributeImpl.DateTime.Remote(transaction, getIID(), value);
             }
 
             @Override
@@ -417,25 +418,25 @@ public abstract class AttributeImpl {
 
         public static class Remote extends AttributeImpl.Remote<LocalDateTime> implements Attribute.DateTime.Remote {
 
-            Remote(final Grakn.Transaction transaction, final java.lang.String iid) {
+            private final LocalDateTime value;
+
+            Remote(final Grakn.Transaction transaction, final java.lang.String iid, final LocalDateTime value) {
                 super(transaction, iid);
+                this.value = value;
             }
 
             public static AttributeImpl.DateTime.Remote of(final Grakn.Transaction transaction, final ConceptProto.Thing thingProto) {
-                return new AttributeImpl.DateTime.Remote(transaction, bytesToHexString(thingProto.getIid().toByteArray()));
+                return new AttributeImpl.DateTime.Remote(transaction, bytesToHexString(thingProto.getIid().toByteArray()), toLocalDateTime(thingProto.getValue().getDatetime()));
             }
 
             @Override
-            public Attribute.DateTime.Remote asRemote(Grakn.Transaction transaction) {
-                return new AttributeImpl.DateTime.Remote(transaction, iid);
+            public Attribute.DateTime.Remote asRemote(final Grakn.Transaction transaction) {
+                return new AttributeImpl.DateTime.Remote(transaction, iid, value);
             }
 
             @Override
             public final LocalDateTime getValue() {
-                final ThingMethod.Req method = ThingMethod.Req.newBuilder()
-                        .setAttributeGetValueReq(ConceptProto.Attribute.GetValue.Req.getDefaultInstance()).build();
-
-                return toLocalDateTime(execute(method).getAttributeGetValueRes().getValue().getDatetime());
+                return value;
             }
 
             @Override

--- a/concept/thing/impl/AttributeImpl.java
+++ b/concept/thing/impl/AttributeImpl.java
@@ -171,7 +171,7 @@ public abstract class AttributeImpl {
 
             @Override
             public Attribute.Boolean.Remote asRemote(Grakn.Transaction transaction) {
-                return new AttributeImpl.Boolean.Remote(transaction, iid, value);
+                return new AttributeImpl.Boolean.Remote(transaction, getIID(), value);
             }
 
             @Override
@@ -235,7 +235,7 @@ public abstract class AttributeImpl {
 
             @Override
             public Attribute.Long.Remote asRemote(Grakn.Transaction transaction) {
-                return new AttributeImpl.Long.Remote(transaction, iid, value);
+                return new AttributeImpl.Long.Remote(transaction, getIID(), value);
             }
 
             @Override
@@ -299,7 +299,7 @@ public abstract class AttributeImpl {
 
             @Override
             public Attribute.Double.Remote asRemote(Grakn.Transaction transaction) {
-                return new AttributeImpl.Double.Remote(transaction, iid, value);
+                return new AttributeImpl.Double.Remote(transaction, getIID(), value);
             }
 
             @Override
@@ -368,7 +368,7 @@ public abstract class AttributeImpl {
 
             @Override
             public Attribute.String.Remote asRemote(Grakn.Transaction transaction) {
-                return new AttributeImpl.String.Remote(transaction, iid, value);
+                return new AttributeImpl.String.Remote(transaction, getIID(), value);
             }
 
             @Override
@@ -431,7 +431,7 @@ public abstract class AttributeImpl {
 
             @Override
             public Attribute.DateTime.Remote asRemote(final Grakn.Transaction transaction) {
-                return new AttributeImpl.DateTime.Remote(transaction, iid, value);
+                return new AttributeImpl.DateTime.Remote(transaction, getIID(), value);
             }
 
             @Override

--- a/concept/thing/impl/AttributeImpl.java
+++ b/concept/thing/impl/AttributeImpl.java
@@ -34,10 +34,9 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.stream.Stream;
 
-import static grakn.client.common.exception.ErrorMessage.Protocol.UNRECOGNISED_FIELD;
+import static grakn.client.common.exception.ErrorMessage.Protocol.BAD_VALUE_TYPE;
 import static grakn.client.concept.proto.ConceptProtoBuilder.type;
 import static grakn.common.collection.Bytes.bytesToHexString;
-import static grakn.common.util.Objects.className;
 
 public abstract class AttributeImpl {
 
@@ -61,9 +60,7 @@ public abstract class AttributeImpl {
                     return AttributeImpl.DateTime.Local.of(thingProto);
                 case UNRECOGNIZED:
                 default:
-                    throw new GraknException(UNRECOGNISED_FIELD.message(
-                            className(ConceptProto.AttributeType.VALUE_TYPE.class), thingProto.getValueType())
-                    );
+                    throw new GraknException(BAD_VALUE_TYPE.message(thingProto.getValueType()));
             }
         }
 
@@ -90,9 +87,7 @@ public abstract class AttributeImpl {
                     return AttributeImpl.DateTime.Remote.of(transaction, thingProto);
                 case UNRECOGNIZED:
                 default:
-                    throw new GraknException(UNRECOGNISED_FIELD.message(
-                            ConceptProto.AttributeType.VALUE_TYPE.class.getSimpleName(), thingProto.getValueType())
-                    );
+                    throw new GraknException(BAD_VALUE_TYPE.message(thingProto.getValueType()));
             }
         }
 

--- a/concept/thing/impl/AttributeImpl.java
+++ b/concept/thing/impl/AttributeImpl.java
@@ -20,7 +20,7 @@
 package grakn.client.concept.thing.impl;
 
 import grakn.client.Grakn;
-import grakn.client.common.exception.GraknException;
+import grakn.client.common.exception.GraknClientException;
 import grakn.client.concept.thing.Attribute;
 import grakn.client.concept.thing.Thing;
 import grakn.client.concept.type.AttributeType;
@@ -34,7 +34,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.stream.Stream;
 
-import static grakn.client.common.exception.ErrorMessage.Protocol.BAD_VALUE_TYPE;
+import static grakn.client.common.exception.ErrorMessage.Concept.BAD_VALUE_TYPE;
 import static grakn.client.concept.proto.ConceptProtoBuilder.type;
 import static grakn.common.collection.Bytes.bytesToHexString;
 
@@ -60,7 +60,7 @@ public abstract class AttributeImpl {
                     return AttributeImpl.DateTime.Local.of(thingProto);
                 case UNRECOGNIZED:
                 default:
-                    throw new GraknException(BAD_VALUE_TYPE.message(thingProto.getValueType()));
+                    throw new GraknClientException(BAD_VALUE_TYPE.message(thingProto.getValueType()));
             }
         }
 
@@ -87,7 +87,7 @@ public abstract class AttributeImpl {
                     return AttributeImpl.DateTime.Remote.of(transaction, thingProto);
                 case UNRECOGNIZED:
                 default:
-                    throw new GraknException(BAD_VALUE_TYPE.message(thingProto.getValueType()));
+                    throw new GraknClientException(BAD_VALUE_TYPE.message(thingProto.getValueType()));
             }
         }
 

--- a/concept/thing/impl/EntityImpl.java
+++ b/concept/thing/impl/EntityImpl.java
@@ -54,7 +54,7 @@ public abstract class EntityImpl {
 
         @Override
         public Entity.Remote asRemote(Grakn.Transaction transaction) {
-            return new EntityImpl.Remote(transaction, iid);
+            return new EntityImpl.Remote(transaction, getIID());
         }
 
         @Override

--- a/concept/thing/impl/RelationImpl.java
+++ b/concept/thing/impl/RelationImpl.java
@@ -73,8 +73,8 @@ public abstract class RelationImpl {
         }
 
         @Override
-        public Relation.Remote asRemote(Grakn.Transaction transaction) {
-            return new RelationImpl.Remote(transaction, iid);
+        public Relation.Remote asRemote(final Grakn.Transaction transaction) {
+            return new RelationImpl.Remote(transaction, getIID());
         }
 
         @Override

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -45,6 +45,7 @@ import static grakn.client.common.exception.ErrorMessage.ClientInternal.MISSING_
 import static grakn.client.common.exception.ErrorMessage.Protocol.UNRECOGNISED_FIELD;
 import static grakn.client.concept.proto.ConceptProtoBuilder.thing;
 import static grakn.client.concept.proto.ConceptProtoBuilder.types;
+import static grakn.common.util.Objects.className;
 
 public abstract class ThingImpl {
 
@@ -72,7 +73,7 @@ public abstract class ThingImpl {
                 case UNRECOGNIZED:
                 default:
                     throw new GraknException(UNRECOGNISED_FIELD.message(
-                            ConceptProto.Thing.SCHEMA.class.getSimpleName(), thingProto.getSchema())
+                            className(ConceptProto.Thing.SCHEMA.class), thingProto.getSchema())
                     );
             }
         }
@@ -84,7 +85,7 @@ public abstract class ThingImpl {
 
         @Override
         public String toString() {
-            return this.getClass().getCanonicalName() + "[iid:" + iid + "]";
+            return className(this.getClass()) + "[iid:" + iid + "]";
         }
 
         @Override
@@ -127,7 +128,7 @@ public abstract class ThingImpl {
                     return AttributeImpl.Remote.of(transaction, protoThing);
                 default:
                 case UNRECOGNIZED:
-                    throw new GraknException(UNRECOGNISED_FIELD.message(ConceptProto.Thing.SCHEMA.class.getCanonicalName(), protoThing.getSchema()));
+                    throw new GraknException(UNRECOGNISED_FIELD.message(className(ConceptProto.Thing.SCHEMA.class), protoThing.getSchema()));
             }
         }
 
@@ -251,7 +252,7 @@ public abstract class ThingImpl {
 
         @Override
         public String toString() {
-            return this.getClass().getCanonicalName() + "[iid:" + iid + "]";
+            return className(this.getClass()) + "[iid:" + iid + "]";
         }
 
         @Override

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -41,7 +41,8 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static grakn.client.common.exception.ErrorMessage.ClientInternal.MISSING_ARGUMENT;
+import static grakn.client.common.exception.ErrorMessage.Concept.NULL_OR_EMPTY_IID;
+import static grakn.client.common.exception.ErrorMessage.Concept.NULL_TRANSACTION;
 import static grakn.client.common.exception.ErrorMessage.Protocol.UNRECOGNISED_FIELD;
 import static grakn.client.concept.proto.ConceptProtoBuilder.thing;
 import static grakn.client.concept.proto.ConceptProtoBuilder.types;
@@ -109,8 +110,8 @@ public abstract class ThingImpl {
         private final int hash;
 
         protected Remote(final Grakn.Transaction transaction, final String iid) {
-            if (transaction == null) throw new GraknException(MISSING_ARGUMENT.message("concepts"));
-            else if (iid == null || iid.isEmpty()) throw new GraknException(MISSING_ARGUMENT.message("iid"));
+            if (transaction == null) throw new GraknException(NULL_TRANSACTION);
+            else if (iid == null || iid.isEmpty()) throw new GraknException(NULL_OR_EMPTY_IID);
             this.transaction = transaction;
             this.iid = iid;
             this.hash = Objects.hash(this.transaction, this.iid);

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -63,7 +63,7 @@ public abstract class ThingImpl {
         }
 
         public static ThingImpl.Local of(final ConceptProto.Thing thingProto) {
-            switch (thingProto.getSchema()) {
+            switch (thingProto.getEncoding()) {
                 case ENTITY:
                     return EntityImpl.Local.of(thingProto);
                 case RELATION:
@@ -73,7 +73,7 @@ public abstract class ThingImpl {
                 case UNRECOGNIZED:
                 default:
                     throw new GraknException(UNRECOGNISED_FIELD.message(
-                            className(ConceptProto.Thing.SCHEMA.class), thingProto.getSchema())
+                            className(ConceptProto.Thing.ENCODING.class), thingProto.getEncoding())
                     );
             }
         }
@@ -119,7 +119,7 @@ public abstract class ThingImpl {
 
         public static ThingImpl.Remote of(final Grakn.Transaction transaction, final ConceptProto.Thing protoThing) {
 
-            switch (protoThing.getSchema()) {
+            switch (protoThing.getEncoding()) {
                 case ENTITY:
                     return EntityImpl.Remote.of(transaction, protoThing);
                 case RELATION:
@@ -128,7 +128,7 @@ public abstract class ThingImpl {
                     return AttributeImpl.Remote.of(transaction, protoThing);
                 default:
                 case UNRECOGNIZED:
-                    throw new GraknException(UNRECOGNISED_FIELD.message(className(ConceptProto.Thing.SCHEMA.class), protoThing.getSchema()));
+                    throw new GraknException(UNRECOGNISED_FIELD.message(className(ConceptProto.Thing.ENCODING.class), protoThing.getEncoding()));
             }
         }
 

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -200,7 +200,7 @@ public abstract class ThingImpl {
         }
 
         @Override
-        public final Stream<? extends Relation> getRelations(RoleType... roleTypes) {
+        public final Stream<? extends Relation.Local> getRelations(RoleType... roleTypes) {
             return stream(
                     ThingMethod.Iter.Req.newBuilder().setThingGetRelationsIterReq(
                             GetRelations.Iter.Req.newBuilder().addAllRoleTypes(types(Arrays.asList(roleTypes)))).build(),

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -105,7 +105,7 @@ public abstract class ThingImpl {
     public abstract static class Remote implements Thing.Remote {
 
         private final Grakn.Transaction transaction;
-        final String iid;
+        private final String iid;
         private final int hash;
 
         protected Remote(final Grakn.Transaction transaction, final String iid) {

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -53,10 +53,9 @@ public abstract class ThingImpl {
 
         private final String iid;
         // TODO: private final ThingType.Local type;
-        // We (probably) need to storae the concept Type, but we should have a better way of retrieving it.
-        // In 1.8 it was in a "pre-filled response" in ConceptProto.Concept, which was highly confusing as it was
+        // We need to store the concept Type, but we need a better way of retrieving it (currently requires a 2nd roundtrip)
+        // In 1.8 it was in a "pre-filled response" in ConceptProto.Concept, which was confusing as it was
         // not actually prefilled when using the Concept API - only when using the Query API.
-        // We should probably create a dedicated Proto class for Graql (AnswerProto or QueryProto) and keep the code clean.
 
         Local(final String iid) {
             this.iid = iid;

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -43,7 +43,7 @@ import java.util.stream.Stream;
 
 import static grakn.client.common.exception.ErrorMessage.Concept.NULL_OR_EMPTY_IID;
 import static grakn.client.common.exception.ErrorMessage.Concept.NULL_TRANSACTION;
-import static grakn.client.common.exception.ErrorMessage.Protocol.UNRECOGNISED_FIELD;
+import static grakn.client.common.exception.ErrorMessage.Protocol.BAD_ENCODING;
 import static grakn.client.concept.proto.ConceptProtoBuilder.thing;
 import static grakn.client.concept.proto.ConceptProtoBuilder.types;
 import static grakn.common.util.Objects.className;
@@ -72,9 +72,7 @@ public abstract class ThingImpl {
                     return AttributeImpl.Local.of(thingProto);
                 case UNRECOGNIZED:
                 default:
-                    throw new GraknException(UNRECOGNISED_FIELD.message(
-                            className(ConceptProto.Thing.ENCODING.class), thingProto.getEncoding())
-                    );
+                    throw new GraknException(BAD_ENCODING.message(thingProto.getEncoding()));
             }
         }
 
@@ -128,7 +126,7 @@ public abstract class ThingImpl {
                     return AttributeImpl.Remote.of(transaction, protoThing);
                 default:
                 case UNRECOGNIZED:
-                    throw new GraknException(UNRECOGNISED_FIELD.message(className(ConceptProto.Thing.ENCODING.class), protoThing.getEncoding()));
+                    throw new GraknException(BAD_ENCODING.message(protoThing.getEncoding()));
             }
         }
 

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -20,7 +20,7 @@
 package grakn.client.concept.thing.impl;
 
 import grakn.client.Grakn;
-import grakn.client.common.exception.GraknException;
+import grakn.client.common.exception.GraknClientException;
 import grakn.client.concept.thing.Attribute;
 import grakn.client.concept.thing.Relation;
 import grakn.client.concept.thing.Thing;
@@ -41,9 +41,9 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static grakn.client.common.exception.ErrorMessage.Concept.NULL_OR_EMPTY_IID;
-import static grakn.client.common.exception.ErrorMessage.Concept.NULL_TRANSACTION;
-import static grakn.client.common.exception.ErrorMessage.Protocol.BAD_ENCODING;
+import static grakn.client.common.exception.ErrorMessage.Concept.MISSING_IID;
+import static grakn.client.common.exception.ErrorMessage.Concept.MISSING_TRANSACTION;
+import static grakn.client.common.exception.ErrorMessage.Concept.BAD_ENCODING;
 import static grakn.client.concept.proto.ConceptProtoBuilder.thing;
 import static grakn.client.concept.proto.ConceptProtoBuilder.types;
 import static grakn.common.util.Objects.className;
@@ -72,7 +72,7 @@ public abstract class ThingImpl {
                     return AttributeImpl.Local.of(thingProto);
                 case UNRECOGNIZED:
                 default:
-                    throw new GraknException(BAD_ENCODING.message(thingProto.getEncoding()));
+                    throw new GraknClientException(BAD_ENCODING.message(thingProto.getEncoding()));
             }
         }
 
@@ -108,8 +108,8 @@ public abstract class ThingImpl {
         private final int hash;
 
         protected Remote(final Grakn.Transaction transaction, final String iid) {
-            if (transaction == null) throw new GraknException(NULL_TRANSACTION);
-            else if (iid == null || iid.isEmpty()) throw new GraknException(NULL_OR_EMPTY_IID);
+            if (transaction == null) throw new GraknClientException(MISSING_TRANSACTION);
+            else if (iid == null || iid.isEmpty()) throw new GraknClientException(MISSING_IID);
             this.transaction = transaction;
             this.iid = iid;
             this.hash = Objects.hash(this.transaction, this.iid);
@@ -126,7 +126,7 @@ public abstract class ThingImpl {
                     return AttributeImpl.Remote.of(transaction, protoThing);
                 default:
                 case UNRECOGNIZED:
-                    throw new GraknException(BAD_ENCODING.message(protoThing.getEncoding()));
+                    throw new GraknClientException(BAD_ENCODING.message(protoThing.getEncoding()));
             }
         }
 

--- a/concept/type/AttributeType.java
+++ b/concept/type/AttributeType.java
@@ -20,7 +20,7 @@
 package grakn.client.concept.type;
 
 import grakn.client.Grakn;
-import grakn.client.common.exception.GraknException;
+import grakn.client.common.exception.GraknClientException;
 import grakn.client.concept.thing.Attribute;
 import grakn.protocol.ConceptProto;
 
@@ -28,8 +28,7 @@ import javax.annotation.Nullable;
 import java.time.LocalDateTime;
 import java.util.stream.Stream;
 
-import static grakn.client.common.exception.ErrorMessage.ClientInternal.UNRECOGNISED_VALUE;
-import static grakn.client.common.exception.ErrorMessage.Protocol.BAD_VALUE_TYPE;
+import static grakn.client.common.exception.ErrorMessage.Concept.BAD_VALUE_TYPE;
 
 public interface AttributeType extends ThingType {
 
@@ -79,7 +78,7 @@ public interface AttributeType extends ThingType {
                     return t;
                 }
             }
-            throw new GraknException(UNRECOGNISED_VALUE);
+            throw new GraknClientException(BAD_VALUE_TYPE);
         }
 
         public static ValueType of(ConceptProto.AttributeType.VALUE_TYPE valueType) {
@@ -96,7 +95,7 @@ public interface AttributeType extends ThingType {
                     return AttributeType.ValueType.DATETIME;
                 default:
                 case UNRECOGNIZED:
-                    throw new GraknException(BAD_VALUE_TYPE.message(valueType));
+                    throw new GraknClientException(BAD_VALUE_TYPE.message(valueType));
             }
         }
 

--- a/concept/type/AttributeType.java
+++ b/concept/type/AttributeType.java
@@ -30,6 +30,7 @@ import java.util.stream.Stream;
 
 import static grakn.client.common.exception.ErrorMessage.ClientInternal.UNRECOGNISED_VALUE;
 import static grakn.client.common.exception.ErrorMessage.Protocol.UNRECOGNISED_FIELD;
+import static grakn.common.util.Objects.className;
 
 public interface AttributeType extends ThingType {
 
@@ -96,7 +97,7 @@ public interface AttributeType extends ThingType {
                     return AttributeType.ValueType.DATETIME;
                 default:
                 case UNRECOGNIZED:
-                    throw new GraknException(UNRECOGNISED_FIELD.message(ConceptProto.AttributeType.VALUE_TYPE.class.getCanonicalName(), valueType));
+                    throw new GraknException(UNRECOGNISED_FIELD.message(className(ConceptProto.AttributeType.VALUE_TYPE.class), valueType));
             }
         }
 

--- a/concept/type/AttributeType.java
+++ b/concept/type/AttributeType.java
@@ -29,8 +29,7 @@ import java.time.LocalDateTime;
 import java.util.stream.Stream;
 
 import static grakn.client.common.exception.ErrorMessage.ClientInternal.UNRECOGNISED_VALUE;
-import static grakn.client.common.exception.ErrorMessage.Protocol.UNRECOGNISED_FIELD;
-import static grakn.common.util.Objects.className;
+import static grakn.client.common.exception.ErrorMessage.Protocol.BAD_VALUE_TYPE;
 
 public interface AttributeType extends ThingType {
 
@@ -97,7 +96,7 @@ public interface AttributeType extends ThingType {
                     return AttributeType.ValueType.DATETIME;
                 default:
                 case UNRECOGNIZED:
-                    throw new GraknException(UNRECOGNISED_FIELD.message(className(ConceptProto.AttributeType.VALUE_TYPE.class), valueType));
+                    throw new GraknException(BAD_VALUE_TYPE.message(valueType));
             }
         }
 

--- a/concept/type/Type.java
+++ b/concept/type/Type.java
@@ -20,7 +20,7 @@
 package grakn.client.concept.type;
 
 import grakn.client.Grakn;
-import grakn.client.common.exception.GraknException;
+import grakn.client.common.exception.GraknClientException;
 import grakn.client.concept.Concept;
 
 import javax.annotation.Nullable;
@@ -57,27 +57,27 @@ public interface Type extends Concept {
 
         @Override
         default ThingType.Local asThingType() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(ThingType.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(ThingType.class)));
         }
 
         @Override
         default EntityType.Local asEntityType() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(EntityType.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(EntityType.class)));
         }
 
         @Override
         default AttributeType.Local asAttributeType() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.class)));
         }
 
         @Override
         default RelationType.Local asRelationType() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(RelationType.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(RelationType.class)));
         }
 
         @Override
         default RoleType.Local asRoleType() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(RoleType.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(RoleType.class)));
         }
     }
 
@@ -101,27 +101,27 @@ public interface Type extends Concept {
 
         @Override
         default ThingType.Remote asThingType() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(ThingType.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(ThingType.class)));
         }
 
         @Override
         default EntityType.Remote asEntityType() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(EntityType.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(EntityType.class)));
         }
 
         @Override
         default RelationType.Remote asRelationType() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(RelationType.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(RelationType.class)));
         }
 
         @Override
         default AttributeType.Remote asAttributeType() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.class)));
         }
 
         @Override
         default RoleType.Remote asRoleType() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(RoleType.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(RoleType.class)));
         }
     }
 }

--- a/concept/type/Type.java
+++ b/concept/type/Type.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 import java.util.stream.Stream;
 
 import static grakn.client.common.exception.ErrorMessage.Concept.INVALID_CONCEPT_CASTING;
+import static grakn.common.util.Objects.className;
 
 public interface Type extends Concept {
 
@@ -56,27 +57,27 @@ public interface Type extends Concept {
 
         @Override
         default ThingType.Local asThingType() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, ThingType.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(ThingType.class)));
         }
 
         @Override
         default EntityType.Local asEntityType() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, EntityType.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(EntityType.class)));
         }
 
         @Override
         default AttributeType.Local asAttributeType() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, AttributeType.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.class)));
         }
 
         @Override
         default RelationType.Local asRelationType() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, RelationType.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(RelationType.class)));
         }
 
         @Override
         default RoleType.Local asRoleType() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, RoleType.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(RoleType.class)));
         }
     }
 
@@ -100,27 +101,27 @@ public interface Type extends Concept {
 
         @Override
         default ThingType.Remote asThingType() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, ThingType.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(ThingType.class)));
         }
 
         @Override
         default EntityType.Remote asEntityType() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, EntityType.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(EntityType.class)));
         }
 
         @Override
         default RelationType.Remote asRelationType() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, RelationType.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(RelationType.class)));
         }
 
         @Override
         default AttributeType.Remote asAttributeType() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, AttributeType.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.class)));
         }
 
         @Override
         default RoleType.Remote asRoleType() {
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, RoleType.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(RoleType.class)));
         }
     }
 }

--- a/concept/type/impl/AttributeTypeImpl.java
+++ b/concept/type/impl/AttributeTypeImpl.java
@@ -20,7 +20,7 @@
 package grakn.client.concept.type.impl;
 
 import grakn.client.Grakn;
-import grakn.client.common.exception.GraknException;
+import grakn.client.common.exception.GraknClientException;
 import grakn.client.concept.thing.Attribute;
 import grakn.client.concept.thing.impl.AttributeImpl;
 import grakn.client.concept.thing.impl.ThingImpl;
@@ -33,8 +33,8 @@ import javax.annotation.Nullable;
 import java.time.LocalDateTime;
 import java.util.stream.Stream;
 
+import static grakn.client.common.exception.ErrorMessage.Concept.BAD_VALUE_TYPE;
 import static grakn.client.common.exception.ErrorMessage.Concept.INVALID_CONCEPT_CASTING;
-import static grakn.client.common.exception.ErrorMessage.Protocol.BAD_VALUE_TYPE;
 import static grakn.client.concept.proto.ConceptProtoBuilder.attributeValue;
 import static grakn.common.util.Objects.className;
 
@@ -65,7 +65,7 @@ public abstract class AttributeTypeImpl {
                     return new AttributeTypeImpl.Local(type.getLabel(), type.getRoot());
                 case UNRECOGNIZED:
                 default:
-                    throw new GraknException(BAD_VALUE_TYPE.message(type.getValueType()));
+                    throw new GraknClientException(BAD_VALUE_TYPE.message(type.getValueType()));
             }
         }
 
@@ -79,7 +79,7 @@ public abstract class AttributeTypeImpl {
             if (isRoot()) {
                 return new AttributeTypeImpl.Boolean.Local(ROOT_LABEL, true);
             }
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.Boolean.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.Boolean.class)));
         }
 
         @Override
@@ -87,7 +87,7 @@ public abstract class AttributeTypeImpl {
             if (isRoot()) {
                 return new AttributeTypeImpl.Long.Local(ROOT_LABEL, true);
             }
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.Long.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.Long.class)));
         }
 
         @Override
@@ -95,7 +95,7 @@ public abstract class AttributeTypeImpl {
             if (isRoot()) {
                 return new AttributeTypeImpl.Double.Local(ROOT_LABEL, true);
             }
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.Double.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.Double.class)));
         }
 
         @Override
@@ -103,7 +103,7 @@ public abstract class AttributeTypeImpl {
             if (isRoot()) {
                 return new AttributeTypeImpl.String.Local(ROOT_LABEL, true);
             }
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.String.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.String.class)));
         }
 
         @Override
@@ -111,7 +111,7 @@ public abstract class AttributeTypeImpl {
             if (isRoot()) {
                 return new AttributeTypeImpl.DateTime.Local(ROOT_LABEL, true);
             }
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.DateTime.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.DateTime.class)));
         }
 
         @Override
@@ -151,7 +151,7 @@ public abstract class AttributeTypeImpl {
                     return new AttributeTypeImpl.Remote(transaction, typeProto.getLabel(), typeProto.getRoot());
                 case UNRECOGNIZED:
                 default:
-                    throw new GraknException(BAD_VALUE_TYPE.message(typeProto.getValueType()));
+                    throw new GraknClientException(BAD_VALUE_TYPE.message(typeProto.getValueType()));
             }
         }
 
@@ -233,7 +233,7 @@ public abstract class AttributeTypeImpl {
             if (isRoot()) {
                 return new AttributeTypeImpl.Boolean.Remote(tx(), ROOT_LABEL, true);
             }
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.Boolean.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.Boolean.class)));
         }
 
         @Override
@@ -241,7 +241,7 @@ public abstract class AttributeTypeImpl {
             if (isRoot()) {
                 return new AttributeTypeImpl.Long.Remote(tx(), ROOT_LABEL, true);
             }
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.Long.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.Long.class)));
         }
 
         @Override
@@ -249,7 +249,7 @@ public abstract class AttributeTypeImpl {
             if (isRoot()) {
                 return new AttributeTypeImpl.Double.Remote(tx(), ROOT_LABEL, true);
             }
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.Double.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.Double.class)));
         }
 
         @Override
@@ -257,7 +257,7 @@ public abstract class AttributeTypeImpl {
             if (isRoot()) {
                 return new AttributeTypeImpl.String.Remote(tx(), ROOT_LABEL, true);
             }
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.String.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.String.class)));
         }
 
         @Override
@@ -265,7 +265,7 @@ public abstract class AttributeTypeImpl {
             if (isRoot()) {
                 return new AttributeTypeImpl.DateTime.Remote(tx(), ROOT_LABEL, true);
             }
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.DateTime.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.DateTime.class)));
         }
 
         @Override

--- a/concept/type/impl/AttributeTypeImpl.java
+++ b/concept/type/impl/AttributeTypeImpl.java
@@ -34,7 +34,7 @@ import java.time.LocalDateTime;
 import java.util.stream.Stream;
 
 import static grakn.client.common.exception.ErrorMessage.Concept.INVALID_CONCEPT_CASTING;
-import static grakn.client.common.exception.ErrorMessage.Protocol.UNRECOGNISED_FIELD;
+import static grakn.client.common.exception.ErrorMessage.Protocol.BAD_VALUE_TYPE;
 import static grakn.client.concept.proto.ConceptProtoBuilder.attributeValue;
 import static grakn.common.util.Objects.className;
 
@@ -65,9 +65,7 @@ public abstract class AttributeTypeImpl {
                     return new AttributeTypeImpl.Local(type.getLabel(), type.getRoot());
                 case UNRECOGNIZED:
                 default:
-                    throw new GraknException(UNRECOGNISED_FIELD.message(
-                            ConceptProto.AttributeType.VALUE_TYPE.class.getSimpleName(), type.getValueType())
-                    );
+                    throw new GraknException(BAD_VALUE_TYPE.message(type.getValueType()));
             }
         }
 
@@ -153,9 +151,7 @@ public abstract class AttributeTypeImpl {
                     return new AttributeTypeImpl.Remote(transaction, typeProto.getLabel(), typeProto.getRoot());
                 case UNRECOGNIZED:
                 default:
-                    throw new GraknException(UNRECOGNISED_FIELD.message(
-                            ConceptProto.AttributeType.VALUE_TYPE.class.getSimpleName(), typeProto.getValueType())
-                    );
+                    throw new GraknException(BAD_VALUE_TYPE.message(typeProto.getValueType()));
             }
         }
 

--- a/concept/type/impl/AttributeTypeImpl.java
+++ b/concept/type/impl/AttributeTypeImpl.java
@@ -171,7 +171,7 @@ public abstract class AttributeTypeImpl {
         @Nullable
         @Override
         public AttributeType.Local getSupertype() {
-            return getSupertype(Type.Local::asAttributeType);
+            return getSupertypeExecute(Type.Local::asAttributeType);
         }
 
         @Override
@@ -318,7 +318,7 @@ public abstract class AttributeTypeImpl {
 
             @Override
             public final AttributeType.Boolean.Local getSupertype() {
-                return getSupertype(t -> t.asAttributeType().asBoolean());
+                return getSupertypeExecute(t -> t.asAttributeType().asBoolean());
             }
 
             @Override
@@ -392,7 +392,7 @@ public abstract class AttributeTypeImpl {
 
             @Override
             public final AttributeType.Long.Local getSupertype() {
-                return getSupertype(t -> t.asAttributeType().asLong());
+                return getSupertypeExecute(t -> t.asAttributeType().asLong());
             }
 
             @Override
@@ -466,7 +466,7 @@ public abstract class AttributeTypeImpl {
 
             @Override
             public final AttributeType.Double.Local getSupertype() {
-                return getSupertype(t -> t.asAttributeType().asDouble());
+                return getSupertypeExecute(t -> t.asAttributeType().asDouble());
             }
 
             @Override
@@ -540,7 +540,7 @@ public abstract class AttributeTypeImpl {
 
             @Override
             public final AttributeType.String.Local getSupertype() {
-                return getSupertype(t -> t.asAttributeType().asString());
+                return getSupertypeExecute(t -> t.asAttributeType().asString());
             }
 
             @Override
@@ -632,7 +632,7 @@ public abstract class AttributeTypeImpl {
 
             @Override
             public final AttributeType.DateTime.Local getSupertype() {
-                return getSupertype(t -> t.asAttributeType().asDateTime());
+                return getSupertypeExecute(t -> t.asAttributeType().asDateTime());
             }
 
             @Override

--- a/concept/type/impl/AttributeTypeImpl.java
+++ b/concept/type/impl/AttributeTypeImpl.java
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
 import static grakn.client.common.exception.ErrorMessage.Concept.INVALID_CONCEPT_CASTING;
 import static grakn.client.common.exception.ErrorMessage.Protocol.UNRECOGNISED_FIELD;
 import static grakn.client.concept.proto.ConceptProtoBuilder.attributeValue;
+import static grakn.common.util.Objects.className;
 
 public abstract class AttributeTypeImpl {
 
@@ -80,7 +81,7 @@ public abstract class AttributeTypeImpl {
             if (isRoot()) {
                 return new AttributeTypeImpl.Boolean.Local(ROOT_LABEL, true);
             }
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, AttributeType.Boolean.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.Boolean.class)));
         }
 
         @Override
@@ -88,7 +89,7 @@ public abstract class AttributeTypeImpl {
             if (isRoot()) {
                 return new AttributeTypeImpl.Long.Local(ROOT_LABEL, true);
             }
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, AttributeType.Long.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.Long.class)));
         }
 
         @Override
@@ -96,7 +97,7 @@ public abstract class AttributeTypeImpl {
             if (isRoot()) {
                 return new AttributeTypeImpl.Double.Local(ROOT_LABEL, true);
             }
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, AttributeType.Double.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.Double.class)));
         }
 
         @Override
@@ -104,7 +105,7 @@ public abstract class AttributeTypeImpl {
             if (isRoot()) {
                 return new AttributeTypeImpl.String.Local(ROOT_LABEL, true);
             }
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, AttributeType.String.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.String.class)));
         }
 
         @Override
@@ -112,7 +113,7 @@ public abstract class AttributeTypeImpl {
             if (isRoot()) {
                 return new AttributeTypeImpl.DateTime.Local(ROOT_LABEL, true);
             }
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, AttributeType.DateTime.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.DateTime.class)));
         }
 
         @Override
@@ -236,7 +237,7 @@ public abstract class AttributeTypeImpl {
             if (isRoot()) {
                 return new AttributeTypeImpl.Boolean.Remote(tx(), ROOT_LABEL, true);
             }
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, AttributeType.Boolean.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.Boolean.class)));
         }
 
         @Override
@@ -244,7 +245,7 @@ public abstract class AttributeTypeImpl {
             if (isRoot()) {
                 return new AttributeTypeImpl.Long.Remote(tx(), ROOT_LABEL, true);
             }
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, AttributeType.Long.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.Long.class)));
         }
 
         @Override
@@ -252,7 +253,7 @@ public abstract class AttributeTypeImpl {
             if (isRoot()) {
                 return new AttributeTypeImpl.Double.Remote(tx(), ROOT_LABEL, true);
             }
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, AttributeType.Double.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.Double.class)));
         }
 
         @Override
@@ -260,7 +261,7 @@ public abstract class AttributeTypeImpl {
             if (isRoot()) {
                 return new AttributeTypeImpl.String.Remote(tx(), ROOT_LABEL, true);
             }
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, AttributeType.String.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.String.class)));
         }
 
         @Override
@@ -268,7 +269,7 @@ public abstract class AttributeTypeImpl {
             if (isRoot()) {
                 return new AttributeTypeImpl.DateTime.Remote(tx(), ROOT_LABEL, true);
             }
-            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, AttributeType.DateTime.class.getCanonicalName()));
+            throw new GraknException(INVALID_CONCEPT_CASTING.message(this, className(AttributeType.DateTime.class)));
         }
 
         @Override

--- a/concept/type/impl/EntityTypeImpl.java
+++ b/concept/type/impl/EntityTypeImpl.java
@@ -66,7 +66,7 @@ public class EntityTypeImpl {
 
         @Override
         public EntityType.Local getSupertype() {
-            return super.getSupertype(Type.Local::asEntityType);
+            return super.getSupertypeExecute(Type.Local::asEntityType);
         }
 
         @Override

--- a/concept/type/impl/RelationTypeImpl.java
+++ b/concept/type/impl/RelationTypeImpl.java
@@ -75,7 +75,7 @@ public class RelationTypeImpl {
 
         @Override
         public RelationType.Local getSupertype() {
-            return super.getSupertype(Type.Local::asRelationType);
+            return super.getSupertypeExecute(Type.Local::asRelationType);
         }
 
         @Override

--- a/concept/type/impl/RoleTypeImpl.java
+++ b/concept/type/impl/RoleTypeImpl.java
@@ -73,7 +73,7 @@ public class RoleTypeImpl {
         @Nullable
         @Override
         public RoleType.Local getSupertype() {
-            return getSupertype(Type.Local::asRoleType);
+            return getSupertypeExecute(Type.Local::asRoleType);
         }
 
         @Override

--- a/concept/type/impl/RuleImpl.java
+++ b/concept/type/impl/RuleImpl.java
@@ -56,7 +56,7 @@ public class RuleImpl {
         @Nullable
         @Override
         public Type.Local getSupertype() {
-            return getSupertype(Type.Local::asRule);
+            return getSupertypeExecute(Type.Local::asRule);
         }
 
         @Override

--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -91,7 +91,7 @@ public abstract class ThingTypeImpl {
 
         @Override
         public ThingType.Local getSupertype() {
-            return super.getSupertype(Type.Local::asThingType);
+            return super.getSupertypeExecute(Type.Local::asThingType);
         }
 
         @Override

--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -46,6 +46,7 @@ import java.util.stream.Stream;
 import static grakn.client.common.exception.ErrorMessage.Protocol.UNRECOGNISED_FIELD;
 import static grakn.client.concept.proto.ConceptProtoBuilder.type;
 import static grakn.client.concept.proto.ConceptProtoBuilder.valueType;
+import static grakn.common.util.Objects.className;
 
 public abstract class ThingTypeImpl {
 
@@ -68,7 +69,7 @@ public abstract class ThingTypeImpl {
                     return new ThingTypeImpl.Local(typeProto.getLabel(), typeProto.getRoot());
                 case UNRECOGNIZED:
                 default:
-                    throw new GraknException(UNRECOGNISED_FIELD.message(ConceptProto.Type.SCHEMA.class.getCanonicalName(), typeProto.getSchema()));
+                    throw new GraknException(UNRECOGNISED_FIELD.message(className(ConceptProto.Type.SCHEMA.class), typeProto.getSchema()));
             }
         }
 

--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -57,7 +57,7 @@ public abstract class ThingTypeImpl {
         }
 
         public static TypeImpl.Local of(ConceptProto.Type typeProto) {
-            switch (typeProto.getSchema()) {
+            switch (typeProto.getEncoding()) {
                 case ENTITY_TYPE:
                     return EntityTypeImpl.Local.of(typeProto);
                 case RELATION_TYPE:
@@ -69,7 +69,7 @@ public abstract class ThingTypeImpl {
                     return new ThingTypeImpl.Local(typeProto.getLabel(), typeProto.getRoot());
                 case UNRECOGNIZED:
                 default:
-                    throw new GraknException(UNRECOGNISED_FIELD.message(className(ConceptProto.Type.SCHEMA.class), typeProto.getSchema()));
+                    throw new GraknException(UNRECOGNISED_FIELD.message(className(ConceptProto.Type.ENCODING.class), typeProto.getEncoding()));
             }
         }
 

--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -43,7 +43,7 @@ import grakn.protocol.ConceptProto.TypeMethod;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static grakn.client.common.exception.ErrorMessage.Protocol.UNRECOGNISED_FIELD;
+import static grakn.client.common.exception.ErrorMessage.Protocol.BAD_ENCODING;
 import static grakn.client.concept.proto.ConceptProtoBuilder.type;
 import static grakn.client.concept.proto.ConceptProtoBuilder.valueType;
 import static grakn.common.util.Objects.className;
@@ -69,7 +69,7 @@ public abstract class ThingTypeImpl {
                     return new ThingTypeImpl.Local(typeProto.getLabel(), typeProto.getRoot());
                 case UNRECOGNIZED:
                 default:
-                    throw new GraknException(UNRECOGNISED_FIELD.message(className(ConceptProto.Type.ENCODING.class), typeProto.getEncoding()));
+                    throw new GraknException(BAD_ENCODING.message(typeProto.getEncoding()));
             }
         }
 

--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -20,7 +20,7 @@
 package grakn.client.concept.type.impl;
 
 import grakn.client.Grakn;
-import grakn.client.common.exception.GraknException;
+import grakn.client.common.exception.GraknClientException;
 import grakn.client.concept.thing.Thing;
 import grakn.client.concept.thing.impl.ThingImpl;
 import grakn.client.concept.type.AttributeType;
@@ -43,10 +43,9 @@ import grakn.protocol.ConceptProto.TypeMethod;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static grakn.client.common.exception.ErrorMessage.Protocol.BAD_ENCODING;
+import static grakn.client.common.exception.ErrorMessage.Concept.BAD_ENCODING;
 import static grakn.client.concept.proto.ConceptProtoBuilder.type;
 import static grakn.client.concept.proto.ConceptProtoBuilder.valueType;
-import static grakn.common.util.Objects.className;
 
 public abstract class ThingTypeImpl {
 
@@ -69,7 +68,7 @@ public abstract class ThingTypeImpl {
                     return new ThingTypeImpl.Local(typeProto.getLabel(), typeProto.getRoot());
                 case UNRECOGNIZED:
                 default:
-                    throw new GraknException(BAD_ENCODING.message(typeProto.getEncoding()));
+                    throw new GraknClientException(BAD_ENCODING.message(typeProto.getEncoding()));
             }
         }
 

--- a/concept/type/impl/TypeImpl.java
+++ b/concept/type/impl/TypeImpl.java
@@ -34,6 +34,7 @@ import java.util.stream.Stream;
 import static grakn.client.common.exception.ErrorMessage.ClientInternal.MISSING_ARGUMENT;
 import static grakn.client.common.exception.ErrorMessage.Protocol.UNRECOGNISED_FIELD;
 import static grakn.client.concept.proto.ConceptProtoBuilder.type;
+import static grakn.common.util.Objects.className;
 
 public abstract class TypeImpl {
 
@@ -58,7 +59,7 @@ public abstract class TypeImpl {
                 case RULE:
                     return RuleImpl.Local.of(typeProto);
                 case UNRECOGNIZED:
-                    throw new GraknException(UNRECOGNISED_FIELD.message(ConceptProto.Type.SCHEMA.class.getCanonicalName(), typeProto.getSchema()));
+                    throw new GraknException(UNRECOGNISED_FIELD.message(className(ConceptProto.Type.SCHEMA.class), typeProto.getSchema()));
                 default:
                     return ThingTypeImpl.Local.of(typeProto);
 
@@ -77,7 +78,7 @@ public abstract class TypeImpl {
 
         @Override
         public String toString() {
-            return this.getClass().getCanonicalName() + "[label: " + (scope != null ? scope + ":" : "") + label + "]";
+            return className(this.getClass()) + "[label: " + (scope != null ? scope + ":" : "") + label + "]";
         }
 
         @Override
@@ -129,7 +130,7 @@ public abstract class TypeImpl {
                     return RuleImpl.Remote.of(transaction, type);
                 case UNRECOGNIZED:
                 default:
-                    throw new GraknException(UNRECOGNISED_FIELD.message(ConceptProto.Type.SCHEMA.class.getCanonicalName(), type.getSchema()));
+                    throw new GraknException(UNRECOGNISED_FIELD.message(className(ConceptProto.Type.SCHEMA.class), type.getSchema()));
             }
         }
 
@@ -221,7 +222,7 @@ public abstract class TypeImpl {
 
         @Override
         public String toString() {
-            return this.getClass().getCanonicalName() + "[label: " + (scope != null ? scope + ":" : "") + label + "]";
+            return className(this.getClass()) + "[label: " + (scope != null ? scope + ":" : "") + label + "]";
         }
 
         @Override

--- a/concept/type/impl/TypeImpl.java
+++ b/concept/type/impl/TypeImpl.java
@@ -20,7 +20,7 @@
 package grakn.client.concept.type.impl;
 
 import grakn.client.Grakn;
-import grakn.client.common.exception.GraknException;
+import grakn.client.common.exception.GraknClientException;
 import grakn.client.concept.type.Type;
 import grakn.protocol.ConceptProto;
 import grakn.protocol.ConceptProto.Type.SetSupertype;
@@ -31,9 +31,9 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static grakn.client.common.exception.ErrorMessage.Concept.NULL_OR_EMPTY_IID;
-import static grakn.client.common.exception.ErrorMessage.Concept.NULL_TRANSACTION;
-import static grakn.client.common.exception.ErrorMessage.Protocol.BAD_ENCODING;
+import static grakn.client.common.exception.ErrorMessage.Concept.MISSING_IID;
+import static grakn.client.common.exception.ErrorMessage.Concept.MISSING_TRANSACTION;
+import static grakn.client.common.exception.ErrorMessage.Concept.BAD_ENCODING;
 import static grakn.client.concept.proto.ConceptProtoBuilder.type;
 import static grakn.common.util.Objects.className;
 
@@ -60,7 +60,7 @@ public abstract class TypeImpl {
                 case RULE:
                     return RuleImpl.Local.of(typeProto);
                 case UNRECOGNIZED:
-                    throw new GraknException(BAD_ENCODING.message(typeProto.getEncoding()));
+                    throw new GraknClientException(BAD_ENCODING.message(typeProto.getEncoding()));
                 default:
                     return ThingTypeImpl.Local.of(typeProto);
 
@@ -106,8 +106,8 @@ public abstract class TypeImpl {
         private final int hash;
 
         Remote(final Grakn.Transaction transaction, final String label, @Nullable String scope, final boolean isRoot) {
-            if (transaction == null) throw new GraknException(NULL_TRANSACTION);
-            else if (label == null || label.isEmpty()) throw new GraknException(NULL_OR_EMPTY_IID);
+            if (transaction == null) throw new GraknClientException(MISSING_TRANSACTION);
+            else if (label == null || label.isEmpty()) throw new GraknClientException(MISSING_IID);
             this.transaction = transaction;
             this.label = label;
             this.scope = scope;
@@ -131,7 +131,7 @@ public abstract class TypeImpl {
                     return RuleImpl.Remote.of(transaction, type);
                 case UNRECOGNIZED:
                 default:
-                    throw new GraknException(BAD_ENCODING.message(type.getEncoding()));
+                    throw new GraknClientException(BAD_ENCODING.message(type.getEncoding()));
             }
         }
 

--- a/concept/type/impl/TypeImpl.java
+++ b/concept/type/impl/TypeImpl.java
@@ -31,7 +31,8 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static grakn.client.common.exception.ErrorMessage.ClientInternal.MISSING_ARGUMENT;
+import static grakn.client.common.exception.ErrorMessage.Concept.NULL_OR_EMPTY_IID;
+import static grakn.client.common.exception.ErrorMessage.Concept.NULL_TRANSACTION;
 import static grakn.client.common.exception.ErrorMessage.Protocol.UNRECOGNISED_FIELD;
 import static grakn.client.concept.proto.ConceptProtoBuilder.type;
 import static grakn.common.util.Objects.className;
@@ -105,8 +106,8 @@ public abstract class TypeImpl {
         private final int hash;
 
         Remote(final Grakn.Transaction transaction, final String label, @Nullable String scope, final boolean isRoot) {
-            if (transaction == null) throw new GraknException(MISSING_ARGUMENT.message("concept"));
-            else if (label == null || label.isEmpty()) throw new GraknException(MISSING_ARGUMENT.message("label"));
+            if (transaction == null) throw new GraknException(NULL_TRANSACTION);
+            else if (label == null || label.isEmpty()) throw new GraknException(NULL_OR_EMPTY_IID);
             this.transaction = transaction;
             this.label = label;
             this.scope = scope;

--- a/concept/type/impl/TypeImpl.java
+++ b/concept/type/impl/TypeImpl.java
@@ -33,7 +33,7 @@ import java.util.stream.Stream;
 
 import static grakn.client.common.exception.ErrorMessage.Concept.NULL_OR_EMPTY_IID;
 import static grakn.client.common.exception.ErrorMessage.Concept.NULL_TRANSACTION;
-import static grakn.client.common.exception.ErrorMessage.Protocol.UNRECOGNISED_FIELD;
+import static grakn.client.common.exception.ErrorMessage.Protocol.BAD_ENCODING;
 import static grakn.client.concept.proto.ConceptProtoBuilder.type;
 import static grakn.common.util.Objects.className;
 
@@ -60,7 +60,7 @@ public abstract class TypeImpl {
                 case RULE:
                     return RuleImpl.Local.of(typeProto);
                 case UNRECOGNIZED:
-                    throw new GraknException(UNRECOGNISED_FIELD.message(className(ConceptProto.Type.ENCODING.class), typeProto.getEncoding()));
+                    throw new GraknException(BAD_ENCODING.message(typeProto.getEncoding()));
                 default:
                     return ThingTypeImpl.Local.of(typeProto);
 
@@ -131,7 +131,7 @@ public abstract class TypeImpl {
                     return RuleImpl.Remote.of(transaction, type);
                 case UNRECOGNIZED:
                 default:
-                    throw new GraknException(UNRECOGNISED_FIELD.message(className(ConceptProto.Type.ENCODING.class), type.getEncoding()));
+                    throw new GraknException(BAD_ENCODING.message(type.getEncoding()));
             }
         }
 

--- a/concept/type/impl/TypeImpl.java
+++ b/concept/type/impl/TypeImpl.java
@@ -165,7 +165,7 @@ public abstract class TypeImpl {
         }
 
         @Nullable
-        <TYPE extends Type.Local> TYPE getSupertype(final Function<Type.Local, TYPE> typeConstructor) {
+        <TYPE extends Type.Local> TYPE getSupertypeExecute(final Function<Type.Local, TYPE> typeConstructor) {
             final TypeMethod.Req method = TypeMethod.Req.newBuilder()
                     .setTypeGetSupertypeReq(ConceptProto.Type.GetSupertype.Req.getDefaultInstance()).build();
 

--- a/concept/type/impl/TypeImpl.java
+++ b/concept/type/impl/TypeImpl.java
@@ -54,13 +54,13 @@ public abstract class TypeImpl {
         }
 
         public static TypeImpl.Local of(final ConceptProto.Type typeProto) {
-            switch (typeProto.getSchema()) {
+            switch (typeProto.getEncoding()) {
                 case ROLE_TYPE:
                     return RoleTypeImpl.Local.of(typeProto);
                 case RULE:
                     return RuleImpl.Local.of(typeProto);
                 case UNRECOGNIZED:
-                    throw new GraknException(UNRECOGNISED_FIELD.message(className(ConceptProto.Type.SCHEMA.class), typeProto.getSchema()));
+                    throw new GraknException(UNRECOGNISED_FIELD.message(className(ConceptProto.Type.ENCODING.class), typeProto.getEncoding()));
                 default:
                     return ThingTypeImpl.Local.of(typeProto);
 
@@ -116,7 +116,7 @@ public abstract class TypeImpl {
         }
 
         public static TypeImpl.Remote of(final Grakn.Transaction transaction, final ConceptProto.Type type) {
-            switch (type.getSchema()) {
+            switch (type.getEncoding()) {
                 case ENTITY_TYPE:
                     return EntityTypeImpl.Remote.of(transaction, type);
                 case RELATION_TYPE:
@@ -131,7 +131,7 @@ public abstract class TypeImpl {
                     return RuleImpl.Remote.of(transaction, type);
                 case UNRECOGNIZED:
                 default:
-                    throw new GraknException(UNRECOGNISED_FIELD.message(className(ConceptProto.Type.SCHEMA.class), type.getSchema()));
+                    throw new GraknException(UNRECOGNISED_FIELD.message(className(ConceptProto.Type.ENCODING.class), type.getEncoding()));
             }
         }
 

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -29,8 +29,8 @@ def graknlabs_graql():
 def graknlabs_common():
     git_repository(
         name = "graknlabs_common",
-        remote = "https://github.com/graknlabs/common",
-        commit = "182d9769d8b6e6fb922fe93cb6d874ddea45df86" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
+        remote = "https://github.com/alexjpwalker/common",
+        commit = "e1fdb40fd299983040ffe32597d55ae44f333403" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 
 def graknlabs_bazel_distribution():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -50,8 +50,8 @@ def graknlabs_dependencies():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/graknlabs/protocol",
-        commit = "6871914abd01dca2c941b88534e0341986acc1df", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/alexjpwalker/protocol",
+        commit = "a95f8486199c468a853f646a36eb3c6ad9bbd3f7", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -50,8 +50,8 @@ def graknlabs_dependencies():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/alexjpwalker/protocol",
-        commit = "a95f8486199c468a853f646a36eb3c6ad9bbd3f7", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/graknlabs/protocol",
+        commit = "3c5a16086ce4caea65b5021f2dc0bdbef9f4005c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():

--- a/rpc/GraknClient.java
+++ b/rpc/GraknClient.java
@@ -28,18 +28,18 @@ import io.grpc.ManagedChannelBuilder;
 
 import java.util.concurrent.TimeUnit;
 
-public class RPCClient implements Client {
+public class GraknClient implements Client {
 
     public static final String DEFAULT_URI = "localhost:48555";
 
     private final ManagedChannel channel;
     private final DatabaseManager databases;
 
-    public RPCClient() {
+    public GraknClient() {
         this(DEFAULT_URI);
     }
 
-    public RPCClient(final String address) {
+    public GraknClient(final String address) {
         channel = ManagedChannelBuilder.forTarget(address)
                 .usePlaintext().build();
         databases = new RPCDatabaseManager(channel);

--- a/rpc/RPCDatabase.java
+++ b/rpc/RPCDatabase.java
@@ -20,9 +20,9 @@
 package grakn.client.rpc;
 
 import grakn.client.Grakn.Database;
-import grakn.client.common.exception.GraknException;
+import grakn.client.common.exception.GraknClientException;
 
-import static grakn.client.common.exception.ErrorMessage.DatabaseManager.NULL_OR_EMPTY_DB_NAME;
+import static grakn.client.common.exception.ErrorMessage.Client.MISSING_DB_NAME;
 
 public class RPCDatabase implements Database {
     private static final long serialVersionUID = 2726154016735929123L;
@@ -36,7 +36,7 @@ public class RPCDatabase implements Database {
 
     public RPCDatabase(String name) {
         if (name == null || name.isEmpty()) {
-            throw new GraknException(NULL_OR_EMPTY_DB_NAME);
+            throw new GraknClientException(MISSING_DB_NAME);
         }
         this.name = name;
     }

--- a/rpc/RPCDatabase.java
+++ b/rpc/RPCDatabase.java
@@ -22,7 +22,7 @@ package grakn.client.rpc;
 import grakn.client.Grakn.Database;
 import grakn.client.common.exception.GraknException;
 
-import static grakn.client.common.exception.ErrorMessage.ClientInternal.MISSING_ARGUMENT;
+import static grakn.client.common.exception.ErrorMessage.DatabaseManager.NULL_OR_EMPTY_DB_NAME;
 
 public class RPCDatabase implements Database {
     private static final long serialVersionUID = 2726154016735929123L;
@@ -36,7 +36,7 @@ public class RPCDatabase implements Database {
 
     public RPCDatabase(String name) {
         if (name == null || name.isEmpty()) {
-            throw new GraknException(MISSING_ARGUMENT.message("name"));
+            throw new GraknException(NULL_OR_EMPTY_DB_NAME);
         }
         this.name = name;
     }

--- a/rpc/RPCDatabaseManager.java
+++ b/rpc/RPCDatabaseManager.java
@@ -21,7 +21,7 @@ package grakn.client.rpc;
 
 import com.google.common.collect.ImmutableList;
 import grakn.client.Grakn.DatabaseManager;
-import grakn.client.common.exception.GraknException;
+import grakn.client.common.exception.GraknClientException;
 import grakn.protocol.DatabaseProto;
 import grakn.protocol.GraknGrpc;
 import io.grpc.ManagedChannel;
@@ -61,7 +61,7 @@ class RPCDatabaseManager implements DatabaseManager {
         try {
             return req.get();
         } catch (StatusRuntimeException e) {
-            throw new GraknException(e);
+            throw new GraknClientException(e);
         }
     }
 }

--- a/rpc/RPCIterator.java
+++ b/rpc/RPCIterator.java
@@ -20,14 +20,14 @@
 package grakn.client.rpc;
 
 import com.google.common.collect.AbstractIterator;
-import grakn.client.common.exception.GraknException;
+import grakn.client.common.exception.GraknClientException;
 import grakn.protocol.TransactionProto;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
-import static grakn.client.common.exception.ErrorMessage.Protocol.MISSING_RESPONSE;
+import static grakn.client.common.exception.ErrorMessage.Client.MISSING_RESPONSE;
 import static grakn.common.util.Objects.className;
 
 class RPCIterator<T> extends AbstractIterator<T> {
@@ -75,7 +75,7 @@ class RPCIterator<T> extends AbstractIterator<T> {
 
     public void waitForStart(final long timeout, final TimeUnit unit) throws InterruptedException, TimeoutException {
         if (first != null) {
-            throw new GraknException(new IllegalStateException("Should not poll RpcIterator multiple times"));
+            throw new GraknClientException(new IllegalStateException("Should not poll RpcIterator multiple times"));
         }
 
         first = currentBatch.poll(timeout, unit).getIterRes();
@@ -97,7 +97,7 @@ class RPCIterator<T> extends AbstractIterator<T> {
             res = currentBatch.take().getIterRes();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new GraknException(e);
+            throw new GraknClientException(e);
         }
         started = true;
         switch (res.getResCase()) {
@@ -107,7 +107,7 @@ class RPCIterator<T> extends AbstractIterator<T> {
             case DONE:
                 return endOfData();
             case RES_NOT_SET:
-                throw new GraknException(MISSING_RESPONSE.message(className(TransactionProto.Transaction.Iter.Res.class)));
+                throw new GraknClientException(MISSING_RESPONSE.message(className(TransactionProto.Transaction.Iter.Res.class)));
             default:
                 return responseReader.apply(res);
         }

--- a/rpc/RPCIterator.java
+++ b/rpc/RPCIterator.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
 import static grakn.client.common.exception.ErrorMessage.Protocol.REQUIRED_FIELD_NOT_SET;
+import static grakn.common.util.Objects.className;
 
 class RPCIterator<T> extends AbstractIterator<T> {
 
@@ -106,7 +107,7 @@ class RPCIterator<T> extends AbstractIterator<T> {
             case DONE:
                 return endOfData();
             case RES_NOT_SET:
-                throw new GraknException(REQUIRED_FIELD_NOT_SET.message(TransactionProto.Transaction.Iter.Res.class.getCanonicalName()));
+                throw new GraknException(REQUIRED_FIELD_NOT_SET.message(className(TransactionProto.Transaction.Iter.Res.class)));
             default:
                 return responseReader.apply(res);
         }

--- a/rpc/RPCIterator.java
+++ b/rpc/RPCIterator.java
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
-import static grakn.client.common.exception.ErrorMessage.Protocol.REQUIRED_FIELD_NOT_SET;
+import static grakn.client.common.exception.ErrorMessage.Protocol.MISSING_RESPONSE;
 import static grakn.common.util.Objects.className;
 
 class RPCIterator<T> extends AbstractIterator<T> {
@@ -107,7 +107,7 @@ class RPCIterator<T> extends AbstractIterator<T> {
             case DONE:
                 return endOfData();
             case RES_NOT_SET:
-                throw new GraknException(REQUIRED_FIELD_NOT_SET.message(className(TransactionProto.Transaction.Iter.Res.class)));
+                throw new GraknException(MISSING_RESPONSE.message(className(TransactionProto.Transaction.Iter.Res.class)));
             default:
                 return responseReader.apply(res);
         }

--- a/rpc/RPCTransaction.java
+++ b/rpc/RPCTransaction.java
@@ -25,7 +25,7 @@ import grakn.client.Grakn.Database;
 import grakn.client.Grakn.Session;
 import grakn.client.Grakn.Transaction;
 import grakn.client.GraknOptions;
-import grakn.client.common.exception.GraknException;
+import grakn.client.common.exception.GraknClientException;
 import grakn.client.concept.Concepts;
 import grakn.client.concept.answer.Answer;
 import grakn.client.concept.answer.AnswerGroup;
@@ -59,7 +59,7 @@ import static grabl.tracing.client.GrablTracingThreadStatic.traceOnThread;
 import static grakn.client.Grakn.Transaction.Type.WRITE;
 import static grakn.client.common.ProtoBuilder.options;
 import static grakn.client.common.ProtoBuilder.tracingData;
-import static grakn.client.common.exception.ErrorMessage.Query.UNRECOGNISED_QUERY_OBJECT;
+import static grakn.client.common.exception.ErrorMessage.Query.BAD_QUERY_OBJECT;
 import static grakn.client.concept.proto.ConceptProtoBuilder.concept;
 
 public class RPCTransaction implements Transaction {
@@ -388,7 +388,7 @@ public class RPCTransaction implements Transaction {
             return execute((GraqlCompute.Cluster) query);
 
         } else {
-            throw new GraknException(UNRECOGNISED_QUERY_OBJECT.message(query));
+            throw new GraknClientException(BAD_QUERY_OBJECT.message(query));
         }
     }
 
@@ -436,7 +436,7 @@ public class RPCTransaction implements Transaction {
             return stream((GraqlCompute.Cluster) query);
 
         } else {
-            throw new GraknException(UNRECOGNISED_QUERY_OBJECT.message(query));
+            throw new GraknClientException(BAD_QUERY_OBJECT.message(query));
         }
     }
 
@@ -539,9 +539,9 @@ public class RPCTransaction implements Transaction {
                 getIterator().waitForStart(timeout, unit);
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();
-                throw new GraknException(ex);
+                throw new GraknClientException(ex);
             } catch (TimeoutException ex) {
-                throw new GraknException(ex);
+                throw new GraknClientException(ex);
             }
             return getInternal();
         }

--- a/test/behaviour/concept/type/attributetype/AttributeTypeSteps.java
+++ b/test/behaviour/concept/type/attributetype/AttributeTypeSteps.java
@@ -19,7 +19,7 @@
 
 package grakn.client.test.behaviour.concept.type.attributetype;
 
-import grakn.client.common.exception.GraknException;
+import grakn.client.common.exception.GraknClientException;
 import grakn.client.concept.type.AttributeType;
 import grakn.client.concept.type.AttributeType.ValueType;
 import grakn.client.concept.type.ThingType;
@@ -30,9 +30,8 @@ import io.cucumber.java.en.When;
 import java.util.List;
 import java.util.Set;
 
-import static grakn.client.common.exception.ErrorMessage.Concept.UNRECOGNISED_CONCEPT;
+import static grakn.client.common.exception.ErrorMessage.Concept.BAD_VALUE_TYPE;
 import static grakn.client.test.behaviour.connection.ConnectionSteps.tx;
-import static grakn.common.util.Objects.className;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -73,7 +72,7 @@ public class AttributeTypeSteps {
             case DATETIME:
                 return attributeType.asDateTime();
             default:
-                throw new GraknException(UNRECOGNISED_CONCEPT.message(className(ValueType.class), valueType));
+                throw new GraknClientException(BAD_VALUE_TYPE.message(valueType));
         }
     }
 

--- a/test/behaviour/concept/type/attributetype/AttributeTypeSteps.java
+++ b/test/behaviour/concept/type/attributetype/AttributeTypeSteps.java
@@ -32,6 +32,7 @@ import java.util.Set;
 
 import static grakn.client.common.exception.ErrorMessage.Concept.UNRECOGNISED_CONCEPT;
 import static grakn.client.test.behaviour.connection.ConnectionSteps.tx;
+import static grakn.common.util.Objects.className;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -72,7 +73,7 @@ public class AttributeTypeSteps {
             case DATETIME:
                 return attributeType.asDateTime();
             default:
-                throw new GraknException(UNRECOGNISED_CONCEPT.message(ValueType.class.getCanonicalName(), valueType));
+                throw new GraknException(UNRECOGNISED_CONCEPT.message(className(ValueType.class), valueType));
         }
     }
 

--- a/test/behaviour/concept/type/attributetype/BUILD
+++ b/test/behaviour/concept/type/attributetype/BUILD
@@ -27,8 +27,6 @@ java_library(
         "AttributeTypeSteps.java"
     ],
     deps = [
-        "@graknlabs_common//:common",
-        
         # Internal Package Dependencies
         "//:client-java",
         "//test/behaviour/connection:steps",

--- a/test/behaviour/concept/type/attributetype/BUILD
+++ b/test/behaviour/concept/type/attributetype/BUILD
@@ -27,6 +27,8 @@ java_library(
         "AttributeTypeSteps.java"
     ],
     deps = [
+        "@graknlabs_common//:common",
+        
         # Internal Package Dependencies
         "//:client-java",
         "//test/behaviour/connection:steps",

--- a/test/behaviour/connection/ConnectionSteps.java
+++ b/test/behaviour/connection/ConnectionSteps.java
@@ -23,6 +23,7 @@ import grakn.client.Grakn;
 import grakn.client.Grakn.Client;
 import grakn.client.Grakn.Session;
 import grakn.client.Grakn.Transaction;
+import grakn.client.rpc.GraknClient;
 import grakn.common.test.server.GraknSingleton;
 import io.cucumber.java.After;
 import io.cucumber.java.en.Given;
@@ -60,7 +61,7 @@ public class ConnectionSteps {
         String address = GraknSingleton.getGraknRunner().address();
         assertNotNull(address);
 
-        client = Grakn.client(address);
+        client = new GraknClient(address);
 
         System.out.println("Connection to Grakn Core established");
 

--- a/test/behaviour/util/Util.java
+++ b/test/behaviour/util/Util.java
@@ -19,7 +19,7 @@
 
 package grakn.client.test.behaviour.util;
 
-import grakn.client.common.exception.GraknException;
+import grakn.client.common.exception.GraknClientException;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -30,7 +30,7 @@ public class Util {
         try {
             function.run();
             fail();
-        } catch (GraknException e) {
+        } catch (GraknClientException e) {
             assertTrue(true);
         }
     }

--- a/test/deployment/pom.xml
+++ b/test/deployment/pom.xml
@@ -7,10 +7,6 @@
     <version>1.0-SNAPSHOT</version>
     <name>test-deployment</name>
     <url>http://maven.apache.org</url>
-    <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-    </properties>
     <repositories>
         <repository>
             <id>repo.grakn.ai.release</id>

--- a/test/integration/ClientQueryTest.java
+++ b/test/integration/ClientQueryTest.java
@@ -24,6 +24,7 @@ import grakn.client.Grakn.Client;
 import grakn.client.Grakn.Session;
 import grakn.client.Grakn.Transaction;
 import grakn.client.concept.answer.ConceptMap;
+import grakn.client.rpc.GraknClient;
 import grakn.common.test.server.GraknCoreRunner;
 import graql.lang.Graql;
 import graql.lang.common.GraqlArg;
@@ -65,7 +66,7 @@ public class ClientQueryTest {
     public static void setUpClass() throws InterruptedException, IOException, TimeoutException {
         grakn = new GraknCoreRunner();
         grakn.start();
-        graknClient = Grakn.client(grakn.address());
+        graknClient = new GraknClient(grakn.address());
     }
 
     @AfterClass


### PR DESCRIPTION
## What is the goal of this PR?

To continue cleaning up and fixing bugs in the client.

## What are the changes implemented in this PR?

- Use grakn.common.util.Objects.className() instead of getCanonicalName() and getSimpleName()
- Change Thing.getRelations to return Relation.Locals
- Rename RPCClient to GraknClient and delete Grakn.client
- Store Remote attributes' values locally - avoids a server roundtrip when calling `getValue`
- Change `putEntityType` and `putRelationType` to return Local concepts
- Overhaul of our Error Messages - now cleanly divided into Client, Concept and Query errors, and each error code uniquely identifies each problem