### PR TITLE
Update grakn core artifact + minor refactorings

### DIFF
--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -283,16 +283,16 @@ public abstract class ThingImpl implements Thing {
             return rpcTransaction;
         }
 
-        Stream<ThingImpl> stream(ConceptProto.Thing.Req.Builder method, Function<ConceptProto.Thing.Res, List<ConceptProto.Thing>> thingGetter) {
+        Stream<ThingImpl> stream(ConceptProto.Thing.Req.Builder method, Function<ConceptProto.Thing.Res, List<ConceptProto.Thing>> thingListGetter) {
             final TransactionProto.Transaction.Req.Builder request = TransactionProto.Transaction.Req.newBuilder()
                     .setThingReq(method.setIid(iid(iid)));
-            return rpcTransaction.stream(request, res -> thingGetter.apply(res.getThingRes()).stream().map(ThingImpl::of));
+            return rpcTransaction.stream(request, res -> thingListGetter.apply(res.getThingRes()).stream().map(ThingImpl::of));
         }
 
-        Stream<TypeImpl> typeStream(ConceptProto.Thing.Req.Builder method, Function<ConceptProto.Thing.Res, List<ConceptProto.Type>> typeGetter) {
+        Stream<TypeImpl> typeStream(ConceptProto.Thing.Req.Builder method, Function<ConceptProto.Thing.Res, List<ConceptProto.Type>> typeListGetter) {
             final TransactionProto.Transaction.Req.Builder request = TransactionProto.Transaction.Req.newBuilder()
                     .setThingReq(method.setIid(iid(iid)));
-            return rpcTransaction.stream(request, res -> typeGetter.apply(res.getThingRes()).stream().map(TypeImpl::of));
+            return rpcTransaction.stream(request, res -> typeListGetter.apply(res.getThingRes()).stream().map(TypeImpl::of));
         }
 
         ConceptProto.Thing.Res execute(ConceptProto.Thing.Req.Builder method) {

--- a/concept/type/impl/RoleTypeImpl.java
+++ b/concept/type/impl/RoleTypeImpl.java
@@ -160,8 +160,8 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
         }
 
         @Override
-        Stream<TypeImpl> typeStream(ConceptProto.Type.Req.Builder method, Function<ConceptProto.Type.Res, List<ConceptProto.Type>> typeGetter) {
-            return super.typeStream(method.setScope(scope), typeGetter);
+        Stream<TypeImpl> typeStream(ConceptProto.Type.Req.Builder method, Function<ConceptProto.Type.Res, List<ConceptProto.Type>> typeListGetter) {
+            return super.typeStream(method.setScope(scope), typeListGetter);
         }
 
         @Override

--- a/concept/type/impl/TypeImpl.java
+++ b/concept/type/impl/TypeImpl.java
@@ -263,16 +263,16 @@ public abstract class TypeImpl implements Type {
             return rpcTransaction;
         }
 
-        Stream<TypeImpl> typeStream(ConceptProto.Type.Req.Builder method, Function<ConceptProto.Type.Res, List<ConceptProto.Type>> typeGetter) {
+        Stream<TypeImpl> typeStream(ConceptProto.Type.Req.Builder method, Function<ConceptProto.Type.Res, List<ConceptProto.Type>> typeListGetter) {
             final TransactionProto.Transaction.Req.Builder request = TransactionProto.Transaction.Req.newBuilder()
                     .setTypeReq(method.setLabel(label));
-            return rpcTransaction.stream(request, res -> typeGetter.apply(res.getTypeRes()).stream().map(TypeImpl::of));
+            return rpcTransaction.stream(request, res -> typeListGetter.apply(res.getTypeRes()).stream().map(TypeImpl::of));
         }
 
-        Stream<ThingImpl> thingStream(ConceptProto.Type.Req.Builder method, Function<ConceptProto.Type.Res, List<ConceptProto.Thing>> thingGetter) {
+        Stream<ThingImpl> thingStream(ConceptProto.Type.Req.Builder method, Function<ConceptProto.Type.Res, List<ConceptProto.Thing>> thingListGetter) {
             final TransactionProto.Transaction.Req.Builder request = TransactionProto.Transaction.Req.newBuilder()
                     .setTypeReq(method.setLabel(label));
-            return rpcTransaction.stream(request, res -> thingGetter.apply(res.getTypeRes()).stream().map(ThingImpl::of));
+            return rpcTransaction.stream(request, res -> thingListGetter.apply(res.getTypeRes()).stream().map(ThingImpl::of));
         }
 
         ConceptProto.Type.Res execute(ConceptProto.Type.Req.Builder method) {

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,5 +27,5 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.tar.gz",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "a939cddf2134657916a989b0a9abb29a39ecfa67",
+        commit = "e43c18d37b753a86e9f278b59336ddfa5c9bdc35",
     )

--- a/rpc/RPCTransaction.java
+++ b/rpc/RPCTransaction.java
@@ -164,8 +164,8 @@ public class RPCTransaction implements Transaction {
             request.setLatencyMillis(networkLatencyMillis);
             collectors.put(requestId, responseCollector);
             requestObserver.onNext(request.build());
-            final QueryIterator<T> queryIterator = new QueryIterator<>(requestId, requestObserver, responseCollector, transformResponse);
-            return StreamSupport.stream(((Iterable<T>) () -> queryIterator).spliterator(), false);
+            final ResponseIterator<T> responseIterator = new ResponseIterator<>(requestId, requestObserver, responseCollector, transformResponse);
+            return StreamSupport.stream(((Iterable<T>) () -> responseIterator).spliterator(), false);
         }
     }
 

--- a/rpc/ResponseIterator.java
+++ b/rpc/ResponseIterator.java
@@ -32,7 +32,7 @@ import java.util.stream.Stream;
 import static grakn.client.common.exception.ErrorMessage.Client.MISSING_RESPONSE;
 import static grakn.common.util.Objects.className;
 
-class QueryIterator<T> extends AbstractIterator<T> {
+class ResponseIterator<T> extends AbstractIterator<T> {
 
     private final UUID requestId;
     private final StreamObserver<TransactionProto.Transaction.Req> requestObserver;
@@ -40,8 +40,8 @@ class QueryIterator<T> extends AbstractIterator<T> {
     private final Function<TransactionProto.Transaction.Res, Stream<T>> transformResponse;
     private Iterator<T> currentIterator;
 
-    QueryIterator(UUID requestId, StreamObserver<TransactionProto.Transaction.Req> requestObserver,
-                  RPCTransaction.ResponseCollector.Multiple responseCollector, Function<TransactionProto.Transaction.Res, Stream<T>> transformResponse) {
+    ResponseIterator(UUID requestId, StreamObserver<TransactionProto.Transaction.Req> requestObserver,
+                     RPCTransaction.ResponseCollector.Multiple responseCollector, Function<TransactionProto.Transaction.Res, Stream<T>> transformResponse) {
         this.requestId = requestId;
         this.transformResponse = transformResponse;
         this.requestObserver = requestObserver;


### PR DESCRIPTION
## What is the goal of this PR?

To update Grakn Core and to align client-java better with client-python while making names more meaningful

## What are the changes implemented in this PR?

- Update grakn artifact
- Rename QueryIterator to ResponseIterator
- Rename typeGetter to typeListGetter across the `concept` package