### PR TITLE
Split up ProtoBuilder into Grakn and Tracing

### DIFF
--- a/GraknProtoBuilder.java
+++ b/GraknProtoBuilder.java
@@ -17,20 +17,11 @@
  * under the License.
  */
 
-package grakn.client.common;
+package grakn.client;
 
-import grabl.tracing.client.GrablTracingThreadStatic;
-import grakn.client.GraknOptions;
 import grakn.protocol.OptionsProto;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
-import static grabl.tracing.client.GrablTracingThreadStatic.currentThreadTrace;
-import static grabl.tracing.client.GrablTracingThreadStatic.isTracingEnabled;
-
-public abstract class ProtoBuilder {
+public abstract class GraknProtoBuilder {
 
     public static OptionsProto.Options options(GraknOptions options) {
         final OptionsProto.Options.Builder builder = OptionsProto.Options.newBuilder();
@@ -38,25 +29,5 @@ public abstract class ProtoBuilder {
         options.explain().ifPresent(builder::setExplain);
         options.batchSize().ifPresent(builder::setBatchSize);
         return builder.build();
-    }
-
-    public static Map<String, String> tracingData() {
-        if (isTracingEnabled()) {
-            final GrablTracingThreadStatic.ThreadTrace threadTrace = currentThreadTrace();
-            if (threadTrace == null) {
-                return Collections.emptyMap();
-            }
-
-            if (threadTrace.getId() == null || threadTrace.getRootId() == null) {
-                return Collections.emptyMap();
-            }
-
-            final Map<String, String> metadata = new HashMap<>(2);
-            metadata.put("traceParentId", threadTrace.getId().toString());
-            metadata.put("traceRootId", threadTrace.getRootId().toString());
-            return metadata;
-        } else {
-            return Collections.emptyMap();
-        }
     }
 }

--- a/common/tracing/TracingProtoBuilder.java
+++ b/common/tracing/TracingProtoBuilder.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package grakn.client.common.tracing;
+
+import grabl.tracing.client.GrablTracingThreadStatic;
+import grakn.client.GraknOptions;
+import grakn.protocol.OptionsProto;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static grabl.tracing.client.GrablTracingThreadStatic.currentThreadTrace;
+import static grabl.tracing.client.GrablTracingThreadStatic.isTracingEnabled;
+
+public abstract class TracingProtoBuilder {
+
+    public static Map<String, String> tracingData() {
+        if (isTracingEnabled()) {
+            final GrablTracingThreadStatic.ThreadTrace threadTrace = currentThreadTrace();
+            if (threadTrace == null) {
+                return Collections.emptyMap();
+            }
+
+            if (threadTrace.getId() == null || threadTrace.getRootId() == null) {
+                return Collections.emptyMap();
+            }
+
+            final Map<String, String> metadata = new HashMap<>(2);
+            metadata.put("traceParentId", threadTrace.getId().toString());
+            metadata.put("traceRootId", threadTrace.getRootId().toString());
+            return metadata;
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+}

--- a/concept/ConceptManager.java
+++ b/concept/ConceptManager.java
@@ -41,7 +41,7 @@ import graql.lang.pattern.Pattern;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 
-import static grakn.client.common.ProtoBuilder.tracingData;
+import static grakn.client.common.tracing.TracingProtoBuilder.tracingData;
 import static grakn.client.concept.proto.ConceptProtoBuilder.iid;
 import static grakn.client.concept.proto.ConceptProtoBuilder.valueType;
 

--- a/logic/LogicManager.java
+++ b/logic/LogicManager.java
@@ -28,7 +28,7 @@ import graql.lang.pattern.Pattern;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 
-import static grakn.client.common.ProtoBuilder.tracingData;
+import static grakn.client.common.tracing.TracingProtoBuilder.tracingData;
 
 public final class LogicManager {
 

--- a/query/QueryManager.java
+++ b/query/QueryManager.java
@@ -34,7 +34,7 @@ import graql.lang.query.GraqlUndefine;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static grakn.client.common.ProtoBuilder.options;
+import static grakn.client.GraknProtoBuilder.options;
 
 public final class QueryManager {
 

--- a/rpc/RPCSession.java
+++ b/rpc/RPCSession.java
@@ -29,7 +29,7 @@ import io.grpc.Channel;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static grakn.client.common.ProtoBuilder.options;
+import static grakn.client.GraknProtoBuilder.options;
 
 public class RPCSession implements Session {
 

--- a/rpc/RPCTransaction.java
+++ b/rpc/RPCTransaction.java
@@ -48,10 +48,10 @@ import java.util.stream.StreamSupport;
 
 import static grabl.tracing.client.GrablTracingThreadStatic.traceOnThread;
 import static grakn.client.Grakn.Transaction.Type.WRITE;
-import static grakn.client.common.ProtoBuilder.options;
-import static grakn.client.common.ProtoBuilder.tracingData;
+import static grakn.client.GraknProtoBuilder.options;
 import static grakn.client.common.exception.ErrorMessage.Client.TRANSACTION_CLOSED;
 import static grakn.client.common.exception.ErrorMessage.Client.UNKNOWN_REQUEST_ID;
+import static grakn.client.common.tracing.TracingProtoBuilder.tracingData;
 import static grakn.common.util.Objects.className;
 
 public class RPCTransaction implements Transaction {


### PR DESCRIPTION
## What is the goal of this PR?

We made ProtoBuilder less 'generic'.

## What are the changes implemented in this PR?

- Split up `common.ProtoBuilder` into `common.tracing.TracingProtoBuilder` and `GraknProtoBuilder`.
