### PR TITLE
Implement missing race condition fix from master

### DIFF
--- a/rpc/Transceiver.java
+++ b/rpc/Transceiver.java
@@ -209,7 +209,7 @@ public class Transceiver implements AutoCloseable {
         private final BlockingQueue<ResponseCollector> collectorQueue = new LinkedBlockingQueue<>();
         private final AtomicBoolean terminated = new AtomicBoolean(false);
 
-        void addCollector(ResponseCollector collector) {
+        synchronized void addCollector(ResponseCollector collector) {
             collectorQueue.add(collector);
         }
 
@@ -230,12 +230,12 @@ public class Transceiver implements AutoCloseable {
         }
 
         @Override
-        public void onNext(Transaction.Res value) {
+        public synchronized void onNext(Transaction.Res value) {
             dispatchResponse(Response.ok(value));
         }
 
         @Override
-        public void onError(Throwable throwable) {
+        public synchronized void onError(Throwable throwable) {
             terminated.set(true);
             assert throwable instanceof StatusRuntimeException : "The server only yields these exceptions";
 
@@ -246,7 +246,7 @@ public class Transceiver implements AutoCloseable {
         }
 
         @Override
-        public void onCompleted() {
+        public synchronized void onCompleted() {
             terminated.set(true);
 
             // Exhaust the queue


### PR DESCRIPTION
## What is the goal of this PR?

We patched a race condition that caused transactions to hang during closing a while ago but the patch was never released and only exists in master. During debugging of a new issue, we rediscovered the same problem, but are now more sure about the nature of the bug and a more correct fix. However, we are also certain that the original fix has proven itself to be stable, so in the interest of keeping master the same as the latest release, we are going to release the original fix as 1.8.3.

## What are the changes implemented in this PR?

- Add `synchronized` to transceiver methods to ensure that no calls result in a race condition.
