### PR TITLE
Receiving batched answers from one GRPC message

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -60,7 +60,7 @@ build:
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        bazel test //test/behaviour/connection/... --test_output=errors
+        bazel test //test/behaviour/connection/... --test_output=errors --jobs=1
         bazel test //test/behaviour/concept/... --test_output=errors
         bazel test //test/behaviour/graql/language/define/... --test_output=errors
       # TODO: use --config=rbe once Grakn Core runs in RBE

--- a/concept/thing/impl/AttributeImpl.java
+++ b/concept/thing/impl/AttributeImpl.java
@@ -123,7 +123,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
             return stream(
                     ConceptProto.Thing.Req.newBuilder().setAttributeGetOwnersReq(
                             GetOwners.Req.getDefaultInstance()),
-                    res -> res.getAttributeGetOwnersRes().getThing()
+                    res -> res.getAttributeGetOwnersRes().getThingList()
             );
         }
 
@@ -132,7 +132,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
             return stream(
                     ConceptProto.Thing.Req.newBuilder().setAttributeGetOwnersReq(
                             GetOwners.Req.newBuilder().setThingType(type(ownerType))),
-                    res -> res.getAttributeGetOwnersRes().getThing()
+                    res -> res.getAttributeGetOwnersRes().getThingList()
             );
         }
 

--- a/concept/thing/impl/RelationImpl.java
+++ b/concept/thing/impl/RelationImpl.java
@@ -93,8 +93,8 @@ public class RelationImpl extends ThingImpl implements Relation {
 
             final TransactionProto.Transaction.Req.Builder request = TransactionProto.Transaction.Req.newBuilder()
                     .setThingReq(method.setIid(iid(getIID())));
-            final Stream<ConceptProto.Relation.GetPlayersByRoleType.Res> stream = rpcTransaction.stream(
-                    request, res -> res.getThingRes().getRelationGetPlayersByRoleTypeRes());
+            final Stream<ConceptProto.Relation.GetPlayersByRoleType.RoleTypeWithPlayer> stream = rpcTransaction.stream(
+                    request, res -> res.getThingRes().getRelationGetPlayersByRoleTypeRes().getRoleTypeWithPlayerList().stream());
 
             final Map<RoleTypeImpl, List<ThingImpl>> rolePlayerMap = new HashMap<>();
             stream.forEach(rolePlayer -> {
@@ -119,7 +119,7 @@ public class RelationImpl extends ThingImpl implements Relation {
             return stream(
                     ConceptProto.Thing.Req.newBuilder().setRelationGetPlayersReq(
                             GetPlayers.Req.newBuilder().addAllRoleTypes(types(Arrays.asList(roleTypes)))),
-                    res -> res.getRelationGetPlayersRes().getThing());
+                    res -> res.getRelationGetPlayersRes().getThingList());
         }
 
         @Override

--- a/concept/type/impl/AttributeTypeImpl.java
+++ b/concept/type/impl/AttributeTypeImpl.java
@@ -222,7 +222,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
                     .setAttributeTypeGetOwnersReq(ConceptProto.AttributeType.GetOwners.Req.newBuilder()
                             .setOnlyKey(onlyKey));
 
-            return stream(method, res -> res.getAttributeTypeGetOwnersRes().getOwner()).map(TypeImpl::asThingType);
+            return stream(method, res -> res.getAttributeTypeGetOwnersRes().getOwnerList()).map(TypeImpl::asThingType);
         }
 
         protected final AttributeImpl<?> put(Object value) {

--- a/concept/type/impl/RelationTypeImpl.java
+++ b/concept/type/impl/RelationTypeImpl.java
@@ -112,7 +112,7 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
             return stream(
                     ConceptProto.Type.Req.newBuilder().setRelationTypeGetRelatesReq(
                             GetRelates.Req.getDefaultInstance()),
-                    res -> res.getRelationTypeGetRelatesRes().getRole()
+                    res -> res.getRelationTypeGetRelatesRes().getRoleList()
             ).map(TypeImpl::asRoleType);
         }
 

--- a/concept/type/impl/RoleTypeImpl.java
+++ b/concept/type/impl/RoleTypeImpl.java
@@ -24,6 +24,7 @@ import grakn.client.concept.type.RoleType;
 import grakn.protocol.ConceptProto;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -134,7 +135,7 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
             return stream(
                     ConceptProto.Type.Req.newBuilder().setRoleTypeGetRelationTypesReq(
                             ConceptProto.RoleType.GetRelationTypes.Req.getDefaultInstance()),
-                    res -> res.getRoleTypeGetRelationTypesRes().getRelationType()
+                    res -> res.getRoleTypeGetRelationTypesRes().getRelationTypeList()
             ).map(TypeImpl::asRelationType);
         }
 
@@ -143,7 +144,7 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
             return stream(
                     ConceptProto.Type.Req.newBuilder().setRoleTypeGetPlayersReq(
                             ConceptProto.RoleType.GetPlayers.Req.getDefaultInstance()),
-                    res -> res.getRoleTypeGetPlayersRes().getThingType()
+                    res -> res.getRoleTypeGetPlayersRes().getThingTypeList()
             ).map(TypeImpl::asThingType);
         }
 
@@ -153,7 +154,7 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
         }
 
         @Override
-        Stream<TypeImpl> stream(ConceptProto.Type.Req.Builder method, Function<ConceptProto.Type.Res, ConceptProto.Type> typeGetter) {
+        Stream<TypeImpl> stream(ConceptProto.Type.Req.Builder method, Function<ConceptProto.Type.Res, List<ConceptProto.Type>> typeGetter) {
             return super.stream(method.setScope(scope), typeGetter);
         }
 

--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -106,7 +106,7 @@ public class ThingTypeImpl extends TypeImpl implements ThingType {
             final ConceptProto.Type.Req.Builder request = ConceptProto.Type.Req.newBuilder()
                     .setThingTypeGetInstancesReq(GetInstances.Req.getDefaultInstance());
 
-            return thingStream(request, res -> res.getThingTypeGetInstancesRes().getThing()).map(thingConstructor);
+            return thingStream(request, res -> res.getThingTypeGetInstancesRes().getThingList()).map(thingConstructor);
         }
 
         @Override
@@ -129,7 +129,7 @@ public class ThingTypeImpl extends TypeImpl implements ThingType {
             return stream(
                     ConceptProto.Type.Req.newBuilder().setThingTypeGetPlaysReq(
                             GetPlays.Req.getDefaultInstance()),
-                    res -> res.getThingTypeGetPlaysRes().getRole()
+                    res -> res.getThingTypeGetPlaysRes().getRoleList()
             ).map(TypeImpl::asRoleType);
         }
 
@@ -139,7 +139,7 @@ public class ThingTypeImpl extends TypeImpl implements ThingType {
             if (valueType != null) req.setValueType(valueType(valueType));
             return stream(
                     ConceptProto.Type.Req.newBuilder().setThingTypeGetOwnsReq(req),
-                    res -> res.getThingTypeGetOwnsRes().getAttributeType()
+                    res -> res.getThingTypeGetOwnsRes().getAttributeTypeList()
             ).map(TypeImpl::asAttributeType);
         }
 

--- a/concept/type/impl/TypeImpl.java
+++ b/concept/type/impl/TypeImpl.java
@@ -35,6 +35,7 @@ import grakn.protocol.ConceptProto.Type.SetSupertype;
 import grakn.protocol.TransactionProto;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -258,13 +259,13 @@ public abstract class TypeImpl implements Type {
         <TYPE extends TypeImpl> Stream<TYPE> getSupertypes(Function<TypeImpl, TYPE> typeConstructor) {
             final ConceptProto.Type.Req.Builder method = ConceptProto.Type.Req.newBuilder()
                     .setTypeGetSupertypesReq(ConceptProto.Type.GetSupertypes.Req.getDefaultInstance());
-            return stream(method, res -> res.getTypeGetSupertypesRes().getType()).map(typeConstructor);
+            return stream(method, res -> res.getTypeGetSupertypesRes().getTypeList()).map(typeConstructor);
         }
 
         <TYPE extends TypeImpl> Stream<TYPE> getSubtypes(Function<TypeImpl, TYPE> typeConstructor) {
             final ConceptProto.Type.Req.Builder method = ConceptProto.Type.Req.newBuilder()
                     .setTypeGetSubtypesReq(ConceptProto.Type.GetSubtypes.Req.getDefaultInstance());
-            return stream(method, res -> res.getTypeGetSubtypesRes().getType()).map(typeConstructor);
+            return stream(method, res -> res.getTypeGetSubtypesRes().getTypeList()).map(typeConstructor);
         }
 
         @Override
@@ -281,16 +282,16 @@ public abstract class TypeImpl implements Type {
             return rpcTransaction;
         }
 
-        Stream<TypeImpl> stream(ConceptProto.Type.Req.Builder method, Function<ConceptProto.Type.Res, ConceptProto.Type> typeGetter) {
+        Stream<TypeImpl> stream(ConceptProto.Type.Req.Builder method, Function<ConceptProto.Type.Res, List<ConceptProto.Type>> typeGetter) {
             final TransactionProto.Transaction.Req.Builder request = TransactionProto.Transaction.Req.newBuilder()
                     .setTypeReq(method.setLabel(label));
-            return rpcTransaction.stream(request, res -> TypeImpl.of(typeGetter.apply(res.getTypeRes())));
+            return rpcTransaction.stream(request, res -> typeGetter.apply(res.getTypeRes()).stream().map(TypeImpl::of));
         }
 
-        Stream<ThingImpl> thingStream(ConceptProto.Type.Req.Builder method, Function<ConceptProto.Type.Res, ConceptProto.Thing> thingGetter) {
+        Stream<ThingImpl> thingStream(ConceptProto.Type.Req.Builder method, Function<ConceptProto.Type.Res, List<ConceptProto.Thing>> thingGetter) {
             final TransactionProto.Transaction.Req.Builder request = TransactionProto.Transaction.Req.newBuilder()
                     .setTypeReq(method.setLabel(label));
-            return rpcTransaction.stream(request, res -> ThingImpl.of(thingGetter.apply(res.getTypeRes())));
+            return rpcTransaction.stream(request, res -> thingGetter.apply(res.getTypeRes()).stream().map(ThingImpl::of));
         }
 
         ConceptProto.Type.Res execute(ConceptProto.Type.Req.Builder method) {

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,5 +27,5 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.tar.gz",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "d4e6c22abd7dbd03c2f71f01da21961df9bb2f5a",
+        commit = "6a6d6d834f96895dc56e8e107ff1d603ae0d2846",
     )

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,5 +27,5 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.tar.gz",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "4d513df90bbbb39bc10cc0eef3c8fb4b9ad8469d",
+        commit = "d4e6c22abd7dbd03c2f71f01da21961df9bb2f5a",
     )

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,5 +27,5 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.tar.gz",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "fd7ef4a226188a582b98e36005d9c749ae835e57",
+        commit = "4d513df90bbbb39bc10cc0eef3c8fb4b9ad8469d",
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -51,7 +51,7 @@ def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        commit = "487263c4be15d61e9bf95cc35e14168ab2b4fba6", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "f9423e2d53c88ce770978d843e97a5d6ccdbd2de", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():

--- a/dependencies/maven/update.sh
+++ b/dependencies/maven/update.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env sh
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -16,7 +17,5 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
-#!/usr/bin/env sh
 
 bazel run @graknlabs_dependencies//library/maven:update

--- a/query/QueryManager.java
+++ b/query/QueryManager.java
@@ -51,7 +51,7 @@ public final class QueryManager {
     public Stream<ConceptMap> match(GraqlMatch query, GraknOptions options) {
         final QueryProto.Query.Req.Builder request = QueryProto.Query.Req.newBuilder().setMatchReq(
                 QueryProto.Graql.Match.Req.newBuilder().setQuery(query.toString()));
-        return iterateQuery(request, options, res -> ConceptMap.of(res.getQueryRes().getMatchRes().getAnswer()));
+        return iterateQuery(request, options, res -> res.getQueryRes().getMatchRes().getAnswerList().stream().map(ConceptMap::of));
     }
 
     public Stream<ConceptMap> insert(GraqlInsert query) {
@@ -61,7 +61,7 @@ public final class QueryManager {
     public Stream<ConceptMap> insert(GraqlInsert query, GraknOptions options) {
         final QueryProto.Query.Req.Builder request = QueryProto.Query.Req.newBuilder().setInsertReq(
                 QueryProto.Graql.Insert.Req.newBuilder().setQuery(query.toString()));
-        return iterateQuery(request, options, res -> ConceptMap.of(res.getQueryRes().getInsertRes().getAnswer()));
+        return iterateQuery(request, options, res -> res.getQueryRes().getInsertRes().getAnswerList().stream().map(ConceptMap::of));
     }
 
     public QueryFuture<Void> delete(GraqlDelete query) {
@@ -95,7 +95,7 @@ public final class QueryManager {
     }
 
     private <T> Stream<T> iterateQuery(QueryProto.Query.Req.Builder request, GraknOptions options,
-                                       Function<TransactionProto.Transaction.Res, T> responseReader) {
+                                       Function<TransactionProto.Transaction.Res, Stream<T>> responseReader) {
         final TransactionProto.Transaction.Req.Builder req = TransactionProto.Transaction.Req.newBuilder()
                 .setQueryReq(request.setOptions(options(options)));
         return rpcTransaction.stream(req, responseReader);

--- a/rpc/QueryIterator.java
+++ b/rpc/QueryIterator.java
@@ -75,11 +75,7 @@ class QueryIterator<T> extends AbstractIterator<T> {
                 throw new GraknClientException(MISSING_RESPONSE.message(className(TransactionProto.Transaction.Res.class)));
             default:
                 currIterator = transformResponse.apply(res).iterator();
-                if (currIterator.hasNext()) {
-                    return currIterator.next();
-                } else {
-                    return computeNext();
-                }
+                return computeNext();
         }
     }
 }

--- a/rpc/RPCTransaction.java
+++ b/rpc/RPCTransaction.java
@@ -159,7 +159,7 @@ public class RPCTransaction implements Transaction {
         }
     }
 
-    public <T> Stream<T> stream(TransactionProto.Transaction.Req.Builder request, Function<TransactionProto.Transaction.Res, T> transformResponse) {
+    public <T> Stream<T> stream(TransactionProto.Transaction.Req.Builder request, Function<TransactionProto.Transaction.Res, Stream<T>> transformResponse) {
         try (ThreadTrace ignored = traceOnThread("stream")) {
             final ResponseCollector.Multiple responseCollector = new ResponseCollector.Multiple();
             final UUID requestId = UUID.randomUUID();


### PR DESCRIPTION
## What is the goal of this PR?

This PR is complementary to https://github.com/graknlabs/grakn-2.0/pull/91

Too many GRPC calls cause performance problem which we decided to solve by allowing multiple answers into one message. We need to update client accordingly so that we can receive multiple answers in one message.

## What are the changes implemented in this PR?

- Update protocol and fix relevant code
- Change `QueryIterator` to save an `iterator` field so that we will exhaust the answers in one message before we process the next message.
