### PR TITLE
Integrate dependency-analysis job

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -25,6 +25,7 @@ config:
     dependencies: [build]
     protocol: [build, release]
     behaviour: [build]
+    grabl-tracing: [build, release]
 
 build:
   quality:

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -18,6 +18,13 @@
 #
 config:
   version-candidate: VERSION
+  dependencies:
+    graql: [build, release]
+    common: [build, release]
+    bazel-distribution: [build]
+    dependencies: [build]
+    protocol: [build, release]
+    behaviour: [build]
 
 build:
   quality:
@@ -31,6 +38,10 @@ build:
           bazel run @graknlabs_dependencies//tool/sonarcloud:code-analysis -- \
           --project-key=graknlabs_client_java \
           --branch=$GRABL_BRANCH --commit-id=$GRABL_COMMIT
+    dependency-analysis:
+      machine: graknlabs-ubuntu-20.04
+      script: |
+        bazel run @graknlabs_dependencies//grabl/analysis:dependency-analysis
   correctness:
     build:
       machine: graknlabs-ubuntu-20.04

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -44,7 +44,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "f647768040014285e75849feed37d67a2b29260e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "a4f56afaacd8d09cc62a6c2fc0fd55718eaa98c2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_protocol():


### PR DESCRIPTION
## What is the goal of this PR?

In order for us to know whether our dependencies are up-to-date, we integrate `dependency-analysis` job into `quality` workflow

## What are the changes implemented in this PR?

* Specify dependencies on other repos in `.grabl/automation.yml`
* Add `dependency-analysis` to `quality` workflow
* Upgrade `graknlabs_dependencies`