### PR TITLE
Remove unnecessary 'final' from parameters

### DIFF
--- a/GraknOptions.java
+++ b/GraknOptions.java
@@ -53,7 +53,7 @@ public class GraknOptions {
         return Optional.ofNullable(batchSize);
     }
 
-    public GraknOptions batchSize(final int batchSize) {
+    public GraknOptions batchSize(int batchSize) {
         if (batchSize < 1) {
             throw new GraknClientException(NEGATIVE_BATCH_SIZE.message(batchSize));
         }

--- a/common/ProtoBuilder.java
+++ b/common/ProtoBuilder.java
@@ -32,7 +32,7 @@ import static grabl.tracing.client.GrablTracingThreadStatic.isTracingEnabled;
 
 public abstract class ProtoBuilder {
 
-    public static OptionsProto.Options options(final GraknOptions options) {
+    public static OptionsProto.Options options(GraknOptions options) {
         final OptionsProto.Options.Builder builder = OptionsProto.Options.newBuilder();
         options.infer().ifPresent(builder::setInfer);
         options.explain().ifPresent(builder::setExplain);

--- a/common/exception/GraknClientException.java
+++ b/common/exception/GraknClientException.java
@@ -25,20 +25,20 @@ import javax.annotation.Nullable;
 
 public class GraknClientException extends RuntimeException {
 
-    public GraknClientException(final String error) {
+    public GraknClientException(String error) {
         super(error);
     }
 
-    public GraknClientException(final ErrorMessage error) {
+    public GraknClientException(ErrorMessage error) {
         super(error.toString());
         assert !getMessage().contains("%s");
     }
 
-    public GraknClientException(final StatusRuntimeException statusRuntimeException) {
+    public GraknClientException(StatusRuntimeException statusRuntimeException) {
         super(statusRuntimeException.getStatus().getDescription());
     }
 
-    public GraknClientException(final Exception e) {
+    public GraknClientException(Exception e) {
         super(e);
     }
 

--- a/concept/ConceptManager.java
+++ b/concept/ConceptManager.java
@@ -49,7 +49,7 @@ public final class ConceptManager {
 
     private final RPCTransaction rpcTransaction;
 
-    public ConceptManager(final RPCTransaction rpcTransaction) {
+    public ConceptManager(RPCTransaction rpcTransaction) {
         this.rpcTransaction = rpcTransaction;
     }
 
@@ -73,7 +73,7 @@ public final class ConceptManager {
         return getType(GraqlToken.Type.ATTRIBUTE.toString()).asAttributeType();
     }
 
-    public EntityType putEntityType(final String label) {
+    public EntityType putEntityType(String label) {
         final ConceptProto.ConceptManager.Req req = ConceptProto.ConceptManager.Req.newBuilder()
                 .setPutEntityTypeReq(ConceptProto.ConceptManager.PutEntityType.Req.newBuilder()
                         .setLabel(label)).build();
@@ -83,13 +83,13 @@ public final class ConceptManager {
 
     @Nullable
     @CheckReturnValue
-    public EntityType getEntityType(final String label) {
+    public EntityType getEntityType(String label) {
         final Type concept = getType(label);
         if (concept instanceof EntityType) return concept.asEntityType();
         else return null;
     }
 
-    public RelationType putRelationType(final String label) {
+    public RelationType putRelationType(String label) {
         final ConceptProto.ConceptManager.Req req = ConceptProto.ConceptManager.Req.newBuilder()
                 .setPutRelationTypeReq(ConceptProto.ConceptManager.PutRelationType.Req.newBuilder()
                         .setLabel(label)).build();
@@ -99,13 +99,13 @@ public final class ConceptManager {
 
     @Nullable
     @CheckReturnValue
-    public RelationType getRelationType(final String label) {
+    public RelationType getRelationType(String label) {
         final Type concept = getType(label);
         if (concept instanceof RelationType) return concept.asRelationType();
         else return null;
     }
 
-    public AttributeType putAttributeType(final String label, final AttributeType.ValueType valueType) {
+    public AttributeType putAttributeType(String label, AttributeType.ValueType valueType) {
         final ConceptProto.ConceptManager.Req req = ConceptProto.ConceptManager.Req.newBuilder()
                 .setPutAttributeTypeReq(ConceptProto.ConceptManager.PutAttributeType.Req.newBuilder()
                         .setLabel(label)
@@ -116,13 +116,13 @@ public final class ConceptManager {
 
     @Nullable
     @CheckReturnValue
-    public AttributeType getAttributeType(final String label) {
+    public AttributeType getAttributeType(String label) {
         final Type concept = getType(label);
         if (concept instanceof AttributeType) return concept.asAttributeType();
         else return null;
     }
 
-    public Rule putRule(final String label, final Pattern when, final Pattern then) {
+    public Rule putRule(String label, Pattern when, Pattern then) {
         final ConceptProto.ConceptManager.Req req = ConceptProto.ConceptManager.Req.newBuilder()
                 .setPutRuleReq(ConceptProto.ConceptManager.PutRule.Req.newBuilder()
                         .setLabel(label)
@@ -134,7 +134,7 @@ public final class ConceptManager {
 
     @Nullable
     @CheckReturnValue
-    public Thing getThing(final String iid) {
+    public Thing getThing(String iid) {
         final ConceptProto.ConceptManager.Req req = ConceptProto.ConceptManager.Req.newBuilder()
                 .setGetThingReq(ConceptProto.ConceptManager.GetThing.Req.newBuilder().setIid(iid(iid))).build();
 
@@ -150,7 +150,7 @@ public final class ConceptManager {
 
     @Nullable
     @CheckReturnValue
-    public Type getType(final String label) {
+    public Type getType(String label) {
         final ConceptProto.ConceptManager.Req req = ConceptProto.ConceptManager.Req.newBuilder()
                 .setGetTypeReq(ConceptProto.ConceptManager.GetType.Req.newBuilder().setLabel(label)).build();
 
@@ -166,7 +166,7 @@ public final class ConceptManager {
 
     @Nullable
     @CheckReturnValue
-    public Rule getRule(final String label) {
+    public Rule getRule(String label) {
         final ConceptProto.ConceptManager.Req req = ConceptProto.ConceptManager.Req.newBuilder()
                 .setGetRuleReq(ConceptProto.ConceptManager.GetRule.Req.newBuilder().setLabel(label)).build();
 
@@ -180,7 +180,7 @@ public final class ConceptManager {
         }
     }
 
-    private ConceptProto.ConceptManager.Res execute(final ConceptProto.ConceptManager.Req request) {
+    private ConceptProto.ConceptManager.Res execute(ConceptProto.ConceptManager.Req request) {
         final TransactionProto.Transaction.Req.Builder req = TransactionProto.Transaction.Req.newBuilder()
                 .putAllMetadata(tracingData())
                 .setConceptManagerReq(request);

--- a/concept/answer/Answer.java
+++ b/concept/answer/Answer.java
@@ -36,7 +36,7 @@ public interface Answer {
         throw new UnsupportedOperationException();
     }
 
-    static Answer of(final Transaction tx, final AnswerProto.Answer res) {
+    static Answer of(Transaction tx, AnswerProto.Answer res) {
         switch (res.getAnswerCase()) {
             case ANSWER_GROUP:
                 return AnswerGroup.of(tx, res.getAnswerGroup());

--- a/concept/answer/AnswerGroup.java
+++ b/concept/answer/AnswerGroup.java
@@ -39,7 +39,7 @@ public class AnswerGroup<T> implements Answer {
         this.answers = answers;
     }
 
-    public static AnswerGroup<? extends Answer> of(final Transaction tx, final AnswerProto.AnswerGroup res) {
+    public static AnswerGroup<? extends Answer> of(Transaction tx, AnswerProto.AnswerGroup res) {
         Concept concept;
         if (res.getOwner().hasThing()) concept = ThingImpl.of(res.getOwner().getThing());
         else concept = TypeImpl.of(res.getOwner().getType());

--- a/concept/answer/AnswerProtoReader.java
+++ b/concept/answer/AnswerProtoReader.java
@@ -30,12 +30,12 @@ import static grakn.common.collection.Bytes.bytesToHexString;
 
 abstract class AnswerProtoReader {
 
-    static String iid(final ByteString res) {
+    static String iid(ByteString res) {
         return bytesToHexString(res.toByteArray());
     }
 
     // We will probably need this in the future when aggregates are implemented
-    static Number number(final AnswerProto.Number res) {
+    static Number number(AnswerProto.Number res) {
         try {
             return NumberFormat.getInstance().parse(res.getValue());
         } catch (ParseException e) {

--- a/concept/answer/ConceptMap.java
+++ b/concept/answer/ConceptMap.java
@@ -45,7 +45,7 @@ public class ConceptMap implements Answer {
         this.queryPattern = queryPattern;
     }
 
-    public static ConceptMap of(final AnswerProto.ConceptMap res) {
+    public static ConceptMap of(AnswerProto.ConceptMap res) {
         final Map<String, Concept> variableMap = new HashMap<>();
         res.getMapMap().forEach((resVar, resConcept) -> {
             Concept concept;

--- a/concept/proto/ConceptProtoBuilder.java
+++ b/concept/proto/ConceptProtoBuilder.java
@@ -117,11 +117,11 @@ public abstract class ConceptProtoBuilder {
         }
     }
 
-    public static ByteString iid(final String iid) {
+    public static ByteString iid(String iid) {
         return ByteString.copyFrom(hexStringToBytes(iid));
     }
 
-    private static ConceptProto.Thing.ENCODING encoding(final Thing thing) {
+    private static ConceptProto.Thing.ENCODING encoding(Thing thing) {
         if (thing instanceof Entity) {
             return ConceptProto.Thing.ENCODING.ENTITY;
         } else if (thing instanceof Relation) {
@@ -133,7 +133,7 @@ public abstract class ConceptProtoBuilder {
         }
     }
 
-    private static ConceptProto.Type.ENCODING encoding(final Type type) {
+    private static ConceptProto.Type.ENCODING encoding(Type type) {
         if (type instanceof EntityType) {
             return ConceptProto.Type.ENCODING.ENTITY_TYPE;
         } else if (type instanceof RelationType) {

--- a/concept/thing/impl/AttributeImpl.java
+++ b/concept/thing/impl/AttributeImpl.java
@@ -40,7 +40,7 @@ import static grakn.common.util.Objects.className;
 
 public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribute<VALUE> {
 
-    AttributeImpl(final java.lang.String iid) {
+    AttributeImpl(java.lang.String iid) {
         super(iid);
     }
 
@@ -96,11 +96,11 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
     public abstract static class Remote<VALUE> extends ThingImpl.Remote implements Attribute.Remote<VALUE> {
 
-        Remote(final Grakn.Transaction transaction, final java.lang.String iid) {
+        Remote(Grakn.Transaction transaction, java.lang.String iid) {
             super(transaction, iid);
         }
 
-        public static AttributeImpl.Remote<?> of(final Grakn.Transaction transaction, final ConceptProto.Thing thingProto) {
+        public static AttributeImpl.Remote<?> of(Grakn.Transaction transaction, ConceptProto.Thing thingProto) {
             switch (thingProto.getValueType()) {
                 case BOOLEAN:
                     return AttributeImpl.Boolean.Remote.of(transaction, thingProto);
@@ -178,12 +178,12 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
         private final java.lang.Boolean value;
 
-        Boolean(final java.lang.String iid, final boolean value) {
+        Boolean(java.lang.String iid, boolean value) {
             super(iid);
             this.value = value;
         }
 
-        public static AttributeImpl.Boolean of(final ConceptProto.Thing thingProto) {
+        public static AttributeImpl.Boolean of(ConceptProto.Thing thingProto) {
             return new AttributeImpl.Boolean(
                     bytesToHexString(thingProto.getIid().toByteArray()),
                     thingProto.getValue().getBoolean()
@@ -209,12 +209,12 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
             private final java.lang.Boolean value;
 
-            Remote(final Grakn.Transaction transaction, final java.lang.String iid, final java.lang.Boolean value) {
+            Remote(Grakn.Transaction transaction, java.lang.String iid, java.lang.Boolean value) {
                 super(transaction, iid);
                 this.value = value;
             }
 
-            public static AttributeImpl.Boolean.Remote of(final Grakn.Transaction transaction, final ConceptProto.Thing thingProto) {
+            public static AttributeImpl.Boolean.Remote of(Grakn.Transaction transaction, ConceptProto.Thing thingProto) {
                 return new AttributeImpl.Boolean.Remote(transaction, bytesToHexString(thingProto.getIid().toByteArray()), thingProto.getValue().getBoolean());
             }
 
@@ -244,12 +244,12 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
         private final long value;
 
-        Long(final java.lang.String iid, final long value) {
+        Long(java.lang.String iid, long value) {
             super(iid);
             this.value = value;
         }
 
-        public static AttributeImpl.Long of(final ConceptProto.Thing thingProto) {
+        public static AttributeImpl.Long of(ConceptProto.Thing thingProto) {
             return new AttributeImpl.Long(
                     bytesToHexString(thingProto.getIid().toByteArray()),
                     thingProto.getValue().getLong()
@@ -275,12 +275,12 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
             private final long value;
 
-            Remote(final Grakn.Transaction transaction, final java.lang.String iid, final long value) {
+            Remote(Grakn.Transaction transaction, java.lang.String iid, long value) {
                 super(transaction, iid);
                 this.value = value;
             }
 
-            public static AttributeImpl.Long.Remote of(final Grakn.Transaction transaction, final ConceptProto.Thing thingProto) {
+            public static AttributeImpl.Long.Remote of(Grakn.Transaction transaction, ConceptProto.Thing thingProto) {
                 return new AttributeImpl.Long.Remote(transaction, bytesToHexString(thingProto.getIid().toByteArray()), thingProto.getValue().getLong());
             }
 
@@ -310,12 +310,12 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
         private final double value;
 
-        Double(final java.lang.String iid, final double value) {
+        Double(java.lang.String iid, double value) {
             super(iid);
             this.value = value;
         }
 
-        public static AttributeImpl.Double of(final ConceptProto.Thing thingProto) {
+        public static AttributeImpl.Double of(ConceptProto.Thing thingProto) {
             return new AttributeImpl.Double(
                     bytesToHexString(thingProto.getIid().toByteArray()),
                     thingProto.getValue().getDouble()
@@ -341,12 +341,12 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
             private final double value;
 
-            Remote(final Grakn.Transaction transaction, final java.lang.String iid, final double value) {
+            Remote(Grakn.Transaction transaction, java.lang.String iid, double value) {
                 super(transaction, iid);
                 this.value = value;
             }
 
-            public static AttributeImpl.Double.Remote of(final Grakn.Transaction transaction, final ConceptProto.Thing thingProto) {
+            public static AttributeImpl.Double.Remote of(Grakn.Transaction transaction, ConceptProto.Thing thingProto) {
                 return new AttributeImpl.Double.Remote(transaction, bytesToHexString(thingProto.getIid().toByteArray()), thingProto.getValue().getDouble());
             }
 
@@ -376,12 +376,12 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
         private final java.lang.String value;
 
-        String(final java.lang.String iid, final java.lang.String value) {
+        String(java.lang.String iid, java.lang.String value) {
             super(iid);
             this.value = value;
         }
 
-        public static AttributeImpl.String of(final ConceptProto.Thing thingProto) {
+        public static AttributeImpl.String of(ConceptProto.Thing thingProto) {
             return new AttributeImpl.String(
                     bytesToHexString(thingProto.getIid().toByteArray()),
                     thingProto.getValue().getString()
@@ -407,12 +407,12 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
             private final java.lang.String value;
 
-            Remote(final Grakn.Transaction transaction, final java.lang.String iid, final java.lang.String value) {
+            Remote(Grakn.Transaction transaction, java.lang.String iid, java.lang.String value) {
                 super(transaction, iid);
                 this.value = value;
             }
 
-            public static AttributeImpl.String.Remote of(final Grakn.Transaction transaction, final ConceptProto.Thing thingProto) {
+            public static AttributeImpl.String.Remote of(Grakn.Transaction transaction, ConceptProto.Thing thingProto) {
                 return new AttributeImpl.String.Remote(transaction, bytesToHexString(thingProto.getIid().toByteArray()), thingProto.getValue().getString());
             }
 
@@ -442,12 +442,12 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
         private final LocalDateTime value;
 
-        DateTime(final java.lang.String iid, final LocalDateTime value) {
+        DateTime(java.lang.String iid, LocalDateTime value) {
             super(iid);
             this.value = value;
         }
 
-        public static AttributeImpl.DateTime of(final ConceptProto.Thing thingProto) {
+        public static AttributeImpl.DateTime of(ConceptProto.Thing thingProto) {
             return new AttributeImpl.DateTime(
                     bytesToHexString(thingProto.getIid().toByteArray()),
                     toLocalDateTime(thingProto.getValue().getDateTime())
@@ -477,17 +477,17 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
             private final LocalDateTime value;
 
-            Remote(final Grakn.Transaction transaction, final java.lang.String iid, final LocalDateTime value) {
+            Remote(Grakn.Transaction transaction, java.lang.String iid, LocalDateTime value) {
                 super(transaction, iid);
                 this.value = value;
             }
 
-            public static AttributeImpl.DateTime.Remote of(final Grakn.Transaction transaction, final ConceptProto.Thing thingProto) {
+            public static AttributeImpl.DateTime.Remote of(Grakn.Transaction transaction, ConceptProto.Thing thingProto) {
                 return new AttributeImpl.DateTime.Remote(transaction, bytesToHexString(thingProto.getIid().toByteArray()), toLocalDateTime(thingProto.getValue().getDateTime()));
             }
 
             @Override
-            public Attribute.DateTime.Remote asRemote(final Grakn.Transaction transaction) {
+            public Attribute.DateTime.Remote asRemote(Grakn.Transaction transaction) {
                 return new AttributeImpl.DateTime.Remote(transaction, getIID(), value);
             }
 

--- a/concept/thing/impl/EntityImpl.java
+++ b/concept/thing/impl/EntityImpl.java
@@ -27,16 +27,16 @@ import grakn.protocol.ConceptProto;
 
 public class EntityImpl extends ThingImpl implements Entity {
 
-    EntityImpl(final String iid) {
+    EntityImpl(String iid) {
         super(iid);
     }
 
-    public static EntityImpl of(final ConceptProto.Thing protoThing) {
+    public static EntityImpl of(ConceptProto.Thing protoThing) {
         return new EntityImpl(Bytes.bytesToHexString(protoThing.getIid().toByteArray()));
     }
 
     @Override
-    public EntityImpl.Remote asRemote(final Grakn.Transaction transaction) {
+    public EntityImpl.Remote asRemote(Grakn.Transaction transaction) {
         return new EntityImpl.Remote(transaction, getIID());
     }
 
@@ -47,16 +47,16 @@ public class EntityImpl extends ThingImpl implements Entity {
 
     public static class Remote extends ThingImpl.Remote implements Entity.Remote {
 
-        public Remote(final Grakn.Transaction transaction, final String iid) {
+        public Remote(Grakn.Transaction transaction, String iid) {
             super(transaction, iid);
         }
 
-        public static EntityImpl.Remote of(final Grakn.Transaction transaction, final ConceptProto.Thing protoThing) {
+        public static EntityImpl.Remote of(Grakn.Transaction transaction, ConceptProto.Thing protoThing) {
             return new EntityImpl.Remote(transaction, Bytes.bytesToHexString(protoThing.getIid().toByteArray()));
         }
 
         @Override
-        public EntityImpl.Remote asRemote(final Grakn.Transaction transaction) {
+        public EntityImpl.Remote asRemote(Grakn.Transaction transaction) {
             return new EntityImpl.Remote(transaction, getIID());
         }
 

--- a/concept/thing/impl/RelationImpl.java
+++ b/concept/thing/impl/RelationImpl.java
@@ -48,16 +48,16 @@ import static grakn.client.concept.proto.ConceptProtoBuilder.types;
 
 public class RelationImpl extends ThingImpl implements Relation {
 
-    RelationImpl(final String iid) {
+    RelationImpl(String iid) {
         super(iid);
     }
 
-    public static RelationImpl of(final ConceptProto.Thing protoThing) {
+    public static RelationImpl of(ConceptProto.Thing protoThing) {
         return new RelationImpl(Bytes.bytesToHexString(protoThing.getIid().toByteArray()));
     }
 
     @Override
-    public RelationImpl.Remote asRemote(final Grakn.Transaction transaction) {
+    public RelationImpl.Remote asRemote(Grakn.Transaction transaction) {
         return new RelationImpl.Remote(transaction, getIID());
     }
 
@@ -68,16 +68,16 @@ public class RelationImpl extends ThingImpl implements Relation {
 
     public static class Remote extends ThingImpl.Remote implements Relation.Remote {
 
-        public Remote(final Grakn.Transaction transaction, final String iid) {
+        public Remote(Grakn.Transaction transaction, String iid) {
             super(transaction, iid);
         }
 
-        public static RelationImpl.Remote of(final Grakn.Transaction transaction, final ConceptProto.Thing protoThing) {
+        public static RelationImpl.Remote of(Grakn.Transaction transaction, ConceptProto.Thing protoThing) {
             return new RelationImpl.Remote(transaction, Bytes.bytesToHexString(protoThing.getIid().toByteArray()));
         }
 
         @Override
-        public RelationImpl.Remote asRemote(final Grakn.Transaction transaction) {
+        public RelationImpl.Remote asRemote(Grakn.Transaction transaction) {
             return new RelationImpl.Remote(transaction, getIID());
         }
 
@@ -115,7 +115,7 @@ public class RelationImpl extends ThingImpl implements Relation {
         }
 
         @Override
-        public Stream<ThingImpl> getPlayers(final RoleType... roleTypes) {
+        public Stream<ThingImpl> getPlayers(RoleType... roleTypes) {
             return stream(
                     ConceptProto.Thing.Req.newBuilder().setRelationGetPlayersReq(
                             GetPlayers.Req.newBuilder().addAllRoleTypes(types(Arrays.asList(roleTypes)))),
@@ -123,13 +123,13 @@ public class RelationImpl extends ThingImpl implements Relation {
         }
 
         @Override
-        public void addPlayer(final RoleType roleType, final Thing player) {
+        public void addPlayer(RoleType roleType, Thing player) {
             execute(ConceptProto.Thing.Req.newBuilder().setRelationAddPlayerReq(
                     AddPlayer.Req.newBuilder().setRoleType(type(roleType)).setPlayer(thing(player))));
         }
 
         @Override
-        public void removePlayer(final RoleType roleType, final Thing player) {
+        public void removePlayer(RoleType roleType, Thing player) {
             execute(ConceptProto.Thing.Req.newBuilder().setRelationRemovePlayerReq(
                     RemovePlayer.Req.newBuilder().setRoleType(type(roleType)).setPlayer(thing(player))));
         }

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -61,12 +61,12 @@ public abstract class ThingImpl implements Thing {
     // In 1.8 it was in a "pre-filled response" in ConceptProto.Concept, which was confusing as it was
     // not actually prefilled when using the Concept API - only when using the Query API.
 
-    ThingImpl(final String iid) {
+    ThingImpl(String iid) {
         if (iid == null || iid.isEmpty()) throw new GraknClientException(MISSING_IID);
         this.iid = iid;
     }
 
-    public static ThingImpl of(final ConceptProto.Thing thingProto) {
+    public static ThingImpl of(ConceptProto.Thing thingProto) {
         switch (thingProto.getEncoding()) {
             case ENTITY:
                 return EntityImpl.of(thingProto);
@@ -140,7 +140,7 @@ public abstract class ThingImpl implements Thing {
         private final String iid;
         private final int hash;
 
-        Remote(final Grakn.Transaction transaction, final String iid) {
+        Remote(Grakn.Transaction transaction, String iid) {
             if (transaction == null) throw new GraknClientException(MISSING_TRANSACTION);
             this.rpcTransaction = (RPCTransaction) transaction;
             if (iid == null || iid.isEmpty()) throw new GraknClientException(MISSING_IID);
@@ -148,7 +148,7 @@ public abstract class ThingImpl implements Thing {
             this.hash = Objects.hash(this.rpcTransaction, this.getIID());
         }
 
-        public static ThingImpl.Remote of(final Grakn.Transaction transaction, final ConceptProto.Thing protoThing) {
+        public static ThingImpl.Remote of(Grakn.Transaction transaction, ConceptProto.Thing protoThing) {
 
             switch (protoThing.getEncoding()) {
                 case ENTITY:
@@ -231,7 +231,7 @@ public abstract class ThingImpl implements Thing {
         }
 
         @Override
-        public final Stream<RelationImpl> getRelations(final RoleType... roleTypes) {
+        public final Stream<RelationImpl> getRelations(RoleType... roleTypes) {
             return stream(
                     ConceptProto.Thing.Req.newBuilder().setThingGetRelationsReq(
                             GetRelations.Req.newBuilder().addAllRoleTypes(types(Arrays.asList(roleTypes)))),
@@ -297,19 +297,19 @@ public abstract class ThingImpl implements Thing {
             return rpcTransaction;
         }
 
-        Stream<ThingImpl> stream(final ConceptProto.Thing.Req.Builder method, final Function<ConceptProto.Thing.Res, ConceptProto.Thing> thingGetter) {
+        Stream<ThingImpl> stream(ConceptProto.Thing.Req.Builder method, Function<ConceptProto.Thing.Res, ConceptProto.Thing> thingGetter) {
             final TransactionProto.Transaction.Req.Builder request = TransactionProto.Transaction.Req.newBuilder()
                     .setThingReq(method.setIid(iid(iid)));
             return rpcTransaction.stream(request, res -> ThingImpl.of(thingGetter.apply(res.getThingRes())));
         }
 
-        Stream<TypeImpl> typeStream(final ConceptProto.Thing.Req.Builder method, final Function<ConceptProto.Thing.Res, ConceptProto.Type> typeGetter) {
+        Stream<TypeImpl> typeStream(ConceptProto.Thing.Req.Builder method, Function<ConceptProto.Thing.Res, ConceptProto.Type> typeGetter) {
             final TransactionProto.Transaction.Req.Builder request = TransactionProto.Transaction.Req.newBuilder()
                     .setThingReq(method.setIid(iid(iid)));
             return rpcTransaction.stream(request, res -> TypeImpl.of(typeGetter.apply(res.getThingRes())));
         }
 
-        ConceptProto.Thing.Res execute(final ConceptProto.Thing.Req.Builder method) {
+        ConceptProto.Thing.Res execute(ConceptProto.Thing.Req.Builder method) {
             final TransactionProto.Transaction.Req.Builder request = TransactionProto.Transaction.Req.newBuilder()
                     .setThingReq(method.setIid(iid(iid)));
             return rpcTransaction.execute(request).getThingRes();

--- a/concept/type/AttributeType.java
+++ b/concept/type/AttributeType.java
@@ -69,7 +69,7 @@ public interface AttributeType extends ThingType {
         }
 
         public static ValueType of(Class<?> valueClass) {
-            for (final ValueType t : ValueType.values()) {
+            for (ValueType t : ValueType.values()) {
                 if (t.valueClass == valueClass) {
                     return t;
                 }

--- a/concept/type/impl/AttributeTypeImpl.java
+++ b/concept/type/impl/AttributeTypeImpl.java
@@ -39,7 +39,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
     private static final java.lang.String ROOT_LABEL = "attribute";
 
-    AttributeTypeImpl(final java.lang.String label, final boolean isRoot) {
+    AttributeTypeImpl(java.lang.String label, boolean isRoot) {
         super(label, isRoot);
     }
 
@@ -75,7 +75,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
     }
 
     @Override
-    public AttributeTypeImpl.Remote asRemote(final Grakn.Transaction transaction) {
+    public AttributeTypeImpl.Remote asRemote(Grakn.Transaction transaction) {
         return new AttributeTypeImpl.Remote(transaction, getLabel(), isRoot());
     }
 
@@ -125,7 +125,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
     }
 
     @Override
-    public boolean equals(final Object o) {
+    public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof AttributeTypeImpl)) return false;
         // We do the above, as opposed to checking if (object == null || getClass() != object.getClass())
@@ -139,7 +139,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
     public static class Remote extends ThingTypeImpl.Remote implements AttributeType.Remote {
 
-        Remote(final Grakn.Transaction transaction, final java.lang.String label, final boolean isRoot) {
+        Remote(Grakn.Transaction transaction, java.lang.String label, boolean isRoot) {
             super(transaction, label, isRoot);
         }
 
@@ -175,11 +175,11 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
         }
 
         @Override
-        public AttributeTypeImpl.Remote asRemote(final Grakn.Transaction transaction) {
+        public AttributeTypeImpl.Remote asRemote(Grakn.Transaction transaction) {
             return new AttributeTypeImpl.Remote(transaction, getLabel(), isRoot());
         }
 
-        public final void setSupertype(final AttributeType type) {
+        public final void setSupertype(AttributeType type) {
             this.setSupertypeExecute(type);
         }
 
@@ -217,7 +217,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
         }
 
         @Override
-        public Stream<ThingTypeImpl> getOwners(final boolean onlyKey) {
+        public Stream<ThingTypeImpl> getOwners(boolean onlyKey) {
             final ConceptProto.Type.Req.Builder method = ConceptProto.Type.Req.newBuilder()
                     .setAttributeTypeGetOwnersReq(ConceptProto.AttributeType.GetOwners.Req.newBuilder()
                             .setOnlyKey(onlyKey));
@@ -225,7 +225,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
             return stream(method, res -> res.getAttributeTypeGetOwnersRes().getOwner()).map(TypeImpl::asThingType);
         }
 
-        protected final AttributeImpl<?> put(final Object value) {
+        protected final AttributeImpl<?> put(Object value) {
             final ConceptProto.Type.Req.Builder method = ConceptProto.Type.Req.newBuilder()
                     .setAttributeTypePutReq(ConceptProto.AttributeType.Put.Req.newBuilder()
                             .setValue(attributeValue(value)));
@@ -233,7 +233,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
         }
 
         @Nullable
-        protected final AttributeImpl<?> get(final Object value) {
+        protected final AttributeImpl<?> get(Object value) {
             final ConceptProto.Type.Req.Builder method = ConceptProto.Type.Req.newBuilder()
                     .setAttributeTypeGetReq(ConceptProto.AttributeType.Get.Req.newBuilder()
                             .setValue(attributeValue(value)));
@@ -293,7 +293,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
         }
 
         @Override
-        public boolean equals(final Object o) {
+        public boolean equals(Object o) {
             if (this == o) return true;
             if (!(o instanceof AttributeTypeImpl.Remote)) return false;
             // We do the above, as opposed to checking if (object == null || getClass() != object.getClass())
@@ -308,7 +308,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
     public static class Boolean extends AttributeTypeImpl implements AttributeType.Boolean {
 
-        Boolean(final java.lang.String label, final boolean isRoot) {
+        Boolean(java.lang.String label, boolean isRoot) {
             super(label, isRoot);
         }
 
@@ -318,7 +318,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
         }
 
         @Override
-        public AttributeTypeImpl.Boolean.Remote asRemote(final Grakn.Transaction transaction) {
+        public AttributeTypeImpl.Boolean.Remote asRemote(Grakn.Transaction transaction) {
             return new AttributeTypeImpl.Boolean.Remote(transaction, getLabel(), isRoot());
         }
 
@@ -329,7 +329,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
         public static class Remote extends AttributeTypeImpl.Remote implements AttributeType.Boolean.Remote {
 
-            public Remote(final Grakn.Transaction transaction, final java.lang.String label, final boolean isRoot) {
+            public Remote(Grakn.Transaction transaction, java.lang.String label, boolean isRoot) {
                 super(transaction, label, isRoot);
             }
 
@@ -339,7 +339,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
             }
 
             @Override
-            public AttributeTypeImpl.Boolean.Remote asRemote(final Grakn.Transaction transaction) {
+            public AttributeTypeImpl.Boolean.Remote asRemote(Grakn.Transaction transaction) {
                 return new AttributeTypeImpl.Boolean.Remote(transaction, getLabel(), isRoot());
             }
 
@@ -364,18 +364,18 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
             }
 
             @Override
-            public final void setSupertype(final AttributeType.Boolean type) {
+            public final void setSupertype(AttributeType.Boolean type) {
                 super.setSupertype(type);
             }
 
             @Override
-            public final AttributeImpl.Boolean put(final boolean value) {
+            public final AttributeImpl.Boolean put(boolean value) {
                 return super.put(value).asBoolean();
             }
 
             @Nullable
             @Override
-            public final AttributeImpl.Boolean get(final boolean value) {
+            public final AttributeImpl.Boolean get(boolean value) {
                 final AttributeImpl<?> attr = super.get(value);
                 return attr != null ? attr.asBoolean() : null;
             }
@@ -389,7 +389,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
     public static class Long extends AttributeTypeImpl implements AttributeType.Long {
 
-        Long(final java.lang.String label, final boolean isRoot) {
+        Long(java.lang.String label, boolean isRoot) {
             super(label, isRoot);
         }
 
@@ -399,7 +399,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
         }
 
         @Override
-        public AttributeTypeImpl.Long.Remote asRemote(final Grakn.Transaction transaction) {
+        public AttributeTypeImpl.Long.Remote asRemote(Grakn.Transaction transaction) {
             return new AttributeTypeImpl.Long.Remote(transaction, getLabel(), isRoot());
         }
 
@@ -410,7 +410,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
         public static class Remote extends AttributeTypeImpl.Remote implements AttributeType.Long.Remote {
 
-            public Remote(final Grakn.Transaction transaction, final java.lang.String label, final boolean isRoot) {
+            public Remote(Grakn.Transaction transaction, java.lang.String label, boolean isRoot) {
                 super(transaction, label, isRoot);
             }
 
@@ -420,7 +420,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
             }
 
             @Override
-            public AttributeTypeImpl.Long.Remote asRemote(final Grakn.Transaction transaction) {
+            public AttributeTypeImpl.Long.Remote asRemote(Grakn.Transaction transaction) {
                 return new AttributeTypeImpl.Long.Remote(transaction, getLabel(), isRoot());
             }
 
@@ -445,18 +445,18 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
             }
 
             @Override
-            public final void setSupertype(final AttributeType.Long type) {
+            public final void setSupertype(AttributeType.Long type) {
                 super.setSupertype(type);
             }
 
             @Override
-            public final AttributeImpl.Long put(final long value) {
+            public final AttributeImpl.Long put(long value) {
                 return super.put(value).asLong();
             }
 
             @Nullable
             @Override
-            public final AttributeImpl.Long get(final long value) {
+            public final AttributeImpl.Long get(long value) {
                 final AttributeImpl<?> attr = super.get(value);
                 return attr != null ? attr.asLong() : null;
             }
@@ -470,7 +470,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
     public static class Double extends AttributeTypeImpl implements AttributeType.Double {
 
-        Double(final java.lang.String label, final boolean isRoot) {
+        Double(java.lang.String label, boolean isRoot) {
             super(label, isRoot);
         }
 
@@ -480,7 +480,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
         }
 
         @Override
-        public AttributeTypeImpl.Double.Remote asRemote(final Grakn.Transaction transaction) {
+        public AttributeTypeImpl.Double.Remote asRemote(Grakn.Transaction transaction) {
             return new AttributeTypeImpl.Double.Remote(transaction, getLabel(), isRoot());
         }
 
@@ -491,7 +491,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
         public static class Remote extends AttributeTypeImpl.Remote implements AttributeType.Double.Remote {
 
-            public Remote(final Grakn.Transaction transaction, final java.lang.String label, final boolean isRoot) {
+            public Remote(Grakn.Transaction transaction, java.lang.String label, boolean isRoot) {
                 super(transaction, label, isRoot);
             }
 
@@ -501,7 +501,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
             }
 
             @Override
-            public AttributeTypeImpl.Double.Remote asRemote(final Grakn.Transaction transaction) {
+            public AttributeTypeImpl.Double.Remote asRemote(Grakn.Transaction transaction) {
                 return new AttributeTypeImpl.Double.Remote(transaction, getLabel(), isRoot());
             }
 
@@ -526,18 +526,18 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
             }
 
             @Override
-            public final void setSupertype(final AttributeType.Double type) {
+            public final void setSupertype(AttributeType.Double type) {
                 super.setSupertype(type);
             }
 
             @Override
-            public final AttributeImpl.Double put(final double value) {
+            public final AttributeImpl.Double put(double value) {
                 return super.put(value).asDouble();
             }
 
             @Nullable
             @Override
-            public final AttributeImpl.Double get(final double value) {
+            public final AttributeImpl.Double get(double value) {
                 final AttributeImpl<?> attr = super.get(value);
                 return attr != null ? attr.asDouble() : null;
             }
@@ -551,7 +551,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
     public static class String extends AttributeTypeImpl implements AttributeType.String {
 
-        String(final java.lang.String label, final boolean isRoot) {
+        String(java.lang.String label, boolean isRoot) {
             super(label, isRoot);
         }
 
@@ -561,7 +561,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
         }
 
         @Override
-        public AttributeTypeImpl.String.Remote asRemote(final Grakn.Transaction transaction) {
+        public AttributeTypeImpl.String.Remote asRemote(Grakn.Transaction transaction) {
             return new AttributeTypeImpl.String.Remote(transaction, getLabel(), isRoot());
         }
 
@@ -572,7 +572,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
         public static class Remote extends AttributeTypeImpl.Remote implements AttributeType.String.Remote {
 
-            public Remote(final Grakn.Transaction transaction, final java.lang.String label, final boolean isRoot) {
+            public Remote(Grakn.Transaction transaction, java.lang.String label, boolean isRoot) {
                 super(transaction, label, isRoot);
             }
 
@@ -582,7 +582,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
             }
 
             @Override
-            public AttributeTypeImpl.String.Remote asRemote(final Grakn.Transaction transaction) {
+            public AttributeTypeImpl.String.Remote asRemote(Grakn.Transaction transaction) {
                 return new AttributeTypeImpl.String.Remote(transaction, getLabel(), isRoot());
             }
 
@@ -607,18 +607,18 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
             }
 
             @Override
-            public final void setSupertype(final AttributeType.String type) {
+            public final void setSupertype(AttributeType.String type) {
                 super.setSupertype(type);
             }
 
             @Override
-            public final AttributeImpl.String put(final java.lang.String value) {
+            public final AttributeImpl.String put(java.lang.String value) {
                 return super.put(value).asString();
             }
 
             @Nullable
             @Override
-            public final AttributeImpl.String get(final java.lang.String value) {
+            public final AttributeImpl.String get(java.lang.String value) {
                 final AttributeImpl<?> attr = super.get(value);
                 return attr != null ? attr.asString() : null;
             }
@@ -650,7 +650,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
     public static class DateTime extends AttributeTypeImpl implements AttributeType.DateTime {
 
-        DateTime(final java.lang.String label, final boolean isRoot) {
+        DateTime(java.lang.String label, boolean isRoot) {
             super(label, isRoot);
         }
 
@@ -660,7 +660,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
         }
 
         @Override
-        public AttributeTypeImpl.DateTime.Remote asRemote(final Grakn.Transaction transaction) {
+        public AttributeTypeImpl.DateTime.Remote asRemote(Grakn.Transaction transaction) {
             return new AttributeTypeImpl.DateTime.Remote(transaction, getLabel(), isRoot());
         }
 
@@ -671,7 +671,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
         public static class Remote extends AttributeTypeImpl.Remote implements AttributeType.DateTime.Remote {
 
-            public Remote(final Grakn.Transaction transaction, final java.lang.String label, final boolean isRoot) {
+            public Remote(Grakn.Transaction transaction, java.lang.String label, boolean isRoot) {
                 super(transaction, label, isRoot);
             }
 
@@ -706,18 +706,18 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
             }
 
             @Override
-            public final void setSupertype(final AttributeType.DateTime type) {
+            public final void setSupertype(AttributeType.DateTime type) {
                 super.setSupertype(type);
             }
 
             @Override
-            public final AttributeImpl.DateTime put(final LocalDateTime value) {
+            public final AttributeImpl.DateTime put(LocalDateTime value) {
                 return super.put(value).asDateTime();
             }
 
             @Nullable
             @Override
-            public final AttributeImpl.DateTime get(final LocalDateTime value) {
+            public final AttributeImpl.DateTime get(LocalDateTime value) {
                 final AttributeImpl<?> attr = super.get(value);
                 return attr != null ? attr.asDateTime() : null;
             }

--- a/concept/type/impl/EntityTypeImpl.java
+++ b/concept/type/impl/EntityTypeImpl.java
@@ -30,16 +30,16 @@ import java.util.stream.Stream;
 
 public class EntityTypeImpl extends ThingTypeImpl implements EntityType {
 
-    public EntityTypeImpl(final String label, final boolean isRoot) {
+    public EntityTypeImpl(String label, boolean isRoot) {
         super(label, isRoot);
     }
 
-    public static EntityTypeImpl of(final ConceptProto.Type typeProto) {
+    public static EntityTypeImpl of(ConceptProto.Type typeProto) {
         return new EntityTypeImpl(typeProto.getLabel(), typeProto.getRoot());
     }
 
     @Override
-    public EntityTypeImpl.Remote asRemote(final Grakn.Transaction transaction) {
+    public EntityTypeImpl.Remote asRemote(Grakn.Transaction transaction) {
         return new EntityTypeImpl.Remote(transaction, getLabel(), isRoot());
     }
 
@@ -50,16 +50,16 @@ public class EntityTypeImpl extends ThingTypeImpl implements EntityType {
 
     public static class Remote extends ThingTypeImpl.Remote implements EntityType.Remote {
 
-        public Remote(final Grakn.Transaction transaction, final String label, final boolean isRoot) {
+        public Remote(Grakn.Transaction transaction, String label, boolean isRoot) {
             super(transaction, label, isRoot);
         }
 
-        public static EntityTypeImpl.Remote of(final Grakn.Transaction transaction, final ConceptProto.Type proto) {
+        public static EntityTypeImpl.Remote of(Grakn.Transaction transaction, ConceptProto.Type proto) {
             return new EntityTypeImpl.Remote(transaction, proto.getLabel(), proto.getRoot());
         }
 
         @Override
-        public final void setSupertype(final EntityType superEntityType) {
+        public final void setSupertype(EntityType superEntityType) {
             this.setSupertypeExecute(superEntityType);
         }
 
@@ -74,7 +74,7 @@ public class EntityTypeImpl extends ThingTypeImpl implements EntityType {
         }
 
         @Override
-        public EntityTypeImpl.Remote asRemote(final Grakn.Transaction transaction) {
+        public EntityTypeImpl.Remote asRemote(Grakn.Transaction transaction) {
             return new EntityTypeImpl.Remote(transaction, getLabel(), isRoot());
         }
 

--- a/concept/type/impl/RelationTypeImpl.java
+++ b/concept/type/impl/RelationTypeImpl.java
@@ -33,16 +33,16 @@ import java.util.stream.Stream;
 
 public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
 
-    public RelationTypeImpl(final String label, final boolean isRoot) {
+    public RelationTypeImpl(String label, boolean isRoot) {
         super(label, isRoot);
     }
 
-    public static RelationTypeImpl of(final ConceptProto.Type typeProto) {
+    public static RelationTypeImpl of(ConceptProto.Type typeProto) {
         return new RelationTypeImpl(typeProto.getLabel(), typeProto.getRoot());
     }
 
     @Override
-    public RelationTypeImpl.Remote asRemote(final Grakn.Transaction transaction) {
+    public RelationTypeImpl.Remote asRemote(Grakn.Transaction transaction) {
         return new RelationTypeImpl.Remote(transaction, getLabel(), isRoot());
     }
 
@@ -53,11 +53,11 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
 
     public static class Remote extends ThingTypeImpl.Remote implements RelationType.Remote {
 
-        public Remote(final Grakn.Transaction transaction, final String label, final boolean isRoot) {
+        public Remote(Grakn.Transaction transaction, String label, boolean isRoot) {
             super(transaction, label, isRoot);
         }
 
-        public static RelationTypeImpl.Remote of(final Grakn.Transaction transaction, final ConceptProto.Type proto) {
+        public static RelationTypeImpl.Remote of(Grakn.Transaction transaction, ConceptProto.Type proto) {
             return new RelationTypeImpl.Remote(transaction, proto.getLabel(), proto.getRoot());
         }
 
@@ -87,7 +87,7 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
         }
 
         @Override
-        public final void setSupertype(final RelationType type) {
+        public final void setSupertype(RelationType type) {
             this.setSupertypeExecute(type);
         }
 
@@ -99,7 +99,7 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
         }
 
         @Override
-        public final RoleTypeImpl getRelates(final String roleLabel) {
+        public final RoleTypeImpl getRelates(String roleLabel) {
             final ConceptProto.Type.Req.Builder method = ConceptProto.Type.Req.newBuilder().setRelationTypeGetRelatesForRoleLabelReq(
                     GetRelatesForRoleLabel.Req.newBuilder().setLabel(roleLabel));
             final GetRelatesForRoleLabel.Res res = execute(method).getRelationTypeGetRelatesForRoleLabelRes();
@@ -117,13 +117,13 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
         }
 
         @Override
-        public final void setRelates(final String roleLabel) {
+        public final void setRelates(String roleLabel) {
             execute(ConceptProto.Type.Req.newBuilder().setRelationTypeSetRelatesReq(
                     SetRelates.Req.newBuilder().setLabel(roleLabel)));
         }
 
         @Override
-        public final void setRelates(final String roleLabel, final String overriddenLabel) {
+        public final void setRelates(String roleLabel, String overriddenLabel) {
             execute(ConceptProto.Type.Req.newBuilder().setRelationTypeSetRelatesReq(
                     SetRelates.Req.newBuilder().setLabel(roleLabel).setOverriddenLabel(overriddenLabel)));
         }

--- a/concept/type/impl/RoleTypeImpl.java
+++ b/concept/type/impl/RoleTypeImpl.java
@@ -35,13 +35,13 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
     private final String scope;
     private final int hash;
 
-    public RoleTypeImpl(final String label, final String scope, final boolean root) {
+    public RoleTypeImpl(String label, String scope, boolean root) {
         super(label, root);
         this.scope = scope;
         this.hash = Objects.hash(this.scope, label);
     }
 
-    public static RoleTypeImpl of(final ConceptProto.Type typeProto) {
+    public static RoleTypeImpl of(ConceptProto.Type typeProto) {
         return new RoleTypeImpl(typeProto.getLabel(), typeProto.getScope(), typeProto.getRoot());
     }
 
@@ -66,7 +66,7 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
     }
 
     @Override
-    public boolean equals(final Object o) {
+    public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
@@ -84,14 +84,14 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
         private final String scope;
         private final int hash;
 
-        public Remote(final Grakn.Transaction transaction, final String label,
-                      final String scope, final boolean isRoot) {
+        public Remote(Grakn.Transaction transaction, String label,
+                      String scope, boolean isRoot) {
             super(transaction, label, isRoot);
             this.scope = scope;
             this.hash = Objects.hash(transaction, label, scope);
         }
 
-        public static RoleTypeImpl.Remote of(final Grakn.Transaction transaction, final ConceptProto.Type proto) {
+        public static RoleTypeImpl.Remote of(Grakn.Transaction transaction, ConceptProto.Type proto) {
             return new RoleTypeImpl.Remote(transaction, proto.getLabel(), proto.getScope(), proto.getRoot());
         }
 
@@ -117,7 +117,7 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
         }
 
         @Override
-        public RoleType.Remote asRemote(final Grakn.Transaction transaction) {
+        public RoleType.Remote asRemote(Grakn.Transaction transaction) {
             return new RoleTypeImpl.Remote(transaction, getLabel(), getScope(), isRoot());
         }
 
@@ -153,12 +153,12 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
         }
 
         @Override
-        Stream<TypeImpl> stream(final ConceptProto.Type.Req.Builder method, final Function<ConceptProto.Type.Res, ConceptProto.Type> typeGetter) {
+        Stream<TypeImpl> stream(ConceptProto.Type.Req.Builder method, Function<ConceptProto.Type.Res, ConceptProto.Type> typeGetter) {
             return super.stream(method.setScope(scope), typeGetter);
         }
 
         @Override
-        ConceptProto.Type.Res execute(final ConceptProto.Type.Req.Builder method) {
+        ConceptProto.Type.Res execute(ConceptProto.Type.Req.Builder method) {
             return super.execute(method.setScope(scope));
         }
 

--- a/concept/type/impl/RuleImpl.java
+++ b/concept/type/impl/RuleImpl.java
@@ -43,7 +43,7 @@ public class RuleImpl implements Rule {
     private final ThingVariable<?> then;
     private final int hash;
 
-    RuleImpl(final String label, final Conjunction<? extends Pattern> when, final ThingVariable<?> then) {
+    RuleImpl(String label, Conjunction<? extends Pattern> when, ThingVariable<?> then) {
         if (label == null || label.isEmpty()) throw new GraknClientException(MISSING_LABEL);
         this.label = label;
         this.when = when;
@@ -51,7 +51,7 @@ public class RuleImpl implements Rule {
         this.hash = Objects.hash(this.label);
     }
 
-    public static RuleImpl of(final ConceptProto.Rule ruleProto) {
+    public static RuleImpl of(ConceptProto.Rule ruleProto) {
         return new RuleImpl(ruleProto.getLabel(), Graql.and(Graql.parsePatterns(ruleProto.getWhen())), Graql.parseVariable(ruleProto.getThen()).asThing());
     }
 
@@ -71,7 +71,7 @@ public class RuleImpl implements Rule {
     }
 
     @Override
-    public RuleImpl.Remote asRemote(final Grakn.Transaction transaction) {
+    public RuleImpl.Remote asRemote(Grakn.Transaction transaction) {
         return new RuleImpl.Remote(transaction, getLabel(), getWhen(), getThen());
     }
 
@@ -86,7 +86,7 @@ public class RuleImpl implements Rule {
     }
 
     @Override
-    public boolean equals(final Object o) {
+    public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
@@ -107,7 +107,7 @@ public class RuleImpl implements Rule {
         private final ThingVariable<?> then;
         private final int hash;
 
-        public Remote(final Grakn.Transaction transaction, final String label, final Conjunction<? extends Pattern> when, final ThingVariable<?> then) {
+        public Remote(Grakn.Transaction transaction, String label, Conjunction<? extends Pattern> when, ThingVariable<?> then) {
             if (transaction == null) throw new GraknClientException(MISSING_TRANSACTION);
             if (label == null || label.isEmpty()) throw new GraknClientException(MISSING_LABEL);
             this.rpcTransaction = (RPCTransaction) transaction;
@@ -117,7 +117,7 @@ public class RuleImpl implements Rule {
             this.hash = Objects.hash(transaction, label);
         }
 
-        public static RuleImpl.Remote of(final Grakn.Transaction transaction, final ConceptProto.Rule ruleProto) {
+        public static RuleImpl.Remote of(Grakn.Transaction transaction, ConceptProto.Rule ruleProto) {
             return new RuleImpl.Remote(transaction, ruleProto.getLabel(), Graql.and(Graql.parsePatterns(ruleProto.getWhen())), Graql.parseVariable(ruleProto.getThen()).asThing());
         }
 
@@ -137,7 +137,7 @@ public class RuleImpl implements Rule {
         }
 
         @Override
-        public void setLabel(final String label) {
+        public void setLabel(String label) {
             execute(ConceptProto.Rule.Req.newBuilder().setRuleSetLabelReq(ConceptProto.Rule.SetLabel.Req.newBuilder().setLabel(label)));
         }
 
@@ -152,7 +152,7 @@ public class RuleImpl implements Rule {
         }
 
         @Override
-        public Remote asRemote(final Grakn.Transaction transaction) {
+        public Remote asRemote(Grakn.Transaction transaction) {
             return new RuleImpl.Remote(transaction, getLabel(), getWhen(), getThen());
         }
 
@@ -167,7 +167,7 @@ public class RuleImpl implements Rule {
         }
 
         @Override
-        public boolean equals(final Object o) {
+        public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
 
@@ -184,7 +184,7 @@ public class RuleImpl implements Rule {
             return rpcTransaction;
         }
 
-        ConceptProto.Rule.Res execute(final ConceptProto.Rule.Req.Builder method) {
+        ConceptProto.Rule.Res execute(ConceptProto.Rule.Req.Builder method) {
             final TransactionProto.Transaction.Req.Builder request = TransactionProto.Transaction.Req.newBuilder()
                     .setRuleReq(method.setLabel(label));
             return rpcTransaction.execute(request).getRuleRes();

--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -46,11 +46,11 @@ import static grakn.client.concept.proto.ConceptProtoBuilder.valueType;
 
 public class ThingTypeImpl extends TypeImpl implements ThingType {
 
-    ThingTypeImpl(final String label, final boolean isRoot) {
+    ThingTypeImpl(String label, boolean isRoot) {
         super(label, isRoot);
     }
 
-    public static ThingTypeImpl of(final ConceptProto.Type typeProto) {
+    public static ThingTypeImpl of(ConceptProto.Type typeProto) {
         switch (typeProto.getEncoding()) {
             case ENTITY_TYPE:
                 return EntityTypeImpl.of(typeProto);
@@ -68,7 +68,7 @@ public class ThingTypeImpl extends TypeImpl implements ThingType {
     }
 
     @Override
-    public ThingTypeImpl.Remote asRemote(final Grakn.Transaction transaction) {
+    public ThingTypeImpl.Remote asRemote(Grakn.Transaction transaction) {
         return new ThingTypeImpl.Remote(transaction, getLabel(), isRoot());
     }
 
@@ -79,11 +79,11 @@ public class ThingTypeImpl extends TypeImpl implements ThingType {
 
     public static class Remote extends TypeImpl.Remote implements ThingType.Remote {
 
-        Remote(final Grakn.Transaction transaction, final String label, final boolean isRoot) {
+        Remote(Grakn.Transaction transaction, String label, boolean isRoot) {
             super(transaction, label, isRoot);
         }
 
-        public static ThingTypeImpl.Remote of(final Grakn.Transaction transaction, final ConceptProto.Type type) {
+        public static ThingTypeImpl.Remote of(Grakn.Transaction transaction, ConceptProto.Type type) {
             return new ThingTypeImpl.Remote(transaction, type.getLabel(), type.getRoot());
         }
 
@@ -134,7 +134,7 @@ public class ThingTypeImpl extends TypeImpl implements ThingType {
         }
 
         @Override
-        public final Stream<AttributeTypeImpl> getOwns(final ValueType valueType, final boolean keysOnly) {
+        public final Stream<AttributeTypeImpl> getOwns(ValueType valueType, boolean keysOnly) {
             final GetOwns.Req.Builder req = GetOwns.Req.newBuilder().setKeysOnly(keysOnly);
             if (valueType != null) req.setValueType(valueType(valueType));
             return stream(
@@ -149,63 +149,63 @@ public class ThingTypeImpl extends TypeImpl implements ThingType {
         }
 
         @Override
-        public Stream<AttributeTypeImpl> getOwns(final ValueType valueType) {
+        public Stream<AttributeTypeImpl> getOwns(ValueType valueType) {
             return getOwns(valueType, false);
         }
 
         @Override
-        public Stream<AttributeTypeImpl> getOwns(final boolean keysOnly) {
+        public Stream<AttributeTypeImpl> getOwns(boolean keysOnly) {
             return getOwns(null, keysOnly);
         }
 
         @Override
-        public final void setOwns(final AttributeType attributeType, final AttributeType overriddenType, final boolean isKey) {
+        public final void setOwns(AttributeType attributeType, AttributeType overriddenType, boolean isKey) {
             final SetOwns.Req.Builder req = SetOwns.Req.newBuilder().setAttributeType(type(attributeType)).setIsKey(isKey);
             if (overriddenType != null) req.setOverriddenType(type(overriddenType));
             execute(ConceptProto.Type.Req.newBuilder().setThingTypeSetOwnsReq(req));
         }
 
         @Override
-        public void setOwns(final AttributeType attributeType, final AttributeType overriddenType) {
+        public void setOwns(AttributeType attributeType, AttributeType overriddenType) {
             setOwns(attributeType, overriddenType, false);
         }
 
         @Override
-        public void setOwns(final AttributeType attributeType, final boolean isKey) {
+        public void setOwns(AttributeType attributeType, boolean isKey) {
             setOwns(attributeType, null, isKey);
         }
 
         @Override
-        public void setOwns(final AttributeType attributeType) {
+        public void setOwns(AttributeType attributeType) {
             setOwns(attributeType, null, false);
         }
 
         @Override
-        public final void setPlays(final RoleType role) {
+        public final void setPlays(RoleType role) {
             execute(ConceptProto.Type.Req.newBuilder().setThingTypeSetPlaysReq(
                     SetPlays.Req.newBuilder().setRole(type(role))));
         }
 
         @Override
-        public final void setPlays(final RoleType role, final RoleType overriddenRole) {
+        public final void setPlays(RoleType role, RoleType overriddenRole) {
             execute(ConceptProto.Type.Req.newBuilder().setThingTypeSetPlaysReq(
                     SetPlays.Req.newBuilder().setRole(type(role)).setOverriddenRole(type(overriddenRole))));
         }
 
         @Override
-        public final void unsetOwns(final AttributeType attributeType) {
+        public final void unsetOwns(AttributeType attributeType) {
             execute(ConceptProto.Type.Req.newBuilder().setThingTypeUnsetOwnsReq(
                     UnsetOwns.Req.newBuilder().setAttributeType(type(attributeType))));
         }
 
         @Override
-        public final void unsetPlays(final RoleType role) {
+        public final void unsetPlays(RoleType role) {
             execute(ConceptProto.Type.Req.newBuilder().setThingTypeUnsetPlaysReq(
                     UnsetPlays.Req.newBuilder().setRole(type(role))));
         }
 
         @Override
-        public ThingTypeImpl.Remote asRemote(final Grakn.Transaction transaction) {
+        public ThingTypeImpl.Remote asRemote(Grakn.Transaction transaction) {
             return new ThingTypeImpl.Remote(transaction, getLabel(), isRoot());
         }
 

--- a/concept/type/impl/TypeImpl.java
+++ b/concept/type/impl/TypeImpl.java
@@ -52,14 +52,14 @@ public abstract class TypeImpl implements Type {
     private final boolean isRoot;
     private final int hash;
 
-    TypeImpl(final String label, final boolean isRoot) {
+    TypeImpl(String label, boolean isRoot) {
         if (label == null || label.isEmpty()) throw new GraknClientException(MISSING_LABEL);
         this.label = label;
         this.isRoot = isRoot;
         this.hash = Objects.hash(this.label);
     }
 
-    public static TypeImpl of(final ConceptProto.Type typeProto) {
+    public static TypeImpl of(ConceptProto.Type typeProto) {
         switch (typeProto.getEncoding()) {
             case ROLE_TYPE:
                 return RoleTypeImpl.of(typeProto);
@@ -126,7 +126,7 @@ public abstract class TypeImpl implements Type {
     }
 
     @Override
-    public boolean equals(final Object o) {
+    public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
@@ -146,7 +146,7 @@ public abstract class TypeImpl implements Type {
         private final boolean isRoot;
         private final int hash;
 
-        Remote(final Grakn.Transaction transaction, final String label, final boolean isRoot) {
+        Remote(Grakn.Transaction transaction, String label, boolean isRoot) {
             if (transaction == null) throw new GraknClientException(MISSING_TRANSACTION);
             if (label == null || label.isEmpty()) throw new GraknClientException(MISSING_LABEL);
             this.rpcTransaction = (RPCTransaction) transaction;
@@ -155,7 +155,7 @@ public abstract class TypeImpl implements Type {
             this.hash = Objects.hash(transaction, label);
         }
 
-        public static TypeImpl.Remote of(final Grakn.Transaction transaction, final ConceptProto.Type type) {
+        public static TypeImpl.Remote of(Grakn.Transaction transaction, ConceptProto.Type type) {
             switch (type.getEncoding()) {
                 case ENTITY_TYPE:
                     return EntityTypeImpl.Remote.of(transaction, type);
@@ -189,7 +189,7 @@ public abstract class TypeImpl implements Type {
         }
 
         @Override
-        public final void setLabel(final String label) {
+        public final void setLabel(String label) {
             execute(ConceptProto.Type.Req.newBuilder()
                     .setTypeSetLabelReq(ConceptProto.Type.SetLabel.Req.newBuilder().setLabel(label)));
         }
@@ -236,12 +236,12 @@ public abstract class TypeImpl implements Type {
             throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(RoleType.class)));
         }
 
-        void setSupertypeExecute(final Type type) {
+        void setSupertypeExecute(Type type) {
             execute(ConceptProto.Type.Req.newBuilder().setTypeSetSupertypeReq(SetSupertype.Req.newBuilder().setType(type(type))));
         }
 
         @Nullable
-        <TYPE extends TypeImpl> TYPE getSupertypeExecute(final Function<TypeImpl, TYPE> typeConstructor) {
+        <TYPE extends TypeImpl> TYPE getSupertypeExecute(Function<TypeImpl, TYPE> typeConstructor) {
             final ConceptProto.Type.GetSupertype.Res response = execute(ConceptProto.Type.Req.newBuilder()
                     .setTypeGetSupertypeReq(ConceptProto.Type.GetSupertype.Req.getDefaultInstance()))
                     .getTypeGetSupertypeRes();
@@ -255,13 +255,13 @@ public abstract class TypeImpl implements Type {
             }
         }
 
-        <TYPE extends TypeImpl> Stream<TYPE> getSupertypes(final Function<TypeImpl, TYPE> typeConstructor) {
+        <TYPE extends TypeImpl> Stream<TYPE> getSupertypes(Function<TypeImpl, TYPE> typeConstructor) {
             final ConceptProto.Type.Req.Builder method = ConceptProto.Type.Req.newBuilder()
                     .setTypeGetSupertypesReq(ConceptProto.Type.GetSupertypes.Req.getDefaultInstance());
             return stream(method, res -> res.getTypeGetSupertypesRes().getType()).map(typeConstructor);
         }
 
-        <TYPE extends TypeImpl> Stream<TYPE> getSubtypes(final Function<TypeImpl, TYPE> typeConstructor) {
+        <TYPE extends TypeImpl> Stream<TYPE> getSubtypes(Function<TypeImpl, TYPE> typeConstructor) {
             final ConceptProto.Type.Req.Builder method = ConceptProto.Type.Req.newBuilder()
                     .setTypeGetSubtypesReq(ConceptProto.Type.GetSubtypes.Req.getDefaultInstance());
             return stream(method, res -> res.getTypeGetSubtypesRes().getType()).map(typeConstructor);
@@ -281,19 +281,19 @@ public abstract class TypeImpl implements Type {
             return rpcTransaction;
         }
 
-        Stream<TypeImpl> stream(final ConceptProto.Type.Req.Builder method, final Function<ConceptProto.Type.Res, ConceptProto.Type> typeGetter) {
+        Stream<TypeImpl> stream(ConceptProto.Type.Req.Builder method, Function<ConceptProto.Type.Res, ConceptProto.Type> typeGetter) {
             final TransactionProto.Transaction.Req.Builder request = TransactionProto.Transaction.Req.newBuilder()
                     .setTypeReq(method.setLabel(label));
             return rpcTransaction.stream(request, res -> TypeImpl.of(typeGetter.apply(res.getTypeRes())));
         }
 
-        Stream<ThingImpl> thingStream(final ConceptProto.Type.Req.Builder method, final Function<ConceptProto.Type.Res, ConceptProto.Thing> thingGetter) {
+        Stream<ThingImpl> thingStream(ConceptProto.Type.Req.Builder method, Function<ConceptProto.Type.Res, ConceptProto.Thing> thingGetter) {
             final TransactionProto.Transaction.Req.Builder request = TransactionProto.Transaction.Req.newBuilder()
                     .setTypeReq(method.setLabel(label));
             return rpcTransaction.stream(request, res -> ThingImpl.of(thingGetter.apply(res.getTypeRes())));
         }
 
-        ConceptProto.Type.Res execute(final ConceptProto.Type.Req.Builder method) {
+        ConceptProto.Type.Res execute(ConceptProto.Type.Req.Builder method) {
             final TransactionProto.Transaction.Req.Builder request = TransactionProto.Transaction.Req.newBuilder()
                     .setTypeReq(method.setLabel(label));
             return rpcTransaction.execute(request).getTypeRes();

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -23,14 +23,14 @@ def graknlabs_graql():
     git_repository(
         name = "graknlabs_graql",
         remote = "https://github.com/graknlabs/graql",
-        commit = "6015870b95c259dfd2492c42e6c680f5b98620ce" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+        commit = "fd5b2b6d3f970b32384f719549ecf2c4d8caf231" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
     )
 
 def graknlabs_common():
     git_repository(
         name = "graknlabs_common",
-        remote = "https://github.com/alexjpwalker/common",
-        commit = "67459a4d0bece9a0ef366aa2d2dc03652268085a" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
+        remote = "https://github.com/graknlabs/common",
+        commit = "39664389f458124c14fa307ab78619d17280b73d" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 
 def graknlabs_bazel_distribution():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -29,8 +29,8 @@ def graknlabs_graql():
 def graknlabs_common():
     git_repository(
         name = "graknlabs_common",
-        remote = "https://github.com/graknlabs/common",
-        commit = "f11a819c6d8373539949363a9f6734eaa1649bf3" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
+        remote = "https://github.com/alexjpwalker/common",
+        commit = "67459a4d0bece9a0ef366aa2d2dc03652268085a" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 
 def graknlabs_bazel_distribution():

--- a/query/QueryManager.java
+++ b/query/QueryManager.java
@@ -40,62 +40,62 @@ public final class QueryManager {
 
     private final RPCTransaction rpcTransaction;
 
-    public QueryManager(final RPCTransaction rpcTransaction) {
+    public QueryManager(RPCTransaction rpcTransaction) {
         this.rpcTransaction = rpcTransaction;
     }
 
-    public Stream<ConceptMap> match(final GraqlMatch query) {
+    public Stream<ConceptMap> match(GraqlMatch query) {
         return match(query, new GraknOptions());
     }
 
-    public Stream<ConceptMap> match(final GraqlMatch query, final GraknOptions options) {
+    public Stream<ConceptMap> match(GraqlMatch query, GraknOptions options) {
         final QueryProto.Query.Req.Builder request = QueryProto.Query.Req.newBuilder().setMatchReq(
                 QueryProto.Graql.Match.Req.newBuilder().setQuery(query.toString()));
         return iterateQuery(request, options, res -> ConceptMap.of(res.getQueryRes().getMatchRes().getAnswer()));
     }
 
-    public Stream<ConceptMap> insert(final GraqlInsert query) {
+    public Stream<ConceptMap> insert(GraqlInsert query) {
         return insert(query, new GraknOptions());
     }
 
-    public Stream<ConceptMap> insert(final GraqlInsert query, final GraknOptions options) {
+    public Stream<ConceptMap> insert(GraqlInsert query, GraknOptions options) {
         final QueryProto.Query.Req.Builder request = QueryProto.Query.Req.newBuilder().setInsertReq(
                 QueryProto.Graql.Insert.Req.newBuilder().setQuery(query.toString()));
         return iterateQuery(request, options, res -> ConceptMap.of(res.getQueryRes().getInsertRes().getAnswer()));
     }
 
-    public QueryFuture<Void> delete(final GraqlDelete query) {
+    public QueryFuture<Void> delete(GraqlDelete query) {
         return delete(query, new GraknOptions());
     }
 
-    public QueryFuture<Void> delete(final GraqlDelete query, final GraknOptions options) {
+    public QueryFuture<Void> delete(GraqlDelete query, GraknOptions options) {
         return runQuery(QueryProto.Query.Req.newBuilder().setDeleteReq(QueryProto.Graql.Delete.Req.newBuilder().setQuery(query.toString())), options);
     }
 
-    public QueryFuture<Void> define(final GraqlDefine query) {
+    public QueryFuture<Void> define(GraqlDefine query) {
         return define(query, new GraknOptions());
     }
 
-    public QueryFuture<Void> define(final GraqlDefine query, final GraknOptions options) {
+    public QueryFuture<Void> define(GraqlDefine query, GraknOptions options) {
         return runQuery(QueryProto.Query.Req.newBuilder().setDefineReq(QueryProto.Graql.Define.Req.newBuilder().setQuery(query.toString())), options);
     }
 
-    public QueryFuture<Void> undefine(final GraqlUndefine query) {
+    public QueryFuture<Void> undefine(GraqlUndefine query) {
         return undefine(query, new GraknOptions());
     }
 
-    public QueryFuture<Void> undefine(final GraqlUndefine query, final GraknOptions options) {
+    public QueryFuture<Void> undefine(GraqlUndefine query, GraknOptions options) {
         return runQuery(QueryProto.Query.Req.newBuilder().setUndefineReq(QueryProto.Graql.Undefine.Req.newBuilder().setQuery(query.toString())), options);
     }
 
-    private QueryFuture<Void> runQuery(final QueryProto.Query.Req.Builder request, final GraknOptions options) {
+    private QueryFuture<Void> runQuery(QueryProto.Query.Req.Builder request, GraknOptions options) {
         final TransactionProto.Transaction.Req.Builder req = TransactionProto.Transaction.Req.newBuilder()
                 .setQueryReq(request.setOptions(options(options)));
         return rpcTransaction.executeAsync(req, res -> null);
     }
 
-    private <T> Stream<T> iterateQuery(final QueryProto.Query.Req.Builder request, final GraknOptions options,
-                                                    final Function<TransactionProto.Transaction.Res, T> responseReader) {
+    private <T> Stream<T> iterateQuery(QueryProto.Query.Req.Builder request, GraknOptions options,
+                                       Function<TransactionProto.Transaction.Res, T> responseReader) {
         final TransactionProto.Transaction.Req.Builder req = TransactionProto.Transaction.Req.newBuilder()
                 .setQueryReq(request.setOptions(options(options)));
         return rpcTransaction.stream(req, responseReader);

--- a/rpc/GraknClient.java
+++ b/rpc/GraknClient.java
@@ -40,18 +40,18 @@ public class GraknClient implements Client {
         this(DEFAULT_URI);
     }
 
-    public GraknClient(final String address) {
+    public GraknClient(String address) {
         channel = ManagedChannelBuilder.forTarget(address).usePlaintext().build();
         databases = new RPCDatabaseManager(channel);
     }
 
     @Override
-    public Session session(final String database, final Session.Type type) {
+    public Session session(String database, Session.Type type) {
         return session(database, type, new GraknOptions());
     }
 
     @Override
-    public Session session(final String database, final Session.Type type, final GraknOptions options) {
+    public Session session(String database, Session.Type type, GraknOptions options) {
         return new RPCSession(this, database, type, options);
     }
 

--- a/rpc/RPCDatabaseManager.java
+++ b/rpc/RPCDatabaseManager.java
@@ -35,22 +35,22 @@ import static grakn.client.common.exception.ErrorMessage.Client.MISSING_DB_NAME;
 class RPCDatabaseManager implements DatabaseManager {
     private final GraknGrpc.GraknBlockingStub blockingGrpcStub;
 
-    RPCDatabaseManager(final Channel channel) {
+    RPCDatabaseManager(Channel channel) {
         blockingGrpcStub = GraknGrpc.newBlockingStub(channel);
     }
 
     @Override
-    public boolean contains(final String name) {
+    public boolean contains(String name) {
         return request(() -> blockingGrpcStub.databaseContains(Database.Contains.Req.newBuilder().setName(nonNull(name)).build()).getContains());
     }
 
     @Override
-    public void create(final String name) {
+    public void create(String name) {
         request(() -> blockingGrpcStub.databaseCreate(Database.Create.Req.newBuilder().setName(nonNull(name)).build()));
     }
 
     @Override
-    public void delete(final String name) {
+    public void delete(String name) {
         request(() -> blockingGrpcStub.databaseDelete(Database.Delete.Req.newBuilder().setName(nonNull(name)).build()));
     }
 
@@ -64,7 +64,7 @@ class RPCDatabaseManager implements DatabaseManager {
         return name;
     }
 
-    private static <RES> RES request(final Supplier<RES> req) {
+    private static <RES> RES request(Supplier<RES> req) {
         try {
             return req.get();
         } catch (StatusRuntimeException e) {

--- a/rpc/RPCSession.java
+++ b/rpc/RPCSession.java
@@ -40,7 +40,7 @@ public class RPCSession implements Session {
     private final AtomicBoolean isOpen;
     private final GraknGrpc.GraknBlockingStub blockingGrpcStub;
 
-    RPCSession(final GraknClient client, final String database, final Type type, final GraknOptions options) {
+    RPCSession(GraknClient client, String database, Type type, GraknOptions options) {
         this.channel = client.channel();
         this.database = database;
         this.type = type;
@@ -54,12 +54,12 @@ public class RPCSession implements Session {
     }
 
     @Override
-    public Transaction transaction(final Transaction.Type type) {
+    public Transaction transaction(Transaction.Type type) {
         return transaction(type, new GraknOptions());
     }
 
     @Override
-    public Transaction transaction(final Transaction.Type type, final GraknOptions options) {
+    public Transaction transaction(Transaction.Type type, GraknOptions options) {
         return new RPCTransaction(this, sessionId, type, options);
     }
 
@@ -87,7 +87,7 @@ public class RPCSession implements Session {
 
     Channel channel() { return channel; }
 
-    private static SessionProto.Session.Type sessionType(final Session.Type type) {
+    private static SessionProto.Session.Type sessionType(Session.Type type) {
         switch (type) {
             case DATA:
                 return SessionProto.Session.Type.DATA;

--- a/test/behaviour/BehaviourTest.java
+++ b/test/behaviour/BehaviourTest.java
@@ -27,7 +27,7 @@ import org.junit.BeforeClass;
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
-public abstract class BehaviourTestBase {
+public abstract class BehaviourTest {
     // The following code is for running the Grakn Core distribution imported as an artifact.
     // If you wish to debug locally against an instance of Grakn that is already running in
     // the background, comment out all the code in this file that references 'runner'

--- a/test/behaviour/BehaviourTestBase.java
+++ b/test/behaviour/BehaviourTestBase.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package grakn.core.test.behaviour;
 
 import grakn.common.test.server.GraknCoreRunner;

--- a/test/behaviour/concept/thing/attribute/AttributeTest.java
+++ b/test/behaviour/concept/thing/attribute/AttributeTest.java
@@ -19,7 +19,7 @@
 
 package grakn.client.test.behaviour.concept.thing.attribute;
 
-import grakn.core.test.behaviour.BehaviourTestBase;
+import grakn.core.test.behaviour.BehaviourTest;
 import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         features = "external/graknlabs_behaviour/concept/thing/attribute.feature",
         tags = "not @ignore and not @ignore-grakn"
 )
-public class AttributeTest extends BehaviourTestBase {
+public class AttributeTest extends BehaviourTest {
     // ATTENTION:
     // When you click RUN from within this class through Intellij IDE, it will fail.
     // You can fix it by doing:

--- a/test/behaviour/concept/thing/entity/EntityTest.java
+++ b/test/behaviour/concept/thing/entity/EntityTest.java
@@ -19,7 +19,7 @@
 
 package grakn.client.test.behaviour.concept.thing.entity;
 
-import grakn.core.test.behaviour.BehaviourTestBase;
+import grakn.core.test.behaviour.BehaviourTest;
 import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         features = "external/graknlabs_behaviour/concept/thing/entity.feature",
         tags = "not @ignore and not @ignore-grakn"
 )
-public class EntityTest extends BehaviourTestBase {
+public class EntityTest extends BehaviourTest {
     // ATTENTION:
     // When you click RUN from within this class through Intellij IDE, it will fail.
     // You can fix it by doing:

--- a/test/behaviour/concept/thing/relation/RelationTest.java
+++ b/test/behaviour/concept/thing/relation/RelationTest.java
@@ -19,7 +19,7 @@
 
 package grakn.client.test.behaviour.concept.thing.relation;
 
-import grakn.core.test.behaviour.BehaviourTestBase;
+import grakn.core.test.behaviour.BehaviourTest;
 import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         features = "external/graknlabs_behaviour/concept/thing/relation.feature",
         tags = "not @ignore and not @ignore-grakn"
 )
-public class RelationTest extends BehaviourTestBase {
+public class RelationTest extends BehaviourTest {
     // ATTENTION:
     // When you click RUN from within this class through Intellij IDE, it will fail.
     // You can fix it by doing:

--- a/test/behaviour/concept/type/attributetype/AttributeTypeSteps.java
+++ b/test/behaviour/concept/type/attributetype/AttributeTypeSteps.java
@@ -101,7 +101,7 @@ public class AttributeTypeSteps {
     }
 
     @Then("attribute\\( ?{type_label} ?) as\\( ?{value_type} ?) unset regex")
-    public void attribute_type_as_value_type_unset_regex(final String typeLabel, final AttributeType.ValueType valueType) {
+    public void attribute_type_as_value_type_unset_regex(String typeLabel, AttributeType.ValueType valueType) {
         if (!valueType.equals(AttributeType.ValueType.STRING)) fail();
         final AttributeType attributeType = attribute_type_as_value_type(typeLabel, valueType);
         attributeType.asString().asRemote(tx()).setRegex(null);
@@ -115,21 +115,21 @@ public class AttributeTypeSteps {
     }
 
     @Then("attribute\\( ?{type_label} ?) as\\( ?{value_type} ?) does not have any regex")
-    public void attribute_type_as_value_type_does_not_have_any_regex(final String typeLabel, final AttributeType.ValueType valueType) {
+    public void attribute_type_as_value_type_does_not_have_any_regex(String typeLabel, AttributeType.ValueType valueType) {
         if (!valueType.equals(AttributeType.ValueType.STRING)) fail();
         final AttributeType attributeType = attribute_type_as_value_type(typeLabel, valueType);
         assertNull(attributeType.asString().asRemote(tx()).getRegex());
     }
 
     @Then("attribute\\( ?{type_label} ?) get key owners contain:")
-    public void attribute_type_get_owners_as_key_contains(final String typeLabel, final List<String> ownerLabels) {
+    public void attribute_type_get_owners_as_key_contains(String typeLabel, List<String> ownerLabels) {
         final AttributeType attributeType = tx().concepts().getAttributeType(typeLabel);
         final Set<String> actuals = attributeType.asRemote(tx()).getOwners(true).map(ThingType::getLabel).collect(toSet());
         assertTrue(actuals.containsAll(ownerLabels));
     }
 
     @Then("attribute\\( ?{type_label} ?) get key owners do not contain:")
-    public void attribute_type_get_owners_as_key_do_not_contains(final String typeLabel, final List<String> ownerLabels) {
+    public void attribute_type_get_owners_as_key_do_not_contains(String typeLabel, List<String> ownerLabels) {
         final AttributeType attributeType = tx().concepts().getAttributeType(typeLabel);
         final Set<String> actuals = attributeType.asRemote(tx()).getOwners(true).map(ThingType::getLabel).collect(toSet());
         for (String ownerLabel : ownerLabels) {
@@ -138,14 +138,14 @@ public class AttributeTypeSteps {
     }
 
     @Then("attribute\\( ?{type_label} ?) get attribute owners contain:")
-    public void attribute_type_get_owners_as_attribute_contains(final String typeLabel, final List<String> ownerLabels) {
+    public void attribute_type_get_owners_as_attribute_contains(String typeLabel, List<String> ownerLabels) {
         final AttributeType attributeType = tx().concepts().getAttributeType(typeLabel);
         final Set<String> actuals = attributeType.asRemote(tx()).getOwners(false).map(ThingType::getLabel).collect(toSet());
         assertTrue(actuals.containsAll(ownerLabels));
     }
 
     @Then("attribute\\( ?{type_label} ?) get attribute owners do not contain:")
-    public void attribute_type_get_owners_as_attribute_do_not_contains(final String typeLabel, final List<String> ownerLabels) {
+    public void attribute_type_get_owners_as_attribute_do_not_contains(String typeLabel, List<String> ownerLabels) {
         final AttributeType attributeType = tx().concepts().getAttributeType(typeLabel);
         final Set<String> actuals = attributeType.asRemote(tx()).getOwners(false).map(ThingType::getLabel).collect(toSet());
         for (String ownerLabel : ownerLabels) {

--- a/test/behaviour/concept/type/attributetype/AttributeTypeTest.java
+++ b/test/behaviour/concept/type/attributetype/AttributeTypeTest.java
@@ -19,7 +19,7 @@
 
 package grakn.client.test.behaviour.concept.type.attributetype;
 
-import grakn.core.test.behaviour.BehaviourTestBase;
+import grakn.core.test.behaviour.BehaviourTest;
 import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         features = "external/graknlabs_behaviour/concept/type/attributetype.feature",
         tags = "not @ignore and not @ignore-grakn"
 )
-public class AttributeTypeTest extends BehaviourTestBase {
+public class AttributeTypeTest extends BehaviourTest {
     // ATTENTION:
     // When you click RUN from within this class through Intellij IDE, it will fail.
     // You can fix it by doing:

--- a/test/behaviour/concept/type/entitytype/EntityTypeTest.java
+++ b/test/behaviour/concept/type/entitytype/EntityTypeTest.java
@@ -19,7 +19,7 @@
 
 package grakn.client.test.behaviour.concept.type.entitytype;
 
-import grakn.core.test.behaviour.BehaviourTestBase;
+import grakn.core.test.behaviour.BehaviourTest;
 import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         features = "external/graknlabs_behaviour/concept/type/entitytype.feature",
         tags = "not @ignore and not @ignore-grakn"
 )
-public class EntityTypeTest extends BehaviourTestBase {
+public class EntityTypeTest extends BehaviourTest {
     // ATTENTION:
     // When you click RUN from within this class through Intellij IDE, it will fail.
     // You can fix it by doing:

--- a/test/behaviour/concept/type/relationtype/RelationTypeSteps.java
+++ b/test/behaviour/concept/type/relationtype/RelationTypeSteps.java
@@ -54,7 +54,7 @@ public class RelationTypeSteps {
     }
 
     @When("relation\\( ?{type_label} ?) unset related role: {type_label}; throws exception")
-    public void relation_type_unset_related_role_throws_exception(final String relationLabel, final String roleLabel) {
+    public void relation_type_unset_related_role_throws_exception(String relationLabel, String roleLabel) {
         assertThrows(() -> relation_type_unset_related_role(relationLabel, roleLabel));
     }
 

--- a/test/behaviour/concept/type/relationtype/RelationTypeTest.java
+++ b/test/behaviour/concept/type/relationtype/RelationTypeTest.java
@@ -19,7 +19,7 @@
 
 package grakn.client.test.behaviour.concept.type.relationtype;
 
-import grakn.core.test.behaviour.BehaviourTestBase;
+import grakn.core.test.behaviour.BehaviourTest;
 import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         features = "external/graknlabs_behaviour/concept/type/relationtype.feature",
         tags = "not @ignore and not @ignore-grakn"
 )
-public class RelationTypeTest extends BehaviourTestBase {
+public class RelationTypeTest extends BehaviourTest {
     // ATTENTION:
     // When you click RUN from within this class through Intellij IDE, it will fail.
     // You can fix it by doing:

--- a/test/behaviour/concept/type/thingtype/ThingTypeSteps.java
+++ b/test/behaviour/concept/type/thingtype/ThingTypeSteps.java
@@ -289,7 +289,7 @@ public class ThingTypeSteps {
     }
 
     @When("{root_label}\\( ?{type_label} ?) unset owns attribute type: {type_label}; throws exception")
-    public void thing_type_unset_owns_attribute_type_throws_exception(final RootLabel rootLabel, final String typeLabel, final String attributeLabel) {
+    public void thing_type_unset_owns_attribute_type_throws_exception(RootLabel rootLabel, String typeLabel, String attributeLabel) {
         assertThrows(() -> thing_type_unset_owns_attribute_type(rootLabel, typeLabel, attributeLabel));
     }
 
@@ -341,7 +341,7 @@ public class ThingTypeSteps {
     }
 
     @When("{root_label}\\( ?{type_label} ?) unset plays role: {scoped_label}; throws exception")
-    public void thing_type_unset_plays_role_throws_exception(final RootLabel rootLabel, final String typeLabel, final Parameters.ScopedLabel roleLabel) {
+    public void thing_type_unset_plays_role_throws_exception(RootLabel rootLabel, String typeLabel, Parameters.ScopedLabel roleLabel) {
         assertThrows(() -> thing_type_unset_plays_role(rootLabel, typeLabel, roleLabel));
     }
 

--- a/test/behaviour/concept/type/thingtype/ThingTypeTest.java
+++ b/test/behaviour/concept/type/thingtype/ThingTypeTest.java
@@ -19,7 +19,7 @@
 
 package grakn.client.test.behaviour.concept.type.thingtype;
 
-import grakn.core.test.behaviour.BehaviourTestBase;
+import grakn.core.test.behaviour.BehaviourTest;
 import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         features = "external/graknlabs_behaviour/concept/type/thingtype.feature",
         tags = "not @ignore and not @ignore-grakn"
 )
-public class ThingTypeTest extends BehaviourTestBase {
+public class ThingTypeTest extends BehaviourTest {
     // ATTENTION:
     // When you click RUN from within this class through Intellij IDE, it will fail.
     // You can fix it by doing:

--- a/test/behaviour/connection/database/DatabaseTest.java
+++ b/test/behaviour/connection/database/DatabaseTest.java
@@ -19,7 +19,7 @@
 
 package grakn.client.test.behaviour.connection.database;
 
-import grakn.core.test.behaviour.BehaviourTestBase;
+import grakn.core.test.behaviour.BehaviourTest;
 import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         features = "external/graknlabs_behaviour/connection/database.feature",
         tags = "not @ignore and not @ignore-client-java and not @ignore-grakn-2.0"
 )
-public class DatabaseTest extends BehaviourTestBase {
+public class DatabaseTest extends BehaviourTest {
     // ATTENTION:
     // When you click RUN from within this class through Intellij IDE, it will fail.
     // You can fix it by doing:

--- a/test/behaviour/connection/session/SessionTest.java
+++ b/test/behaviour/connection/session/SessionTest.java
@@ -19,7 +19,7 @@
 
 package grakn.client.test.behaviour.connection.session;
 
-import grakn.core.test.behaviour.BehaviourTestBase;
+import grakn.core.test.behaviour.BehaviourTest;
 import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         features = "external/graknlabs_behaviour/connection/session.feature",
         tags = "not @ignore and not @ignore-client-java"
 )
-public class SessionTest extends BehaviourTestBase {
+public class SessionTest extends BehaviourTest {
     // ATTENTION:
     // When you click RUN from within this class through Intellij IDE, it will fail.
     // You can fix it by doing:

--- a/test/behaviour/connection/transaction/TransactionTest.java
+++ b/test/behaviour/connection/transaction/TransactionTest.java
@@ -19,7 +19,7 @@
 
 package grakn.client.test.behaviour.connection.transaction;
 
-import grakn.core.test.behaviour.BehaviourTestBase;
+import grakn.core.test.behaviour.BehaviourTest;
 import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         features = "external/graknlabs_behaviour/connection/transaction.feature",
         tags = "not @ignore and not @ignore-client-java and not @ignore-grakn-2.0"
 )
-public class TransactionTest extends BehaviourTestBase {
+public class TransactionTest extends BehaviourTest {
     // ATTENTION:
     // When you click RUN from within this class through Intellij IDE, it will fail.
     // You can fix it by doing:

--- a/test/behaviour/debug/DebugTest.java
+++ b/test/behaviour/debug/DebugTest.java
@@ -19,7 +19,7 @@
 
 package grakn.client.test.behaviour.debug;
 
-import grakn.core.test.behaviour.BehaviourTestBase;
+import grakn.core.test.behaviour.BehaviourTest;
 import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
         glue = "grakn.client.test.behaviour",
         features = "test/behaviour/debug/debug.feature"
 )
-public class DebugTest extends BehaviourTestBase {
+public class DebugTest extends BehaviourTest {
     // ATTENTION:
     // When you click RUN from within this class through Intellij IDE, it will fail.
     // You can fix it by doing:

--- a/test/behaviour/graql/GraqlSteps.java
+++ b/test/behaviour/graql/GraqlSteps.java
@@ -76,45 +76,45 @@ public class GraqlSteps {
     }
 
     @Given("graql define; throws exception")
-    public void graql_define_throws(final String defineQueryStatements) {
+    public void graql_define_throws(String defineQueryStatements) {
         assertThrows(() -> graql_define(defineQueryStatements).get());
     }
 
     @Given("graql undefine")
-    public QueryFuture<Void> graql_undefine(final String undefineQueryStatements) {
+    public QueryFuture<Void> graql_undefine(String undefineQueryStatements) {
         final GraqlUndefine graqlQuery = Graql.parseQuery(String.join("\n", undefineQueryStatements));
         return tx().query().undefine(graqlQuery);
     }
 
     @Given("graql undefine; throws exception")
-    public void graql_undefine_throws(final String undefineQueryStatements) {
+    public void graql_undefine_throws(String undefineQueryStatements) {
         assertThrows(() -> graql_undefine(undefineQueryStatements).get());
     }
 
     @Given("graql insert")
-    public Stream<ConceptMap> graql_insert(final String insertQueryStatements) {
+    public Stream<ConceptMap> graql_insert(String insertQueryStatements) {
         final GraqlInsert graqlQuery = Graql.parseQuery(String.join("\n", insertQueryStatements));
         return tx().query().insert(graqlQuery);
     }
 
     @Given("graql insert; throws exception")
-    public void graql_insert_throws(final String insertQueryStatements) {
+    public void graql_insert_throws(String insertQueryStatements) {
         assertThrows(() -> graql_insert(insertQueryStatements));
     }
 
     @Given("graql delete")
-    public QueryFuture<Void> graql_delete(final String deleteQueryStatements) {
+    public QueryFuture<Void> graql_delete(String deleteQueryStatements) {
         final GraqlDelete graqlQuery = Graql.parseQuery(String.join("\n", deleteQueryStatements));
         return tx().query().delete(graqlQuery);
     }
 
     @Given("graql delete; throws exception")
-    public void graql_delete_throws(final String deleteQueryStatements) {
+    public void graql_delete_throws(String deleteQueryStatements) {
         assertThrows(() -> graql_delete(deleteQueryStatements).get());
     }
 
     @When("get answers of graql insert")
-    public void get_answers_of_graql_insert(final String graqlQueryStatements) {
+    public void get_answers_of_graql_insert(String graqlQueryStatements) {
         final GraqlInsert graqlQuery = Graql.parseQuery(String.join("\n", graqlQueryStatements));
         // Erase answers from previous steps to avoid polluting the result space
         answers = null;
@@ -126,7 +126,7 @@ public class GraqlSteps {
     }
 
     @When("get answers of graql query")
-    public void graql_query(final String graqlQueryStatements) {
+    public void graql_query(String graqlQueryStatements) {
         // TODO: re-enable when match is implemented
 //        final GraqlQuery graqlQuery = Graql.parse(String.join("\n", graqlQueryStatements));
 //        // Erase answers from previous steps to avoid polluting the result space
@@ -150,12 +150,12 @@ public class GraqlSteps {
     }
 
     @When("graql match; throws exception")
-    public void graql_match_throws_exception(final String graqlQueryStatements) {
+    public void graql_match_throws_exception(String graqlQueryStatements) {
         // TODO
     }
 
     @Then("answer size is: {number}")
-    public void answer_quantity_assertion(final int expectedAnswers) {
+    public void answer_quantity_assertion(int expectedAnswers) {
         // TODO
 //        assertEquals(
 //                String.format("Expected [%d] answers, but got [%d]", expectedAnswers, answers.count()),
@@ -247,7 +247,7 @@ public class GraqlSteps {
     }
 
     @Then("group identifiers are")
-    public void group_identifiers_are(final Map<String, Map<String, String>> identifiers) {
+    public void group_identifiers_are(Map<String, Map<String, String>> identifiers) {
         for (Map.Entry<String, Map<String, String>> entry : identifiers.entrySet()) {
             String groupIdentifier = entry.getKey();
             Map<String, String> variables = entry.getValue();
@@ -342,11 +342,11 @@ public class GraqlSteps {
 
         private static final String GROUP_COLUMN_NAME = "group";
 
-        public AnswerIdentifierGroup(final List<Map<String, String>> answerIdentifierTable, final Map<String, String> groupOwnerIdentifiers) {
+        public AnswerIdentifierGroup(List<Map<String, String>> answerIdentifierTable, Map<String, String> groupOwnerIdentifiers) {
             final String groupIdentifier = answerIdentifierTable.get(0).get(GROUP_COLUMN_NAME);
             groupOwnerIdentifier = groupOwnerIdentifiers.get(groupIdentifier);
             answersIdentifiers = new ArrayList<>();
-            for (final Map<String, String> rawAnswerIdentifiers : answerIdentifierTable) {
+            for (Map<String, String> rawAnswerIdentifiers : answerIdentifierTable) {
                 answersIdentifiers.add(rawAnswerIdentifiers.entrySet().stream()
                                                .filter(e -> !e.getKey().equals(GROUP_COLUMN_NAME))
                                                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
@@ -354,7 +354,7 @@ public class GraqlSteps {
         }
     }
 
-    private boolean matchAnswer(final Map<String, String> answerIdentifiers, final ConceptMap answer) {
+    private boolean matchAnswer(Map<String, String> answerIdentifiers, ConceptMap answer) {
 
         if (!(answerIdentifiers).keySet().equals(answer.map().keySet())) {
             return false;
@@ -451,7 +451,7 @@ public class GraqlSteps {
     } */
 
     @Then("each answer satisfies")
-    public void each_answer_satisfies(final String templatedGraqlQuery) {
+    public void each_answer_satisfies(String templatedGraqlQuery) {
         // TODO
 //        final String templatedQuery = String.join("\n", templatedGraqlQuery);
 //        for (ConceptMap answer : answers.collect(Collectors.toList())) {
@@ -562,14 +562,14 @@ public class GraqlSteps {
         }
 
         @Override
-        public boolean check(final Concept concept) {
+        public boolean check(Concept concept) {
             if (!(concept instanceof Thing)) { return false; }
 
             final Set<Attribute<?>> keys = concept.asThing().asRemote(tx()).getHas(true).collect(Collectors.toSet());
 
             final HashMap<String, String> keyMap = new HashMap<>();
 
-            for (final Attribute<?> key : keys) {
+            for (Attribute<?> key : keys) {
                 keyMap.put(
                         key.asRemote(tx()).getType().getLabel(),
                         key.getValue().toString());

--- a/test/behaviour/graql/language/define/DefineTest.java
+++ b/test/behaviour/graql/language/define/DefineTest.java
@@ -19,7 +19,7 @@
 
 package grakn.client.test.behaviour.graql.language.define;
 
-import grakn.core.test.behaviour.BehaviourTestBase;
+import grakn.core.test.behaviour.BehaviourTest;
 import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         features = "external/graknlabs_behaviour/graql/language/define.feature",
         tags = "not @ignore and not @ignore-client-java"
 )
-public class DefineTest extends BehaviourTestBase {
+public class DefineTest extends BehaviourTest {
     // ATTENTION:
     // When you click RUN from within this class through Intellij IDE, it will fail.
     // You can fix it by doing:

--- a/test/behaviour/graql/language/delete/DeleteTest.java
+++ b/test/behaviour/graql/language/delete/DeleteTest.java
@@ -19,7 +19,7 @@
 
 package grakn.client.test.behaviour.graql.language.delete;
 
-import grakn.core.test.behaviour.BehaviourTestBase;
+import grakn.core.test.behaviour.BehaviourTest;
 import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         features = "external/graknlabs_behaviour/graql/language/delete.feature",
         tags = "not @ignore and not @ignore-client-java"
 )
-public class DeleteTest extends BehaviourTestBase {
+public class DeleteTest extends BehaviourTest {
     // ATTENTION:
     // When you click RUN from within this class through Intellij IDE, it will fail.
     // You can fix it by doing:

--- a/test/behaviour/graql/language/get/GetTest.java
+++ b/test/behaviour/graql/language/get/GetTest.java
@@ -19,7 +19,7 @@
 
 package grakn.client.test.behaviour.graql.language.get;
 
-import grakn.core.test.behaviour.BehaviourTestBase;
+import grakn.core.test.behaviour.BehaviourTest;
 import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         features = "external/graknlabs_behaviour/graql/language/get.feature",
         tags = "not @ignore and not @ignore-client-java"
 )
-public class GetTest extends BehaviourTestBase {
+public class GetTest extends BehaviourTest {
     // ATTENTION:
     // When you click RUN from within this class through Intellij IDE, it will fail.
     // You can fix it by doing:

--- a/test/behaviour/graql/language/insert/InsertTest.java
+++ b/test/behaviour/graql/language/insert/InsertTest.java
@@ -19,7 +19,7 @@
 
 package grakn.client.test.behaviour.graql.language.insert;
 
-import grakn.core.test.behaviour.BehaviourTestBase;
+import grakn.core.test.behaviour.BehaviourTest;
 import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         features = "external/graknlabs_behaviour/graql/language/insert.feature",
         tags = "not @ignore and not @ignore-client-java"
 )
-public class InsertTest extends BehaviourTestBase {
+public class InsertTest extends BehaviourTest {
     // ATTENTION:
     // When you click RUN from within this class through Intellij IDE, it will fail.
     // You can fix it by doing:

--- a/test/behaviour/graql/language/match/MatchTest.java
+++ b/test/behaviour/graql/language/match/MatchTest.java
@@ -19,7 +19,7 @@
 
 package grakn.client.test.behaviour.graql.language.match;
 
-import grakn.core.test.behaviour.BehaviourTestBase;
+import grakn.core.test.behaviour.BehaviourTest;
 import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         features = "external/graknlabs_behaviour/graql/language/match.feature",
         tags = "not @ignore and not @ignore-client-java"
 )
-public class MatchTest extends BehaviourTestBase {
+public class MatchTest extends BehaviourTest {
     // ATTENTION:
     // When you click RUN from within this class through Intellij IDE, it will fail.
     // You can fix it by doing:

--- a/test/behaviour/graql/language/undefine/UndefineTest.java
+++ b/test/behaviour/graql/language/undefine/UndefineTest.java
@@ -19,7 +19,7 @@
 
 package grakn.client.test.behaviour.graql.language.undefine;
 
-import grakn.core.test.behaviour.BehaviourTestBase;
+import grakn.core.test.behaviour.BehaviourTest;
 import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         features = "external/graknlabs_behaviour/graql/language/undefine.feature",
         tags = "not @ignore and not @ignore-client-java"
 )
-public class UndefineTest extends BehaviourTestBase {
+public class UndefineTest extends BehaviourTest {
     // ATTENTION:
     // When you click RUN from within this class through Intellij IDE, it will fail.
     // You can fix it by doing:

--- a/test/integration/ClientQueryTest.java
+++ b/test/integration/ClientQueryTest.java
@@ -233,7 +233,7 @@ public class ClientQueryTest {
         }
     }
 
-    private void localhostGraknTx(final Consumer<Transaction> fn, final Session.Type sessionType) {
+    private void localhostGraknTx(Consumer<Transaction> fn, Session.Type sessionType) {
         String database = "grakn";
         try (Session session = graknClient.session(database, sessionType)) {
             try (Transaction transaction = session.transaction(WRITE)) {


### PR DESCRIPTION
## What is the goal of this PR?

To improve code readability across the project

## What are the changes implemented in this PR?

Remove unnecessary 'final' from parameters.

We keep them in local variables and class members.
