### PR TITLE
Update protocol to extract out LogicManager + Session pulse

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -37,6 +37,7 @@ java_library(
     srcs = glob([
         "common/**/*.java",
         "concept/**/*.java",
+        "logic/**/*.java",
         "query/**/*.java",
         "rpc/**/*.java",
         "test/*.java",
@@ -79,6 +80,7 @@ checkstyle_test(
         ".grabl/automation.yml",
         "common/**/*",
         "concept/**/*",
+        "logic/**/*",
         "query/**/*",
         "rpc/**/*",
         "test/*",

--- a/Grakn.java
+++ b/Grakn.java
@@ -20,6 +20,7 @@
 package grakn.client;
 
 import grakn.client.concept.ConceptManager;
+import grakn.client.logic.LogicManager;
 import grakn.client.query.QueryManager;
 
 import java.util.List;
@@ -100,6 +101,8 @@ public interface Grakn {
         boolean isOpen();
 
         ConceptManager concepts();
+
+        LogicManager logics();
 
         QueryManager query();
 

--- a/Grakn.java
+++ b/Grakn.java
@@ -102,7 +102,7 @@ public interface Grakn {
 
         ConceptManager concepts();
 
-        LogicManager logics();
+        LogicManager logic();
 
         QueryManager query();
 

--- a/concept/ConceptManager.java
+++ b/concept/ConceptManager.java
@@ -24,19 +24,16 @@ import grakn.client.concept.thing.impl.ThingImpl;
 import grakn.client.concept.type.AttributeType;
 import grakn.client.concept.type.EntityType;
 import grakn.client.concept.type.RelationType;
-import grakn.client.concept.logic.Rule;
 import grakn.client.concept.type.ThingType;
 import grakn.client.concept.type.Type;
 import grakn.client.concept.type.impl.AttributeTypeImpl;
 import grakn.client.concept.type.impl.EntityTypeImpl;
 import grakn.client.concept.type.impl.RelationTypeImpl;
-import grakn.client.concept.logic.impl.RuleImpl;
 import grakn.client.concept.type.impl.TypeImpl;
 import grakn.client.rpc.RPCTransaction;
 import grakn.protocol.ConceptProto;
 import grakn.protocol.TransactionProto;
 import graql.lang.common.GraqlToken;
-import graql.lang.pattern.Pattern;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
@@ -122,16 +119,6 @@ public final class ConceptManager {
         else return null;
     }
 
-    public Rule putRule(String label, Pattern when, Pattern then) {
-        final ConceptProto.ConceptManager.Req req = ConceptProto.ConceptManager.Req.newBuilder()
-                .setPutRuleReq(ConceptProto.ConceptManager.PutRule.Req.newBuilder()
-                        .setLabel(label)
-                        .setWhen(when.toString())
-                        .setThen(then.toString())).build();
-        final ConceptProto.ConceptManager.Res res = execute(req);
-        return RuleImpl.of(res.getPutRuleRes().getRule());
-    }
-
     @Nullable
     @CheckReturnValue
     public Thing getThing(String iid) {
@@ -156,22 +143,6 @@ public final class ConceptManager {
             return TypeImpl.of(response.getGetTypeRes().getType());
         else
             return null;
-    }
-
-    @Nullable
-    @CheckReturnValue
-    public Rule getRule(String label) {
-        final ConceptProto.ConceptManager.Req req = ConceptProto.ConceptManager.Req.newBuilder()
-                .setGetRuleReq(ConceptProto.ConceptManager.GetRule.Req.newBuilder().setLabel(label)).build();
-
-        final ConceptProto.ConceptManager.Res response = execute(req);
-        switch (response.getGetRuleRes().getResCase()) {
-            case RULE:
-                return RuleImpl.of(response.getGetRuleRes().getRule());
-            default:
-            case RES_NOT_SET:
-                return null;
-        }
     }
 
     private ConceptProto.ConceptManager.Res execute(ConceptProto.ConceptManager.Req request) {

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -18,14 +18,14 @@
 #
 
 load("@graknlabs_dependencies//distribution/artifact:rules.bzl", "native_artifact_files")
-load("@graknlabs_dependencies//distribution:deployment.bzl", "deployment_private")
+load("@graknlabs_dependencies//distribution:deployment.bzl", "deployment")
 
 def graknlabs_grakn_core_artifacts():
     native_artifact_files(
         name = "graknlabs_grakn_core_artifact",
         group_name = "graknlabs_grakn_core",
         artifact_name = "grakn-core-server-{platform}-{version}.tar.gz",
-        tag_source = deployment_private["artifact.release"],
-        commit_source = deployment_private["artifact.snapshot"],
-        commit = "e43c18d37b753a86e9f278b59336ddfa5c9bdc35",
+        tag_source = deployment["artifact.release"],
+        commit_source = deployment["artifact.snapshot"],
+        commit = "170a62eb430d6e5c1debd69b8efa4f70eadd0a47",
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -51,7 +51,7 @@ def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        commit = "ae9cb7adbf234a39d35f158652e290d7190b0cc6", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "3c0b4d0ed5a828865485f0dd7a66973b7b04ad71", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():

--- a/logic/LogicManager.java
+++ b/logic/LogicManager.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package grakn.client.logic;
+
+import grakn.client.logic.impl.RuleImpl;
+import grakn.client.rpc.RPCTransaction;
+import grakn.protocol.LogicProto;
+import grakn.protocol.TransactionProto;
+import graql.lang.pattern.Pattern;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
+
+import static grakn.client.common.ProtoBuilder.tracingData;
+
+public final class LogicManager {
+
+    private final RPCTransaction rpcTransaction;
+
+    public LogicManager(RPCTransaction rpcTransaction) {
+        this.rpcTransaction = rpcTransaction;
+    }
+
+    public Rule putRule(String label, Pattern when, Pattern then) {
+        final LogicProto.LogicManager.Req req = LogicProto.LogicManager.Req.newBuilder()
+                .setPutRuleReq(LogicProto.LogicManager.PutRule.Req.newBuilder()
+                        .setLabel(label)
+                        .setWhen(when.toString())
+                        .setThen(then.toString())).build();
+        final LogicProto.LogicManager.Res res = execute(req);
+        return RuleImpl.of(res.getPutRuleRes().getRule());
+    }
+
+    @Nullable
+    @CheckReturnValue
+    public Rule getRule(String label) {
+        final LogicProto.LogicManager.Req req = LogicProto.LogicManager.Req.newBuilder()
+                .setGetRuleReq(LogicProto.LogicManager.GetRule.Req.newBuilder().setLabel(label)).build();
+
+        final LogicProto.LogicManager.Res response = execute(req);
+        switch (response.getGetRuleRes().getResCase()) {
+            case RULE:
+                return RuleImpl.of(response.getGetRuleRes().getRule());
+            default:
+            case RES_NOT_SET:
+                return null;
+        }
+    }
+
+    private LogicProto.LogicManager.Res execute(LogicProto.LogicManager.Req request) {
+        final TransactionProto.Transaction.Req.Builder req = TransactionProto.Transaction.Req.newBuilder()
+                .putAllMetadata(tracingData())
+                .setLogicManagerReq(request);
+        return rpcTransaction.execute(req).getLogicManagerRes();
+    }
+}

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package grakn.client.concept.logic;
+package grakn.client.logic;
 
 import grakn.client.Grakn;
 import graql.lang.pattern.Pattern;

--- a/logic/impl/RuleImpl.java
+++ b/logic/impl/RuleImpl.java
@@ -17,13 +17,13 @@
  * under the License.
  */
 
-package grakn.client.concept.logic.impl;
+package grakn.client.logic.impl;
 
 import grakn.client.Grakn;
 import grakn.client.common.exception.GraknClientException;
-import grakn.client.concept.logic.Rule;
+import grakn.client.logic.Rule;
 import grakn.client.rpc.RPCTransaction;
-import grakn.protocol.ConceptProto;
+import grakn.protocol.LogicProto;
 import grakn.protocol.TransactionProto;
 import graql.lang.Graql;
 import graql.lang.pattern.Conjunction;
@@ -51,7 +51,7 @@ public class RuleImpl implements Rule {
         this.hash = Objects.hash(this.label);
     }
 
-    public static RuleImpl of(ConceptProto.Rule ruleProto) {
+    public static RuleImpl of(LogicProto.Rule ruleProto) {
         return new RuleImpl(ruleProto.getLabel(), Graql.and(Graql.parsePatterns(ruleProto.getWhen())), Graql.parseVariable(ruleProto.getThen()).asThing());
     }
 
@@ -117,7 +117,7 @@ public class RuleImpl implements Rule {
             this.hash = Objects.hash(transaction, label);
         }
 
-        public static RuleImpl.Remote of(Grakn.Transaction transaction, ConceptProto.Rule ruleProto) {
+        public static RuleImpl.Remote of(Grakn.Transaction transaction, LogicProto.Rule ruleProto) {
             return new RuleImpl.Remote(transaction, ruleProto.getLabel(), Graql.and(Graql.parsePatterns(ruleProto.getWhen())), Graql.parseVariable(ruleProto.getThen()).asThing());
         }
 
@@ -138,18 +138,18 @@ public class RuleImpl implements Rule {
 
         @Override
         public void setLabel(String label) {
-            execute(ConceptProto.Rule.Req.newBuilder().setRuleSetLabelReq(ConceptProto.Rule.SetLabel.Req.newBuilder().setLabel(label)));
+            execute(LogicProto.Rule.Req.newBuilder().setRuleSetLabelReq(LogicProto.Rule.SetLabel.Req.newBuilder().setLabel(label)));
             this.label = label;
         }
 
         @Override
         public void delete() {
-            execute(ConceptProto.Rule.Req.newBuilder().setRuleDeleteReq(ConceptProto.Rule.Delete.Req.getDefaultInstance()));
+            execute(LogicProto.Rule.Req.newBuilder().setRuleDeleteReq(LogicProto.Rule.Delete.Req.getDefaultInstance()));
         }
 
         @Override
         public final boolean isDeleted() {
-            return rpcTransaction.concepts().getRule(label) != null;
+            return rpcTransaction.logics().getRule(label) != null;
         }
 
         @Override
@@ -185,7 +185,7 @@ public class RuleImpl implements Rule {
             return rpcTransaction;
         }
 
-        ConceptProto.Rule.Res execute(ConceptProto.Rule.Req.Builder method) {
+        LogicProto.Rule.Res execute(LogicProto.Rule.Req.Builder method) {
             final TransactionProto.Transaction.Req.Builder request = TransactionProto.Transaction.Req.newBuilder()
                     .setRuleReq(method.setLabel(label));
             return rpcTransaction.execute(request).getRuleRes();

--- a/logic/impl/RuleImpl.java
+++ b/logic/impl/RuleImpl.java
@@ -149,7 +149,7 @@ public class RuleImpl implements Rule {
 
         @Override
         public final boolean isDeleted() {
-            return rpcTransaction.logics().getRule(label) != null;
+            return rpcTransaction.logic().getRule(label) != null;
         }
 
         @Override

--- a/rpc/RPCTransaction.java
+++ b/rpc/RPCTransaction.java
@@ -114,7 +114,7 @@ public class RPCTransaction implements Transaction {
     }
 
     @Override
-    public LogicManager logics() {
+    public LogicManager logic() {
         return logicManager;
     }
 

--- a/rpc/RPCTransaction.java
+++ b/rpc/RPCTransaction.java
@@ -26,6 +26,7 @@ import grakn.client.GraknOptions;
 import grakn.client.common.exception.ErrorMessage;
 import grakn.client.common.exception.GraknClientException;
 import grakn.client.concept.ConceptManager;
+import grakn.client.logic.LogicManager;
 import grakn.client.query.QueryManager;
 import grakn.protocol.GraknGrpc;
 import grakn.protocol.TransactionProto;
@@ -58,6 +59,7 @@ public class RPCTransaction implements Transaction {
 
     private final Transaction.Type type;
     private final ConceptManager conceptManager;
+    private final LogicManager logicManager;
     private final QueryManager queryManager;
     private final StreamObserver<TransactionProto.Transaction.Req> requestObserver;
     private final ResponseCollectors collectors;
@@ -71,6 +73,7 @@ public class RPCTransaction implements Transaction {
         try (ThreadTrace ignored = traceOnThread(type == WRITE ? "tx.write" : "tx.read")) {
             this.type = type;
             conceptManager = new ConceptManager(this);
+            logicManager = new LogicManager(this);
             queryManager = new QueryManager(this);
             collectors = new ResponseCollectors();
 
@@ -108,6 +111,11 @@ public class RPCTransaction implements Transaction {
     @Override
     public ConceptManager concepts() {
         return conceptManager;
+    }
+
+    @Override
+    public LogicManager logics() {
+        return logicManager;
     }
 
     @Override


### PR DESCRIPTION
## What is the goal of this PR?

We have separated out the `LogicManager` to manage rules in the newest version of protocol, now we update client-java with this newest version of the protocol.

As part of the upgrade process, we need to also implement session pulse in order to keep the session alive. Otherwise the session will be killed by the server.

## What are the changes implemented in this PR?

- Extract `logicManager` class that sits in `logic` package and manages rules.
- Implement a `TimerTask` for sending pulse request to the server.