### PR TITLE
Unused code cleanup and streaming fixes

### DIFF
--- a/Grakn.java
+++ b/Grakn.java
@@ -28,9 +28,9 @@ public interface Grakn {
 
     interface Client extends AutoCloseable {
 
-        Session session(String databaseName, Session.Type type);
+        Session session(String database, Session.Type type);
 
-        Session session(String databaseName, Session.Type type, GraknOptions options);
+        Session session(String database, Session.Type type, GraknOptions options);
 
         DatabaseManager databases();
 

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -49,7 +49,7 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
         public static final Concept INVALID_CONCEPT_CASTING =
                 new Concept(1, "Invalid concept conversion from '%s' to '%s'.");
         public static final Concept MISSING_TRANSACTION =
-                new Concept(2, "Transaction can not be null.");
+                new Concept(2, "Transaction cannot be null.");
         public static final Concept MISSING_IID =
                 new Concept(3, "IID cannot be null or empty.");
         public static final Concept MISSING_LABEL =

--- a/concept/ConceptManager.java
+++ b/concept/ConceptManager.java
@@ -139,13 +139,10 @@ public final class ConceptManager {
                 .setGetThingReq(ConceptProto.ConceptManager.GetThing.Req.newBuilder().setIid(iid(iid))).build();
 
         final ConceptProto.ConceptManager.Res response = execute(req);
-        switch (response.getGetThingRes().getResCase()) {
-            case THING:
-                return ThingImpl.of(response.getGetThingRes().getThing());
-            default:
-            case RES_NOT_SET:
-                return null;
-        }
+        if (response.getGetThingRes().getResCase() == ConceptProto.ConceptManager.GetThing.Res.ResCase.THING)
+            return ThingImpl.of(response.getGetThingRes().getThing());
+        else
+            return null;
     }
 
     @Nullable
@@ -155,13 +152,10 @@ public final class ConceptManager {
                 .setGetTypeReq(ConceptProto.ConceptManager.GetType.Req.newBuilder().setLabel(label)).build();
 
         final ConceptProto.ConceptManager.Res response = execute(req);
-        switch (response.getGetTypeRes().getResCase()) {
-            case TYPE:
-                return TypeImpl.of(response.getGetTypeRes().getType());
-            default:
-            case RES_NOT_SET:
-                return null;
-        }
+        if (response.getGetTypeRes().getResCase() == ConceptProto.ConceptManager.GetType.Res.ResCase.TYPE)
+            return TypeImpl.of(response.getGetTypeRes().getType());
+        else
+            return null;
     }
 
     @Nullable

--- a/concept/ConceptManager.java
+++ b/concept/ConceptManager.java
@@ -84,8 +84,8 @@ public final class ConceptManager {
     @Nullable
     @CheckReturnValue
     public EntityType getEntityType(String label) {
-        final Type concept = getType(label);
-        if (concept instanceof EntityType) return concept.asEntityType();
+        final Type type = getType(label);
+        if (type instanceof EntityType) return type.asEntityType();
         else return null;
     }
 
@@ -100,8 +100,8 @@ public final class ConceptManager {
     @Nullable
     @CheckReturnValue
     public RelationType getRelationType(String label) {
-        final Type concept = getType(label);
-        if (concept instanceof RelationType) return concept.asRelationType();
+        final Type type = getType(label);
+        if (type instanceof RelationType) return type.asRelationType();
         else return null;
     }
 
@@ -117,8 +117,8 @@ public final class ConceptManager {
     @Nullable
     @CheckReturnValue
     public AttributeType getAttributeType(String label) {
-        final Type concept = getType(label);
-        if (concept instanceof AttributeType) return concept.asAttributeType();
+        final Type type = getType(label);
+        if (type instanceof AttributeType) return type.asAttributeType();
         else return null;
     }
 

--- a/concept/thing/impl/AttributeImpl.java
+++ b/concept/thing/impl/AttributeImpl.java
@@ -100,24 +100,6 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
             super(transaction, iid);
         }
 
-        public static AttributeImpl.Remote<?> of(Grakn.Transaction transaction, ConceptProto.Thing thingProto) {
-            switch (thingProto.getValueType()) {
-                case BOOLEAN:
-                    return AttributeImpl.Boolean.Remote.of(transaction, thingProto);
-                case LONG:
-                    return AttributeImpl.Long.Remote.of(transaction, thingProto);
-                case DOUBLE:
-                    return AttributeImpl.Double.Remote.of(transaction, thingProto);
-                case STRING:
-                    return AttributeImpl.String.Remote.of(transaction, thingProto);
-                case DATETIME:
-                    return AttributeImpl.DateTime.Remote.of(transaction, thingProto);
-                case UNRECOGNIZED:
-                default:
-                    throw new GraknClientException(BAD_VALUE_TYPE.message(thingProto.getValueType()));
-            }
-        }
-
         @Override
         public final Stream<ThingImpl> getOwners() {
             return stream(

--- a/concept/thing/impl/EntityImpl.java
+++ b/concept/thing/impl/EntityImpl.java
@@ -51,10 +51,6 @@ public class EntityImpl extends ThingImpl implements Entity {
             super(transaction, iid);
         }
 
-        public static EntityImpl.Remote of(Grakn.Transaction transaction, ConceptProto.Thing protoThing) {
-            return new EntityImpl.Remote(transaction, Bytes.bytesToHexString(protoThing.getIid().toByteArray()));
-        }
-
         @Override
         public EntityImpl.Remote asRemote(Grakn.Transaction transaction) {
             return new EntityImpl.Remote(transaction, getIID());

--- a/concept/thing/impl/RelationImpl.java
+++ b/concept/thing/impl/RelationImpl.java
@@ -72,10 +72,6 @@ public class RelationImpl extends ThingImpl implements Relation {
             super(transaction, iid);
         }
 
-        public static RelationImpl.Remote of(Grakn.Transaction transaction, ConceptProto.Thing protoThing) {
-            return new RelationImpl.Remote(transaction, Bytes.bytesToHexString(protoThing.getIid().toByteArray()));
-        }
-
         @Override
         public RelationImpl.Remote asRemote(Grakn.Transaction transaction) {
             return new RelationImpl.Remote(transaction, getIID());

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -149,21 +149,6 @@ public abstract class ThingImpl implements Thing {
             this.hash = Objects.hash(this.rpcTransaction, this.getIID());
         }
 
-        public static ThingImpl.Remote of(Grakn.Transaction transaction, ConceptProto.Thing protoThing) {
-
-            switch (protoThing.getEncoding()) {
-                case ENTITY:
-                    return EntityImpl.Remote.of(transaction, protoThing);
-                case RELATION:
-                    return RelationImpl.Remote.of(transaction, protoThing);
-                case ATTRIBUTE:
-                    return AttributeImpl.Remote.of(transaction, protoThing);
-                default:
-                case UNRECOGNIZED:
-                    throw new GraknClientException(BAD_ENCODING.message(protoThing.getEncoding()));
-            }
-        }
-
         @Override
         public final String getIID() {
             return iid;

--- a/concept/type/ThingType.java
+++ b/concept/type/ThingType.java
@@ -56,7 +56,7 @@ public interface ThingType extends Type {
 
         void setPlays(RoleType roleType, RoleType overriddenType);
 
-        void setOwns(AttributeType attributeType, AttributeType otherType, boolean isKey);
+        void setOwns(AttributeType attributeType, AttributeType overriddenType, boolean isKey);
 
         void setOwns(AttributeType attributeType, AttributeType overriddenType);
 

--- a/concept/type/impl/AttributeTypeImpl.java
+++ b/concept/type/impl/AttributeTypeImpl.java
@@ -143,27 +143,6 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
             super(transaction, label, isRoot);
         }
 
-        public static AttributeTypeImpl.Remote of(Grakn.Transaction transaction, ConceptProto.Type typeProto) {
-            switch (typeProto.getValueType()) {
-                case BOOLEAN:
-                    return new AttributeTypeImpl.Boolean.Remote(transaction, typeProto.getLabel(), typeProto.getRoot());
-                case LONG:
-                    return new AttributeTypeImpl.Long.Remote(transaction, typeProto.getLabel(), typeProto.getRoot());
-                case DOUBLE:
-                    return new AttributeTypeImpl.Double.Remote(transaction, typeProto.getLabel(), typeProto.getRoot());
-                case STRING:
-                    return new AttributeTypeImpl.String.Remote(transaction, typeProto.getLabel(), typeProto.getRoot());
-                case DATETIME:
-                    return new AttributeTypeImpl.DateTime.Remote(transaction, typeProto.getLabel(), typeProto.getRoot());
-                case OBJECT:
-                    assert typeProto.getRoot();
-                    return new AttributeTypeImpl.Remote(transaction, typeProto.getLabel(), typeProto.getRoot());
-                case UNRECOGNIZED:
-                default:
-                    throw new GraknClientException(BAD_VALUE_TYPE.message(typeProto.getValueType()));
-            }
-        }
-
         @Override
         public ValueType getValueType() {
             return ValueType.OBJECT;
@@ -229,7 +208,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
             final ConceptProto.Type.Req.Builder method = ConceptProto.Type.Req.newBuilder()
                     .setAttributeTypePutReq(ConceptProto.AttributeType.Put.Req.newBuilder()
                             .setValue(attributeValue(value)));
-            return ThingImpl.of(execute(method).getAttributeTypePutRes().getAttribute()).asAttribute();
+            return AttributeImpl.of(execute(method).getAttributeTypePutRes().getAttribute());
         }
 
         @Nullable
@@ -240,7 +219,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
             final ConceptProto.AttributeType.Get.Res response = execute(method).getAttributeTypeGetRes();
             switch (response.getResCase()) {
                 case ATTRIBUTE:
-                    return ThingImpl.of(response.getAttribute()).asAttribute();
+                    return AttributeImpl.of(response.getAttribute());
                 default:
                 case RES_NOT_SET:
                     return null;

--- a/concept/type/impl/EntityTypeImpl.java
+++ b/concept/type/impl/EntityTypeImpl.java
@@ -24,13 +24,12 @@ import grakn.client.concept.thing.impl.EntityImpl;
 import grakn.client.concept.thing.impl.ThingImpl;
 import grakn.client.concept.type.EntityType;
 import grakn.protocol.ConceptProto;
-import grakn.protocol.ConceptProto.EntityType.Create;
 
 import java.util.stream.Stream;
 
 public class EntityTypeImpl extends ThingTypeImpl implements EntityType {
 
-    public EntityTypeImpl(String label, boolean isRoot) {
+    EntityTypeImpl(String label, boolean isRoot) {
         super(label, isRoot);
     }
 
@@ -50,12 +49,8 @@ public class EntityTypeImpl extends ThingTypeImpl implements EntityType {
 
     public static class Remote extends ThingTypeImpl.Remote implements EntityType.Remote {
 
-        public Remote(Grakn.Transaction transaction, String label, boolean isRoot) {
+        Remote(Grakn.Transaction transaction, String label, boolean isRoot) {
             super(transaction, label, isRoot);
-        }
-
-        public static EntityTypeImpl.Remote of(Grakn.Transaction transaction, ConceptProto.Type proto) {
-            return new EntityTypeImpl.Remote(transaction, proto.getLabel(), proto.getRoot());
         }
 
         @Override
@@ -91,8 +86,8 @@ public class EntityTypeImpl extends ThingTypeImpl implements EntityType {
         @Override
         public final EntityImpl create() {
             final ConceptProto.Type.Req.Builder method = ConceptProto.Type.Req.newBuilder()
-                    .setEntityTypeCreateReq(Create.Req.getDefaultInstance());
-            return ThingImpl.of(execute(method).getEntityTypeCreateRes().getEntity()).asEntity();
+                    .setEntityTypeCreateReq(ConceptProto.EntityType.Create.Req.getDefaultInstance());
+            return EntityImpl.of(execute(method).getEntityTypeCreateRes().getEntity());
         }
 
         @Override

--- a/concept/type/impl/RelationTypeImpl.java
+++ b/concept/type/impl/RelationTypeImpl.java
@@ -33,7 +33,7 @@ import java.util.stream.Stream;
 
 public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
 
-    public RelationTypeImpl(String label, boolean isRoot) {
+    RelationTypeImpl(String label, boolean isRoot) {
         super(label, isRoot);
     }
 
@@ -55,10 +55,6 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
 
         public Remote(Grakn.Transaction transaction, String label, boolean isRoot) {
             super(transaction, label, isRoot);
-        }
-
-        public static RelationTypeImpl.Remote of(Grakn.Transaction transaction, ConceptProto.Type proto) {
-            return new RelationTypeImpl.Remote(transaction, proto.getLabel(), proto.getRoot());
         }
 
         @Override
@@ -95,7 +91,7 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
         public final RelationImpl create() {
             final ConceptProto.Type.Req.Builder method = ConceptProto.Type.Req.newBuilder().setRelationTypeCreateReq(
                     ConceptProto.RelationType.Create.Req.getDefaultInstance());
-            return ThingImpl.of(execute(method).getRelationTypeCreateRes().getRelation()).asRelation();
+            return RelationImpl.of(execute(method).getRelationTypeCreateRes().getRelation());
         }
 
         @Override

--- a/concept/type/impl/RoleTypeImpl.java
+++ b/concept/type/impl/RoleTypeImpl.java
@@ -36,7 +36,7 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
     private final String scope;
     private final int hash;
 
-    public RoleTypeImpl(String label, String scope, boolean root) {
+    RoleTypeImpl(String label, String scope, boolean root) {
         super(label, root);
         this.scope = scope;
         this.hash = Objects.hash(this.scope, label);
@@ -90,10 +90,6 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
             super(transaction, label, isRoot);
             this.scope = scope;
             this.hash = Objects.hash(transaction, label, scope);
-        }
-
-        public static RoleTypeImpl.Remote of(Grakn.Transaction transaction, ConceptProto.Type proto) {
-            return new RoleTypeImpl.Remote(transaction, proto.getLabel(), proto.getScope(), proto.getRoot());
         }
 
         @Nullable

--- a/concept/type/impl/RuleImpl.java
+++ b/concept/type/impl/RuleImpl.java
@@ -102,7 +102,7 @@ public class RuleImpl implements Rule {
     public static class Remote implements Rule.Remote {
 
         final RPCTransaction rpcTransaction;
-        private final String label;
+        private String label;
         private final Conjunction<? extends Pattern> when;
         private final ThingVariable<?> then;
         private final int hash;
@@ -139,6 +139,7 @@ public class RuleImpl implements Rule {
         @Override
         public void setLabel(String label) {
             execute(ConceptProto.Rule.Req.newBuilder().setRuleSetLabelReq(ConceptProto.Rule.SetLabel.Req.newBuilder().setLabel(label)));
+            this.label = label;
         }
 
         @Override

--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -83,10 +83,6 @@ public class ThingTypeImpl extends TypeImpl implements ThingType {
             super(transaction, label, isRoot);
         }
 
-        public static ThingTypeImpl.Remote of(Grakn.Transaction transaction, ConceptProto.Type type) {
-            return new ThingTypeImpl.Remote(transaction, type.getLabel(), type.getRoot());
-        }
-
         @Override
         public ThingTypeImpl getSupertype() {
             return super.getSupertypeExecute(TypeImpl::asThingType);

--- a/concept/type/impl/TypeImpl.java
+++ b/concept/type/impl/TypeImpl.java
@@ -143,7 +143,7 @@ public abstract class TypeImpl implements Type {
     public abstract static class Remote implements Type.Remote {
 
         final RPCTransaction rpcTransaction;
-        private final String label;
+        private String label;
         private final boolean isRoot;
         private final int hash;
 
@@ -154,24 +154,6 @@ public abstract class TypeImpl implements Type {
             this.label = label;
             this.isRoot = isRoot;
             this.hash = Objects.hash(transaction, label);
-        }
-
-        public static TypeImpl.Remote of(Grakn.Transaction transaction, ConceptProto.Type type) {
-            switch (type.getEncoding()) {
-                case ENTITY_TYPE:
-                    return EntityTypeImpl.Remote.of(transaction, type);
-                case RELATION_TYPE:
-                    return RelationTypeImpl.Remote.of(transaction, type);
-                case ATTRIBUTE_TYPE:
-                    return AttributeTypeImpl.Remote.of(transaction, type);
-                case ROLE_TYPE:
-                    return RoleTypeImpl.Remote.of(transaction, type);
-                case THING_TYPE:
-                    return ThingTypeImpl.Remote.of(transaction, type);
-                case UNRECOGNIZED:
-                default:
-                    throw new GraknClientException(BAD_ENCODING.message(type.getEncoding()));
-            }
         }
 
         @Override
@@ -193,6 +175,7 @@ public abstract class TypeImpl implements Type {
         public final void setLabel(String label) {
             execute(ConceptProto.Type.Req.newBuilder()
                     .setTypeSetLabelReq(ConceptProto.Type.SetLabel.Req.newBuilder().setLabel(label)));
+            this.label = label;
         }
 
         @Override

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,5 +27,5 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.tar.gz",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "ab1b7109401b861b82d8ee7b132db6ffd2fdb327",
+        commit = "75add9c31b68bea8a1d285a133cc3e2dad9e5af5",
     )

--- a/rpc/QueryFuture.java
+++ b/rpc/QueryFuture.java
@@ -33,11 +33,9 @@ public class QueryFuture<T> implements Future<T> {
     private final RPCTransaction.ResponseCollector.Single collector;
     private final Function<TransactionProto.Transaction.Res, T> transformResponse;
 
-    QueryFuture(TransactionProto.Transaction.Req request, StreamObserver<TransactionProto.Transaction.Req> requestObserver,
-            RPCTransaction.ResponseCollector.Single collector, Function<TransactionProto.Transaction.Res, T> transformResponse) {
+    QueryFuture(RPCTransaction.ResponseCollector.Single collector, Function<TransactionProto.Transaction.Res, T> transformResponse) {
         this.collector = collector;
         this.transformResponse = transformResponse;
-        requestObserver.onNext(request);
     }
 
     @Override

--- a/rpc/RPCTransaction.java
+++ b/rpc/RPCTransaction.java
@@ -151,7 +151,8 @@ public class RPCTransaction implements Transaction {
             final UUID requestId = UUID.randomUUID();
             request.setId(requestId.toString());
             collectors.put(requestId, responseCollector);
-            return new QueryFuture<>(request.build(), requestObserver, responseCollector, transformResponse);
+            requestObserver.onNext(request.build());
+            return new QueryFuture<>(responseCollector, transformResponse);
         }
     }
 
@@ -162,7 +163,8 @@ public class RPCTransaction implements Transaction {
             request.setId(requestId.toString());
             request.setLatencyMillis(networkLatencyMillis);
             collectors.put(requestId, responseCollector);
-            final QueryIterator<T> queryIterator = new QueryIterator<>(request.build(), requestObserver, responseCollector, transformResponse);
+            requestObserver.onNext(request.build());
+            final QueryIterator<T> queryIterator = new QueryIterator<>(requestId, requestObserver, responseCollector, transformResponse);
             return StreamSupport.stream(((Iterable<T>) () -> queryIterator).spliterator(), false);
         }
     }
@@ -175,7 +177,6 @@ public class RPCTransaction implements Transaction {
                 final ResponseCollector collector = collectors.get(requestId);
                 if (collector == null) throw new GraknClientException(UNKNOWN_REQUEST_ID.message(requestId));
                 collector.add(new Response.Ok(res));
-                if (collector.isDone()) collectors.remove(requestId);
             }
 
             @Override

--- a/rpc/RPCTransaction.java
+++ b/rpc/RPCTransaction.java
@@ -212,10 +212,6 @@ public class RPCTransaction implements Transaction {
             map.put(requestId, collector);
         }
 
-        private synchronized void remove(UUID requestId) {
-            map.remove(requestId);
-        }
-
         private synchronized void clearWithError(Response.Error errorResponse) {
             map.values().parallelStream().forEach(x -> x.add(errorResponse));
             map.clear();


### PR DESCRIPTION
## What is the goal of this PR?

To clean up redundant code and fix errors when performing streaming requests.

## What are the changes implemented in this PR?

- Clear unused methods from `concept` package
- Fix error in `RPCTransaction` when the server sends a `DONE` response and then receives a `CONTINUE` request from the client - this is, in fact, the expected flow and should not trigger an error.
- Fix `setLabel` not updating the `label` locally.
