### PR TITLE
Fix thread safety, data & memory usage issues

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -61,9 +61,10 @@ build:
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
         bazel build //...
-        bazel test //test/behaviour/connection/... --test_output=errors
-        bazel test //test/behaviour/concept/... --test_output=errors
-        bazel test //test/behaviour/graql/language/define/... --test_output=errors
+        sleep 1800
+#        bazel test //test/behaviour/connection/... --test_output=errors
+#        bazel test //test/behaviour/concept/... --test_output=errors
+#        bazel test //test/behaviour/graql/language/define/... --test_output=errors
       # TODO: use --config=rbe once Grakn Core runs in RBE
       # TODO: revert above tests to //test/behaviour/...
     deploy-maven-snapshot:

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -31,40 +31,38 @@ build:
           --project-key=graknlabs_client_java \
           --branch=$GRABL_BRANCH --commit-id=$GRABL_COMMIT
   correctness:
-#    build:
-#      machine: graknlabs-ubuntu-20.04
-#      script: |
-#        export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
-#        bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-#        bazel build --config=rbe //...
-#        bazel run @graknlabs_dependencies//tool/checkstyle:test-coverage
-#        bazel test --config=rbe $(bazel query 'kind(checkstyle_test, //...)')
-#    build-dependency:
-#      machine: graknlabs-ubuntu-20.04
-#      script: |
-#        dependencies/maven/update.sh
-#        git diff --exit-code dependencies/maven/artifacts.snapshot
-#        bazel run @graknlabs_dependencies//tool/unuseddeps:unused-deps -- list
-#    test-integration:
-#      machine: graknlabs-ubuntu-20.04
-#      script: |
-#        export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
-#        bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-#        bazel test //test/integration/... --test_output=errors
-#      # TODO: use --config=rbe once Grakn Core runs in RBE
+    build:
+      machine: graknlabs-ubuntu-20.04
+      script: |
+        export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
+        bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
+        bazel build --config=rbe //...
+        bazel run @graknlabs_dependencies//tool/checkstyle:test-coverage
+        bazel test --config=rbe $(bazel query 'kind(checkstyle_test, //...)')
+    build-dependency:
+      machine: graknlabs-ubuntu-20.04
+      script: |
+        dependencies/maven/update.sh
+        git diff --exit-code dependencies/maven/artifacts.snapshot
+        bazel run @graknlabs_dependencies//tool/unuseddeps:unused-deps -- list
+    test-integration:
+      machine: graknlabs-ubuntu-20.04
+      script: |
+        export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
+        bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
+        bazel test //test/integration/... --test_output=errors
+      # TODO: use --config=rbe once Grakn Core runs in RBE
     test-behaviour:
       machine: graknlabs-ubuntu-20.04
       script: |
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        bazel build //...
-        sleep 1800
-#        bazel test //test/behaviour/connection/... --test_output=errors
-#        bazel test //test/behaviour/concept/... --test_output=errors
-#        bazel test //test/behaviour/graql/language/define/... --test_output=errors
+        bazel test //test/behaviour/connection/... --test_output=errors --jobs=1
+        bazel test //test/behaviour/concept/... --test_output=errors
+        bazel test //test/behaviour/graql/language/define/... --test_output=errors
       # TODO: use --config=rbe once Grakn Core runs in RBE
       # TODO: revert above tests to //test/behaviour/...
     deploy-maven-snapshot:

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -61,13 +61,9 @@ build:
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
         bazel build //...
-        sleep 1800
-#        bazel test //test/behaviour/connection/session:test-core --test_output=streamed --cache_test_results=no
-#        bazel test //test/behaviour/connection/database:test-core --test_output=streamed --cache_test_results=no
-#        bazel test //test/behaviour/connection/session:test-core --test_output=streamed --cache_test_results=no
-#        bazel test //test/behaviour/connection/... --test_output=errors
-#        bazel test //test/behaviour/concept/... --test_output=errors
-#        bazel test //test/behaviour/graql/language/define/... --test_output=errors
+        bazel test //test/behaviour/connection/... --test_output=errors
+        bazel test //test/behaviour/concept/... --test_output=errors
+        bazel test //test/behaviour/graql/language/define/... --test_output=errors
       # TODO: use --config=rbe once Grakn Core runs in RBE
       # TODO: revert above tests to //test/behaviour/...
     deploy-maven-snapshot:

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -60,11 +60,11 @@ build:
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        bazel test //test/behaviour/connection/database:test-core --test_output=streamed --cache_test_results=no
-        bazel test //test/behaviour/connection/session:test-core --test_output=streamed --cache_test_results=no
-        bazel test //test/behaviour/connection/database:test-core --test_output=streamed --cache_test_results=no
-        bazel test //test/behaviour/connection/session:test-core --test_output=streamed --cache_test_results=no
-#        sleep 1800
+        bazel build //...
+#        bazel test //test/behaviour/connection/session:test-core --test_output=streamed --cache_test_results=no
+#        bazel test //test/behaviour/connection/database:test-core --test_output=streamed --cache_test_results=no
+#        bazel test //test/behaviour/connection/session:test-core --test_output=streamed --cache_test_results=no
+        sleep 1800
 #        bazel test //test/behaviour/connection/... --test_output=errors
 #        bazel test //test/behaviour/concept/... --test_output=errors
 #        bazel test //test/behaviour/graql/language/define/... --test_output=errors

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -31,37 +31,40 @@ build:
           --project-key=graknlabs_client_java \
           --branch=$GRABL_BRANCH --commit-id=$GRABL_COMMIT
   correctness:
-    build:
-      machine: graknlabs-ubuntu-20.04
-      script: |
-        export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
-        bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        bazel build --config=rbe //...
-        bazel run @graknlabs_dependencies//tool/checkstyle:test-coverage
-        bazel test --config=rbe $(bazel query 'kind(checkstyle_test, //...)')
-    build-dependency:
-      machine: graknlabs-ubuntu-20.04
-      script: |
-        dependencies/maven/update.sh
-        git diff --exit-code dependencies/maven/artifacts.snapshot
-        bazel run @graknlabs_dependencies//tool/unuseddeps:unused-deps -- list
-    test-integration:
-      machine: graknlabs-ubuntu-20.04
-      script: |
-        export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
-        bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        bazel test //test/integration/... --test_output=errors
-      # TODO: use --config=rbe once Grakn Core runs in RBE
+#    build:
+#      machine: graknlabs-ubuntu-20.04
+#      script: |
+#        export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
+#        bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
+#        bazel build --config=rbe //...
+#        bazel run @graknlabs_dependencies//tool/checkstyle:test-coverage
+#        bazel test --config=rbe $(bazel query 'kind(checkstyle_test, //...)')
+#    build-dependency:
+#      machine: graknlabs-ubuntu-20.04
+#      script: |
+#        dependencies/maven/update.sh
+#        git diff --exit-code dependencies/maven/artifacts.snapshot
+#        bazel run @graknlabs_dependencies//tool/unuseddeps:unused-deps -- list
+#    test-integration:
+#      machine: graknlabs-ubuntu-20.04
+#      script: |
+#        export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
+#        bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
+#        bazel test //test/integration/... --test_output=errors
+#      # TODO: use --config=rbe once Grakn Core runs in RBE
     test-behaviour:
       machine: graknlabs-ubuntu-20.04
       script: |
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        bazel build //test/behaviour/connection/...
-        sleep 1800
+        bazel build //test/behaviour/connection/database:test-core --test_output=streamed
+        bazel build //test/behaviour/connection/session:test-core --test_output=streamed
+        bazel build //test/behaviour/connection/database:test-core --test_output=streamed
+        bazel build //test/behaviour/connection/session:test-core --test_output=streamed
+#        sleep 1800
 #        bazel test //test/behaviour/connection/... --test_output=errors
 #        bazel test //test/behaviour/concept/... --test_output=errors
 #        bazel test //test/behaviour/graql/language/define/... --test_output=errors

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -63,6 +63,7 @@ build:
         bazel test //test/behaviour/connection/... --test_output=errors --jobs=1
         bazel test //test/behaviour/concept/... --test_output=errors
         bazel test //test/behaviour/graql/language/define/... --test_output=errors
+      # TODO: delete --jobs=1 if we fix the issue with excess memory usage
       # TODO: use --config=rbe once Grakn Core runs in RBE
       # TODO: revert above tests to //test/behaviour/...
     deploy-maven-snapshot:

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -61,10 +61,10 @@ build:
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
         bazel build //...
+        sleep 1800
 #        bazel test //test/behaviour/connection/session:test-core --test_output=streamed --cache_test_results=no
 #        bazel test //test/behaviour/connection/database:test-core --test_output=streamed --cache_test_results=no
 #        bazel test //test/behaviour/connection/session:test-core --test_output=streamed --cache_test_results=no
-        sleep 1800
 #        bazel test //test/behaviour/connection/... --test_output=errors
 #        bazel test //test/behaviour/concept/... --test_output=errors
 #        bazel test //test/behaviour/graql/language/define/... --test_output=errors

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -60,9 +60,11 @@ build:
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        bazel test //test/behaviour/connection/... --test_output=errors
-        bazel test //test/behaviour/concept/... --test_output=errors
-        bazel test //test/behaviour/graql/language/define/... --test_output=errors
+        bazel build //test/behaviour/connection/...
+        sleep 1800
+#        bazel test //test/behaviour/connection/... --test_output=errors
+#        bazel test //test/behaviour/concept/... --test_output=errors
+#        bazel test //test/behaviour/graql/language/define/... --test_output=errors
       # TODO: use --config=rbe once Grakn Core runs in RBE
       # TODO: revert above tests to //test/behaviour/...
     deploy-maven-snapshot:

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -60,10 +60,10 @@ build:
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        bazel build //test/behaviour/connection/database:test-core --test_output=streamed
-        bazel build //test/behaviour/connection/session:test-core --test_output=streamed
-        bazel build //test/behaviour/connection/database:test-core --test_output=streamed
-        bazel build //test/behaviour/connection/session:test-core --test_output=streamed
+        bazel test //test/behaviour/connection/database:test-core --test_output=streamed --cache_test_results=no
+        bazel test //test/behaviour/connection/session:test-core --test_output=streamed --cache_test_results=no
+        bazel test //test/behaviour/connection/database:test-core --test_output=streamed --cache_test_results=no
+        bazel test //test/behaviour/connection/session:test-core --test_output=streamed --cache_test_results=no
 #        sleep 1800
 #        bazel test //test/behaviour/connection/... --test_output=errors
 #        bazel test //test/behaviour/concept/... --test_output=errors

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,5 +27,5 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.tar.gz",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "a1ee9c967debb873e0fb8efe0198ce098fb5f36e",
+        commit = "a9c7831cb546302f598f27604ce7bc3c145d618e",
     )

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,5 +27,5 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.tar.gz",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "064973b199d42e87a73a34e65efa60df9bee5e14",
+        commit = "fd7ef4a226188a582b98e36005d9c749ae835e57",
     )

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,5 +27,5 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.tar.gz",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "a9c7831cb546302f598f27604ce7bc3c145d618e",
+        commit = "064973b199d42e87a73a34e65efa60df9bee5e14",
     )

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,5 +27,5 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.tar.gz",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "fd7ef4a226188a582b98e36005d9c749ae835e57",
+        commit = "a1ee9c967debb873e0fb8efe0198ce098fb5f36e",
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -37,14 +37,14 @@ def graknlabs_bazel_distribution():
     git_repository(
         name = "graknlabs_bazel_distribution",
         remote = "https://github.com/graknlabs/bazel-distribution",
-        commit = "30e30cec9e3fe4821103cafbd240ee9862e262ea" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_bazel_distribution
+        commit = "ba4a7d6e6fa98fcb44e7c6eae492aeeb9d85001b" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_bazel_distribution
     )
 
 def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "e282f9248b65e43467903aef492c32797cd30942", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "63ea26dabe7320dc7dd191a5f3bfa93b60dca38b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_protocol():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -29,8 +29,8 @@ def graknlabs_graql():
 def graknlabs_common():
     git_repository(
         name = "graknlabs_common",
-        remote = "https://github.com/graknlabs/common",
-        commit = "39664389f458124c14fa307ab78619d17280b73d" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
+        remote = "https://github.com/alexjpwalker/common",
+        commit = "011c48e5c1a6a3d3ecec2176e223ca75baeb3403" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 
 def graknlabs_bazel_distribution():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -29,8 +29,8 @@ def graknlabs_graql():
 def graknlabs_common():
     git_repository(
         name = "graknlabs_common",
-        remote = "https://github.com/alexjpwalker/common",
-        commit = "011c48e5c1a6a3d3ecec2176e223ca75baeb3403" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
+        remote = "https://github.com/graknlabs/common",
+        commit = "fcd45c6a30018e0107d5bbf4c5cd4fba2f10b245" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 
 def graknlabs_bazel_distribution():

--- a/rpc/GraknClient.java
+++ b/rpc/GraknClient.java
@@ -35,14 +35,12 @@ public class GraknClient implements Client {
 
     private final ManagedChannel channel;
     private final DatabaseManager databases;
-    private final String address;
 
     public GraknClient() {
         this(DEFAULT_URI);
     }
 
     public GraknClient(String address) {
-        this.address = address;
         channel = ManagedChannelBuilder.forTarget(address).usePlaintext().build();
         databases = new RPCDatabaseManager(channel);
     }
@@ -79,6 +77,4 @@ public class GraknClient implements Client {
     Channel channel() {
         return channel;
     }
-
-    String address() {return address;}
 }

--- a/rpc/GraknClient.java
+++ b/rpc/GraknClient.java
@@ -35,12 +35,14 @@ public class GraknClient implements Client {
 
     private final ManagedChannel channel;
     private final DatabaseManager databases;
+    private final String address;
 
     public GraknClient() {
         this(DEFAULT_URI);
     }
 
     public GraknClient(String address) {
+        this.address = address;
         channel = ManagedChannelBuilder.forTarget(address).usePlaintext().build();
         databases = new RPCDatabaseManager(channel);
     }
@@ -77,4 +79,6 @@ public class GraknClient implements Client {
     Channel channel() {
         return channel;
     }
+
+    String address() {return address;}
 }

--- a/rpc/RPCTransaction.java
+++ b/rpc/RPCTransaction.java
@@ -121,12 +121,6 @@ public class RPCTransaction implements Transaction {
                 .putAllMetadata(tracingData())
                 .setCommitReq(TransactionProto.Transaction.Commit.Req.getDefaultInstance());
         execute(commitReq);
-        // TODO: Currently this close request is parsed as an "unknown frame" on the server because the server
-        //  terminates the stream when commit is called. Three possible solutions are:
-        //  1) don't close the transaction, or the stream, on commit
-        //  2) let the server take full responsibility for closing the stream on commit
-        //  3) let the client take full responsibility for closing the stream on commit
-        close();
     }
 
     @Override

--- a/rpc/RPCTransaction.java
+++ b/rpc/RPCTransaction.java
@@ -146,7 +146,7 @@ public class RPCTransaction implements Transaction {
             final ResponseCollector.Single responseCollector = new ResponseCollector.Single();
             final UUID requestId = UUID.randomUUID();
             request.setId(requestId.toString());
-            addCollectorIfTransactionIsOpen(requestId, responseCollector);
+            assertOpenAndAddCollector(requestId, responseCollector);
             return new QueryFuture<>(request.build(), requestObserver, responseCollector, transformResponse);
         }
     }
@@ -157,13 +157,13 @@ public class RPCTransaction implements Transaction {
             final UUID requestId = UUID.randomUUID();
             request.setId(requestId.toString());
             request.setLatencyMillis(networkLatencyMillis);
-            addCollectorIfTransactionIsOpen(requestId, responseCollector);
+            assertOpenAndAddCollector(requestId, responseCollector);
             final QueryIterator<T> queryIterator = new QueryIterator<>(request.build(), requestObserver, responseCollector, transformResponse);
             return StreamSupport.stream(((Iterable<T>) () -> queryIterator).spliterator(), false);
         }
     }
 
-    private void addCollectorIfTransactionIsOpen(UUID requestId, ResponseCollector collector) {
+    private void assertOpenAndAddCollector(UUID requestId, ResponseCollector collector) {
         collectors.compute(requestId, (id, col) -> {
             if (transactionWasClosed.get()) throw new GraknClientException(TRANSACTION_CLOSED);
             return collector;

--- a/test/BUILD
+++ b/test/BUILD
@@ -17,8 +17,16 @@
 # under the License.
 #
 
+load("@graknlabs_common//test/server:rules.bzl", "native_grakn_artifact")
 load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 load("@graknlabs_bazel_distribution//artifact:rules.bzl", "artifact_extractor")
+
+native_grakn_artifact(
+    name = "native-grakn-artifact",
+    mac_artifact = "@graknlabs_grakn_core_artifact_mac//file",
+    linux_artifact = "@graknlabs_grakn_core_artifact_linux//file",
+    visibility = ["//test:__subpackages__"],
+)
 
 checkstyle_test(
     name = "checkstyle",

--- a/test/behaviour/concept/thing/attribute/BUILD
+++ b/test/behaviour/concept/thing/attribute/BUILD
@@ -65,8 +65,7 @@ grakn_java_test(
     data = [
         "@graknlabs_behaviour//concept/thing:attribute.feature",
     ],
-    grakn_artifact_linux = "@graknlabs_grakn_core_artifact_linux//file",
-    grakn_artifact_mac = "@graknlabs_grakn_core_artifact_mac//file",
+    native_grakn_artifact = "//test:native-grakn-artifact",
     size = "medium",
 )
 

--- a/test/behaviour/concept/thing/entity/BUILD
+++ b/test/behaviour/concept/thing/entity/BUILD
@@ -66,8 +66,7 @@ grakn_java_test(
     data = [
         "@graknlabs_behaviour//concept/thing:entity.feature",
     ],
-    grakn_artifact_linux = "@graknlabs_grakn_core_artifact_linux//file",
-    grakn_artifact_mac = "@graknlabs_grakn_core_artifact_mac//file",
+    native_grakn_artifact = "//test:native-grakn-artifact",
     size = "medium",
 )
 

--- a/test/behaviour/concept/thing/relation/BUILD
+++ b/test/behaviour/concept/thing/relation/BUILD
@@ -68,8 +68,7 @@ grakn_java_test(
     data = [
         "@graknlabs_behaviour//concept/thing:relation.feature",
     ],
-    grakn_artifact_linux = "@graknlabs_grakn_core_artifact_linux//file",
-    grakn_artifact_mac = "@graknlabs_grakn_core_artifact_mac//file",
+    native_grakn_artifact = "//test:native-grakn-artifact",
     size = "medium",
 )
 

--- a/test/behaviour/concept/type/attributetype/BUILD
+++ b/test/behaviour/concept/type/attributetype/BUILD
@@ -63,8 +63,7 @@ grakn_java_test(
     data = [
         "@graknlabs_behaviour//concept/type:attributetype.feature",
     ],
-    grakn_artifact_linux = "@graknlabs_grakn_core_artifact_linux//file",
-    grakn_artifact_mac = "@graknlabs_grakn_core_artifact_mac//file",
+    native_grakn_artifact = "//test:native-grakn-artifact",
     size = "medium",
 )
 

--- a/test/behaviour/concept/type/entitytype/BUILD
+++ b/test/behaviour/concept/type/entitytype/BUILD
@@ -60,8 +60,7 @@ grakn_java_test(
     data = [
         "@graknlabs_behaviour//concept/type:entitytype.feature",
     ],
-    grakn_artifact_linux = "@graknlabs_grakn_core_artifact_linux//file",
-    grakn_artifact_mac = "@graknlabs_grakn_core_artifact_mac//file",
+    native_grakn_artifact = "//test:native-grakn-artifact",
     size = "medium",
 )
 

--- a/test/behaviour/concept/type/relationtype/BUILD
+++ b/test/behaviour/concept/type/relationtype/BUILD
@@ -67,8 +67,7 @@ grakn_java_test(
     data = [
         "@graknlabs_behaviour//concept/type:relationtype.feature",
     ],
-    grakn_artifact_linux = "@graknlabs_grakn_core_artifact_linux//file",
-    grakn_artifact_mac = "@graknlabs_grakn_core_artifact_mac//file",
+    native_grakn_artifact = "//test:native-grakn-artifact",
     size = "medium",
 )
 

--- a/test/behaviour/concept/type/thingtype/BUILD
+++ b/test/behaviour/concept/type/thingtype/BUILD
@@ -68,8 +68,7 @@ grakn_java_test(
     data = [
         "@graknlabs_behaviour//concept/type:thingtype.feature",
     ],
-    grakn_artifact_linux = "@graknlabs_grakn_core_artifact_linux//file",
-    grakn_artifact_mac = "@graknlabs_grakn_core_artifact_mac//file",
+    native_grakn_artifact = "//test:native-grakn-artifact",
     size = "small",
 )
 

--- a/test/behaviour/connection/database/BUILD
+++ b/test/behaviour/connection/database/BUILD
@@ -62,8 +62,7 @@ grakn_java_test(
     data = [
         "@graknlabs_behaviour//connection:database.feature",
     ],
-    grakn_artifact_linux = "@graknlabs_grakn_core_artifact_linux//file",
-    grakn_artifact_mac = "@graknlabs_grakn_core_artifact_mac//file",
+    native_grakn_artifact = "//test:native-grakn-artifact",
     size = "small",
 )
 

--- a/test/behaviour/connection/session/BUILD
+++ b/test/behaviour/connection/session/BUILD
@@ -62,9 +62,8 @@ grakn_java_test(
     data = [
         "@graknlabs_behaviour//connection:session.feature",
     ],
-    grakn_artifact_linux = "@graknlabs_grakn_core_artifact_linux//file",
-    grakn_artifact_mac = "@graknlabs_grakn_core_artifact_mac//file",
-    size = "small",
+    native_grakn_artifact = "//test:native-grakn-artifact",
+    size = "medium",
 )
 
 checkstyle_test(

--- a/test/behaviour/connection/transaction/BUILD
+++ b/test/behaviour/connection/transaction/BUILD
@@ -66,8 +66,7 @@ grakn_java_test(
     data = [
         "@graknlabs_behaviour//connection:transaction.feature",
     ],
-    grakn_artifact_linux = "@graknlabs_grakn_core_artifact_linux//file",
-    grakn_artifact_mac = "@graknlabs_grakn_core_artifact_mac//file",
+    native_grakn_artifact = "//test:native-grakn-artifact",
     size = "small",
 )
 

--- a/test/behaviour/debug/BUILD
+++ b/test/behaviour/debug/BUILD
@@ -47,8 +47,7 @@ grakn_java_test(
     data = [
         ":debug.feature",
     ],
-    grakn_artifact_linux = "@graknlabs_grakn_core_artifact_linux//file",
-    grakn_artifact_mac = "@graknlabs_grakn_core_artifact_mac//file",
+    native_grakn_artifact = "//test:native-grakn-artifact",
     size = "medium",
     tags = ["manual"]
 )

--- a/test/behaviour/graql/language/define/BUILD
+++ b/test/behaviour/graql/language/define/BUILD
@@ -43,8 +43,7 @@ grakn_java_test(
     data = [
         "@graknlabs_behaviour//graql/language:define.feature",
     ],
-    grakn_artifact_linux = "@graknlabs_grakn_core_artifact_linux//file",
-    grakn_artifact_mac = "@graknlabs_grakn_core_artifact_mac//file",
+    native_grakn_artifact = "//test:native-grakn-artifact",
     size = "medium",
     visibility = ["//visibility:public"],
 )

--- a/test/behaviour/graql/language/delete/BUILD
+++ b/test/behaviour/graql/language/delete/BUILD
@@ -43,8 +43,7 @@ grakn_java_test(
     data = [
         "@graknlabs_behaviour//graql/language:delete.feature",
     ],
-    grakn_artifact_linux = "@graknlabs_grakn_core_artifact_linux//file",
-    grakn_artifact_mac = "@graknlabs_grakn_core_artifact_mac//file",
+    native_grakn_artifact = "//test:native-grakn-artifact",
     size = "medium",
     visibility = ["//visibility:public"],
 )

--- a/test/behaviour/graql/language/get/BUILD
+++ b/test/behaviour/graql/language/get/BUILD
@@ -43,8 +43,7 @@ grakn_java_test(
     data = [
         "@graknlabs_behaviour//graql/language:get.feature",
     ],
-    grakn_artifact_linux = "@graknlabs_grakn_core_artifact_linux//file",
-    grakn_artifact_mac = "@graknlabs_grakn_core_artifact_mac//file",
+    native_grakn_artifact = "//test:native-grakn-artifact",
     size = "medium",
     visibility = ["//visibility:public"],
 )

--- a/test/behaviour/graql/language/insert/BUILD
+++ b/test/behaviour/graql/language/insert/BUILD
@@ -43,8 +43,7 @@ grakn_java_test(
     data = [
         "@graknlabs_behaviour//graql/language:insert.feature",
     ],
-    grakn_artifact_linux = "@graknlabs_grakn_core_artifact_linux//file",
-    grakn_artifact_mac = "@graknlabs_grakn_core_artifact_mac//file",
+    native_grakn_artifact = "//test:native-grakn-artifact",
     size = "medium",
     visibility = ["//visibility:public"]
 )

--- a/test/behaviour/graql/language/match/BUILD
+++ b/test/behaviour/graql/language/match/BUILD
@@ -43,8 +43,7 @@ grakn_java_test(
     data = [
         "@graknlabs_behaviour//graql/language:match.feature",
     ],
-    grakn_artifact_linux = "@graknlabs_grakn_core_artifact_linux//file",
-    grakn_artifact_mac = "@graknlabs_grakn_core_artifact_mac//file",
+    native_grakn_artifact = "//test:native-grakn-artifact",
     size = "medium",
     visibility = ["//visibility:public"]
 )

--- a/test/behaviour/graql/language/undefine/BUILD
+++ b/test/behaviour/graql/language/undefine/BUILD
@@ -43,8 +43,7 @@ grakn_java_test(
     data = [
         "@graknlabs_behaviour//graql/language:undefine.feature",
     ],
-    grakn_artifact_linux = "@graknlabs_grakn_core_artifact_linux//file",
-    grakn_artifact_mac = "@graknlabs_grakn_core_artifact_mac//file",
+    native_grakn_artifact = "//test:native-grakn-artifact",
     size = "medium",
     visibility = ["//visibility:public"]
 )

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -37,8 +37,7 @@ grakn_java_test(
         "@maven//:org_hamcrest_hamcrest_library",
         "@maven//:org_slf4j_slf4j_api",
     ],
-    grakn_artifact_linux = "@graknlabs_grakn_core_artifact_linux//file",
-    grakn_artifact_mac = "@graknlabs_grakn_core_artifact_mac//file",
+    native_grakn_artifact = "//test:native-grakn-artifact",
 )
 
 checkstyle_test(


### PR DESCRIPTION
## What is the goal of this PR?

To fix a number of issues causing intermittent test failures.

## What are the changes implemented in this PR?

- Atomically modify the `ResponseCollector` map in `RPCTransaction` (enforced using the `AtomicBoolean` `transactionWasClosed`). This fixes an issue where `TransactionTest` would intermittently stall.
- Don't call `close()` after commit - it's better for the server to take responsibility for closing.
- Declare `native_grakn_artifact` explicitly and in one place. This fixes an issue where the build would fail in CI because it was trying to upload Grakn 32 times, once for each test.
- Add `--jobs=1` to `automation.yml` when running `bazel test //test/behaviour/connection/...`. This fixes an issue where this test would intermittently fail in CI due to Grabl not having enough memory to handle 24 concurrent RocksDB databases.
