### PR TITLE
Make session pulse respect isAlive flag

### DIFF
--- a/rpc/RPCSession.java
+++ b/rpc/RPCSession.java
@@ -108,7 +108,12 @@ public class RPCSession implements Session {
         @Override
         public void run() {
             if (!isOpen()) return;
-            blockingGrpcStub.sessionPulse(SessionProto.Session.Pulse.Req.newBuilder().setSessionId(sessionId).build());
+            final SessionProto.Session.Pulse.Res res = blockingGrpcStub.sessionPulse(
+                    SessionProto.Session.Pulse.Req.newBuilder().setSessionId(sessionId).build());
+            if (!res.getAlive()) {
+                isOpen.set(false);
+                pulse.cancel();
+            }
         }
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

We are making session pulses read the server response and close the session locally if the session is marked as closed remotely.

## What are the changes implemented in this PR?

- Session pulses now close the session locally if the session is marked as closed remotely
