### PR TITLE
Remove duplication in getPlayersByRoleType

### DIFF
--- a/concept/thing/impl/RelationImpl.java
+++ b/concept/thing/impl/RelationImpl.java
@@ -102,12 +102,7 @@ public class RelationImpl extends ThingImpl implements Relation {
                     rolePlayerMap.put(role, new ArrayList<>(Collections.singletonList(player)));
                 }
             });
-
-            final Map<RoleTypeImpl, List<ThingImpl>> result = new HashMap<>();
-            for (Map.Entry<RoleTypeImpl, List<ThingImpl>> entry : rolePlayerMap.entrySet()) {
-                result.put(entry.getKey(), entry.getValue());
-            }
-            return result;
+            return rolePlayerMap;
         }
 
         @Override


### PR DESCRIPTION
## What is the goal of this PR?

In getPlayersByRoleType, a hasmap is created, filled out with the contents of an existing hashmap, and returned. This PR removes this and simply returns the existing hashmap.
