### PR TITLE
Update protocol: repeated fields now pluralised

### DIFF
--- a/concept/thing/impl/AttributeImpl.java
+++ b/concept/thing/impl/AttributeImpl.java
@@ -105,7 +105,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
             return stream(
                     ConceptProto.Thing.Req.newBuilder().setAttributeGetOwnersReq(
                             GetOwners.Req.getDefaultInstance()),
-                    res -> res.getAttributeGetOwnersRes().getThingList()
+                    res -> res.getAttributeGetOwnersRes().getThingsList()
             );
         }
 
@@ -114,7 +114,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
             return stream(
                     ConceptProto.Thing.Req.newBuilder().setAttributeGetOwnersReq(
                             GetOwners.Req.newBuilder().setThingType(type(ownerType))),
-                    res -> res.getAttributeGetOwnersRes().getThingList()
+                    res -> res.getAttributeGetOwnersRes().getThingsList()
             );
         }
 

--- a/concept/thing/impl/AttributeImpl.java
+++ b/concept/thing/impl/AttributeImpl.java
@@ -25,7 +25,6 @@ import grakn.client.concept.thing.Attribute;
 import grakn.client.concept.type.ThingType;
 import grakn.client.concept.type.impl.AttributeTypeImpl;
 import grakn.protocol.ConceptProto;
-import grakn.protocol.ConceptProto.Attribute.GetOwners;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -104,7 +103,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
         public final Stream<ThingImpl> getOwners() {
             return thingStream(
                     ConceptProto.Thing.Req.newBuilder().setAttributeGetOwnersReq(
-                            GetOwners.Req.getDefaultInstance()),
+                            ConceptProto.Attribute.GetOwners.Req.getDefaultInstance()),
                     res -> res.getAttributeGetOwnersRes().getThingsList()
             );
         }
@@ -113,7 +112,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
         public Stream<ThingImpl> getOwners(ThingType ownerType) {
             return thingStream(
                     ConceptProto.Thing.Req.newBuilder().setAttributeGetOwnersReq(
-                            GetOwners.Req.newBuilder().setThingType(type(ownerType))),
+                            ConceptProto.Attribute.GetOwners.Req.newBuilder().setThingType(type(ownerType))),
                     res -> res.getAttributeGetOwnersRes().getThingsList()
             );
         }

--- a/concept/thing/impl/AttributeImpl.java
+++ b/concept/thing/impl/AttributeImpl.java
@@ -102,7 +102,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
         @Override
         public final Stream<ThingImpl> getOwners() {
-            return stream(
+            return thingStream(
                     ConceptProto.Thing.Req.newBuilder().setAttributeGetOwnersReq(
                             GetOwners.Req.getDefaultInstance()),
                     res -> res.getAttributeGetOwnersRes().getThingsList()
@@ -111,7 +111,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
         @Override
         public Stream<ThingImpl> getOwners(ThingType ownerType) {
-            return stream(
+            return thingStream(
                     ConceptProto.Thing.Req.newBuilder().setAttributeGetOwnersReq(
                             GetOwners.Req.newBuilder().setThingType(type(ownerType))),
                     res -> res.getAttributeGetOwnersRes().getThingsList()

--- a/concept/thing/impl/AttributeImpl.java
+++ b/concept/thing/impl/AttributeImpl.java
@@ -195,10 +195,6 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
                 this.value = value;
             }
 
-            public static AttributeImpl.Boolean.Remote of(Grakn.Transaction transaction, ConceptProto.Thing thingProto) {
-                return new AttributeImpl.Boolean.Remote(transaction, bytesToHexString(thingProto.getIid().toByteArray()), thingProto.getValue().getBoolean());
-            }
-
             @Override
             public Attribute.Boolean.Remote asRemote(Grakn.Transaction transaction) {
                 return new AttributeImpl.Boolean.Remote(transaction, getIID(), value);
@@ -259,10 +255,6 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
             Remote(Grakn.Transaction transaction, java.lang.String iid, long value) {
                 super(transaction, iid);
                 this.value = value;
-            }
-
-            public static AttributeImpl.Long.Remote of(Grakn.Transaction transaction, ConceptProto.Thing thingProto) {
-                return new AttributeImpl.Long.Remote(transaction, bytesToHexString(thingProto.getIid().toByteArray()), thingProto.getValue().getLong());
             }
 
             @Override
@@ -327,10 +319,6 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
                 this.value = value;
             }
 
-            public static AttributeImpl.Double.Remote of(Grakn.Transaction transaction, ConceptProto.Thing thingProto) {
-                return new AttributeImpl.Double.Remote(transaction, bytesToHexString(thingProto.getIid().toByteArray()), thingProto.getValue().getDouble());
-            }
-
             @Override
             public Attribute.Double.Remote asRemote(Grakn.Transaction transaction) {
                 return new AttributeImpl.Double.Remote(transaction, getIID(), value);
@@ -391,10 +379,6 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
             Remote(Grakn.Transaction transaction, java.lang.String iid, java.lang.String value) {
                 super(transaction, iid);
                 this.value = value;
-            }
-
-            public static AttributeImpl.String.Remote of(Grakn.Transaction transaction, ConceptProto.Thing thingProto) {
-                return new AttributeImpl.String.Remote(transaction, bytesToHexString(thingProto.getIid().toByteArray()), thingProto.getValue().getString());
             }
 
             @Override
@@ -461,10 +445,6 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
             Remote(Grakn.Transaction transaction, java.lang.String iid, LocalDateTime value) {
                 super(transaction, iid);
                 this.value = value;
-            }
-
-            public static AttributeImpl.DateTime.Remote of(Grakn.Transaction transaction, ConceptProto.Thing thingProto) {
-                return new AttributeImpl.DateTime.Remote(transaction, bytesToHexString(thingProto.getIid().toByteArray()), toLocalDateTime(thingProto.getValue().getDateTime()));
             }
 
             @Override

--- a/concept/thing/impl/RelationImpl.java
+++ b/concept/thing/impl/RelationImpl.java
@@ -28,9 +28,6 @@ import grakn.client.concept.type.impl.RoleTypeImpl;
 import grakn.client.concept.type.impl.TypeImpl;
 import grakn.common.collection.Bytes;
 import grakn.protocol.ConceptProto;
-import grakn.protocol.ConceptProto.Relation.AddPlayer;
-import grakn.protocol.ConceptProto.Relation.GetPlayers;
-import grakn.protocol.ConceptProto.Relation.RemovePlayer;
 import grakn.protocol.TransactionProto;
 
 import java.util.ArrayList;
@@ -109,20 +106,20 @@ public class RelationImpl extends ThingImpl implements Relation {
         public Stream<ThingImpl> getPlayers(RoleType... roleTypes) {
             return thingStream(
                     ConceptProto.Thing.Req.newBuilder().setRelationGetPlayersReq(
-                            GetPlayers.Req.newBuilder().addAllRoleTypes(types(Arrays.asList(roleTypes)))),
+                            ConceptProto.Relation.GetPlayers.Req.newBuilder().addAllRoleTypes(types(Arrays.asList(roleTypes)))),
                     res -> res.getRelationGetPlayersRes().getThingsList());
         }
 
         @Override
         public void addPlayer(RoleType roleType, Thing player) {
             execute(ConceptProto.Thing.Req.newBuilder().setRelationAddPlayerReq(
-                    AddPlayer.Req.newBuilder().setRoleType(type(roleType)).setPlayer(thing(player))));
+                    ConceptProto.Relation.AddPlayer.Req.newBuilder().setRoleType(type(roleType)).setPlayer(thing(player))));
         }
 
         @Override
         public void removePlayer(RoleType roleType, Thing player) {
             execute(ConceptProto.Thing.Req.newBuilder().setRelationRemovePlayerReq(
-                    RemovePlayer.Req.newBuilder().setRoleType(type(roleType)).setPlayer(thing(player))));
+                    ConceptProto.Relation.RemovePlayer.Req.newBuilder().setRoleType(type(roleType)).setPlayer(thing(player))));
         }
 
         @Override

--- a/concept/thing/impl/RelationImpl.java
+++ b/concept/thing/impl/RelationImpl.java
@@ -90,7 +90,7 @@ public class RelationImpl extends ThingImpl implements Relation {
             final TransactionProto.Transaction.Req.Builder request = TransactionProto.Transaction.Req.newBuilder()
                     .setThingReq(method.setIid(iid(getIID())));
             final Stream<ConceptProto.Relation.GetPlayersByRoleType.RoleTypeWithPlayer> stream = rpcTransaction.stream(
-                    request, res -> res.getThingRes().getRelationGetPlayersByRoleTypeRes().getRoleTypeWithPlayerList().stream());
+                    request, res -> res.getThingRes().getRelationGetPlayersByRoleTypeRes().getRoleTypesWithPlayersList().stream());
 
             final Map<RoleTypeImpl, List<ThingImpl>> rolePlayerMap = new HashMap<>();
             stream.forEach(rolePlayer -> {
@@ -110,7 +110,7 @@ public class RelationImpl extends ThingImpl implements Relation {
             return stream(
                     ConceptProto.Thing.Req.newBuilder().setRelationGetPlayersReq(
                             GetPlayers.Req.newBuilder().addAllRoleTypes(types(Arrays.asList(roleTypes)))),
-                    res -> res.getRelationGetPlayersRes().getThingList());
+                    res -> res.getRelationGetPlayersRes().getThingsList());
         }
 
         @Override

--- a/concept/thing/impl/RelationImpl.java
+++ b/concept/thing/impl/RelationImpl.java
@@ -107,7 +107,7 @@ public class RelationImpl extends ThingImpl implements Relation {
 
         @Override
         public Stream<ThingImpl> getPlayers(RoleType... roleTypes) {
-            return stream(
+            return thingStream(
                     ConceptProto.Thing.Req.newBuilder().setRelationGetPlayersReq(
                             GetPlayers.Req.newBuilder().addAllRoleTypes(types(Arrays.asList(roleTypes)))),
                     res -> res.getRelationGetPlayersRes().getThingsList());

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -33,10 +33,6 @@ import grakn.client.concept.type.impl.ThingTypeImpl;
 import grakn.client.concept.type.impl.TypeImpl;
 import grakn.client.rpc.RPCTransaction;
 import grakn.protocol.ConceptProto;
-import grakn.protocol.ConceptProto.Thing.Delete;
-import grakn.protocol.ConceptProto.Thing.GetPlays;
-import grakn.protocol.ConceptProto.Thing.GetRelations;
-import grakn.protocol.ConceptProto.Thing.UnsetHas;
 import grakn.protocol.TransactionProto;
 
 import java.util.Arrays;
@@ -211,7 +207,7 @@ public abstract class ThingImpl implements Thing {
         public final Stream<RoleTypeImpl> getPlays() {
             return typeStream(
                     ConceptProto.Thing.Req.newBuilder().setThingGetPlaysReq(
-                            GetPlays.Req.getDefaultInstance()),
+                            ConceptProto.Thing.GetPlays.Req.getDefaultInstance()),
                     res -> res.getThingGetPlaysRes().getRoleTypesList()
             ).map(TypeImpl::asRoleType);
         }
@@ -220,7 +216,7 @@ public abstract class ThingImpl implements Thing {
         public final Stream<RelationImpl> getRelations(RoleType... roleTypes) {
             return stream(
                     ConceptProto.Thing.Req.newBuilder().setThingGetRelationsReq(
-                            GetRelations.Req.newBuilder().addAllRoleTypes(types(Arrays.asList(roleTypes)))),
+                            ConceptProto.Thing.GetRelations.Req.newBuilder().addAllRoleTypes(types(Arrays.asList(roleTypes)))),
                     res -> res.getThingGetRelationsRes().getRelationsList()
             ).map(ThingImpl::asRelation);
         }
@@ -235,13 +231,13 @@ public abstract class ThingImpl implements Thing {
         @Override
         public final void unsetHas(Attribute<?> attribute) {
             execute(ConceptProto.Thing.Req.newBuilder().setThingUnsetHasReq(
-                    UnsetHas.Req.newBuilder().setAttribute(thing(attribute))
+                    ConceptProto.Thing.UnsetHas.Req.newBuilder().setAttribute(thing(attribute))
             ));
         }
 
         @Override
         public final void delete() {
-            execute(ConceptProto.Thing.Req.newBuilder().setThingDeleteReq(Delete.Req.getDefaultInstance()));
+            execute(ConceptProto.Thing.Req.newBuilder().setThingDeleteReq(ConceptProto.Thing.Delete.Req.getDefaultInstance()));
         }
 
         @Override

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -172,7 +172,7 @@ public abstract class ThingImpl implements Thing {
             final ConceptProto.Thing.Req.Builder method = ConceptProto.Thing.Req.newBuilder()
                     .setThingGetHasReq(ConceptProto.Thing.GetHas.Req.newBuilder()
                             .addAllAttributeTypes(types(Arrays.asList(attributeTypes))));
-            return stream(method, res -> res.getThingGetHasRes().getAttributeList()).map(ThingImpl::asAttribute);
+            return stream(method, res -> res.getThingGetHasRes().getAttributesList()).map(ThingImpl::asAttribute);
         }
 
         @Override
@@ -204,7 +204,7 @@ public abstract class ThingImpl implements Thing {
         public final Stream<AttributeImpl<?>> getHas(boolean onlyKey) {
             final ConceptProto.Thing.Req.Builder method = ConceptProto.Thing.Req.newBuilder()
                     .setThingGetHasReq(ConceptProto.Thing.GetHas.Req.newBuilder().setKeysOnly(onlyKey));
-            return stream(method, res -> res.getThingGetHasRes().getAttributeList()).map(ThingImpl::asAttribute);
+            return stream(method, res -> res.getThingGetHasRes().getAttributesList()).map(ThingImpl::asAttribute);
         }
 
         @Override
@@ -212,7 +212,7 @@ public abstract class ThingImpl implements Thing {
             return typeStream(
                     ConceptProto.Thing.Req.newBuilder().setThingGetPlaysReq(
                             GetPlays.Req.getDefaultInstance()),
-                    res -> res.getThingGetPlaysRes().getRoleTypeList()
+                    res -> res.getThingGetPlaysRes().getRoleTypesList()
             ).map(TypeImpl::asRoleType);
         }
 
@@ -221,7 +221,7 @@ public abstract class ThingImpl implements Thing {
             return stream(
                     ConceptProto.Thing.Req.newBuilder().setThingGetRelationsReq(
                             GetRelations.Req.newBuilder().addAllRoleTypes(types(Arrays.asList(roleTypes)))),
-                    res -> res.getThingGetRelationsRes().getRelationList()
+                    res -> res.getThingGetRelationsRes().getRelationsList()
             ).map(ThingImpl::asRelation);
         }
 

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -168,7 +168,7 @@ public abstract class ThingImpl implements Thing {
             final ConceptProto.Thing.Req.Builder method = ConceptProto.Thing.Req.newBuilder()
                     .setThingGetHasReq(ConceptProto.Thing.GetHas.Req.newBuilder()
                             .addAllAttributeTypes(types(Arrays.asList(attributeTypes))));
-            return stream(method, res -> res.getThingGetHasRes().getAttributesList()).map(ThingImpl::asAttribute);
+            return thingStream(method, res -> res.getThingGetHasRes().getAttributesList()).map(ThingImpl::asAttribute);
         }
 
         @Override
@@ -200,7 +200,7 @@ public abstract class ThingImpl implements Thing {
         public final Stream<AttributeImpl<?>> getHas(boolean onlyKey) {
             final ConceptProto.Thing.Req.Builder method = ConceptProto.Thing.Req.newBuilder()
                     .setThingGetHasReq(ConceptProto.Thing.GetHas.Req.newBuilder().setKeysOnly(onlyKey));
-            return stream(method, res -> res.getThingGetHasRes().getAttributesList()).map(ThingImpl::asAttribute);
+            return thingStream(method, res -> res.getThingGetHasRes().getAttributesList()).map(ThingImpl::asAttribute);
         }
 
         @Override
@@ -214,7 +214,7 @@ public abstract class ThingImpl implements Thing {
 
         @Override
         public final Stream<RelationImpl> getRelations(RoleType... roleTypes) {
-            return stream(
+            return thingStream(
                     ConceptProto.Thing.Req.newBuilder().setThingGetRelationsReq(
                             ConceptProto.Thing.GetRelations.Req.newBuilder().addAllRoleTypes(types(Arrays.asList(roleTypes)))),
                     res -> res.getThingGetRelationsRes().getRelationsList()
@@ -279,7 +279,7 @@ public abstract class ThingImpl implements Thing {
             return rpcTransaction;
         }
 
-        Stream<ThingImpl> stream(ConceptProto.Thing.Req.Builder method, Function<ConceptProto.Thing.Res, List<ConceptProto.Thing>> thingListGetter) {
+        Stream<ThingImpl> thingStream(ConceptProto.Thing.Req.Builder method, Function<ConceptProto.Thing.Res, List<ConceptProto.Thing>> thingListGetter) {
             final TransactionProto.Transaction.Req.Builder request = TransactionProto.Transaction.Req.newBuilder()
                     .setThingReq(method.setIid(iid(iid)));
             return rpcTransaction.stream(request, res -> thingListGetter.apply(res.getThingRes()).stream().map(ThingImpl::of));

--- a/concept/type/impl/AttributeTypeImpl.java
+++ b/concept/type/impl/AttributeTypeImpl.java
@@ -202,7 +202,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
             final ConceptProto.Type.Req.Builder method = ConceptProto.Type.Req.newBuilder()
                     .setAttributeTypeGetOwnersReq(ConceptProto.AttributeType.GetOwners.Req.newBuilder()
                             .setOnlyKey(onlyKey));
-            return typeStream(method, res -> res.getAttributeTypeGetOwnersRes().getOwnerList()).map(TypeImpl::asThingType);
+            return typeStream(method, res -> res.getAttributeTypeGetOwnersRes().getOwnersList()).map(TypeImpl::asThingType);
         }
 
         protected final AttributeImpl<?> put(Object value) {

--- a/concept/type/impl/RelationTypeImpl.java
+++ b/concept/type/impl/RelationTypeImpl.java
@@ -79,7 +79,7 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
             return typeStream(
                     ConceptProto.Type.Req.newBuilder().setRelationTypeGetRelatesReq(
                             ConceptProto.RelationType.GetRelates.Req.getDefaultInstance()),
-                    res -> res.getRelationTypeGetRelatesRes().getRoleList()
+                    res -> res.getRelationTypeGetRelatesRes().getRolesList()
             ).map(TypeImpl::asRoleType);
         }
 

--- a/concept/type/impl/RoleTypeImpl.java
+++ b/concept/type/impl/RoleTypeImpl.java
@@ -141,7 +141,7 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
             return typeStream(
                     ConceptProto.Type.Req.newBuilder().setRoleTypeGetRelationTypesReq(
                             ConceptProto.RoleType.GetRelationTypes.Req.getDefaultInstance()),
-                    res -> res.getRoleTypeGetRelationTypesRes().getRelationTypeList()
+                    res -> res.getRoleTypeGetRelationTypesRes().getRelationTypesList()
             ).map(TypeImpl::asRelationType);
         }
 
@@ -150,7 +150,7 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
             return typeStream(
                     ConceptProto.Type.Req.newBuilder().setRoleTypeGetPlayersReq(
                             ConceptProto.RoleType.GetPlayers.Req.getDefaultInstance()),
-                    res -> res.getRoleTypeGetPlayersRes().getThingTypeList()
+                    res -> res.getRoleTypeGetPlayersRes().getThingTypesList()
             ).map(TypeImpl::asThingType);
         }
 

--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -97,7 +97,7 @@ public class ThingTypeImpl extends TypeImpl implements ThingType {
         public Stream<? extends ThingImpl> getInstances() {
             final ConceptProto.Type.Req.Builder request = ConceptProto.Type.Req.newBuilder()
                     .setThingTypeGetInstancesReq(ConceptProto.ThingType.GetInstances.Req.getDefaultInstance());
-            return thingStream(request, res -> res.getThingTypeGetInstancesRes().getThingList());
+            return thingStream(request, res -> res.getThingTypeGetInstancesRes().getThingsList());
         }
 
         @Override
@@ -149,7 +149,7 @@ public class ThingTypeImpl extends TypeImpl implements ThingType {
         public final Stream<RoleTypeImpl> getPlays() {
             final ConceptProto.Type.Req.Builder request = ConceptProto.Type.Req.newBuilder()
                     .setThingTypeGetPlaysReq(ConceptProto.ThingType.GetPlays.Req.getDefaultInstance());
-            return typeStream(request, res -> res.getThingTypeGetPlaysRes().getRoleList()).map(TypeImpl::asRoleType);
+            return typeStream(request, res -> res.getThingTypeGetPlaysRes().getRolesList()).map(TypeImpl::asRoleType);
         }
 
         @Override
@@ -172,7 +172,7 @@ public class ThingTypeImpl extends TypeImpl implements ThingType {
             final ConceptProto.ThingType.GetOwns.Req.Builder getOwnsReq = ConceptProto.ThingType.GetOwns.Req.newBuilder().setKeysOnly(keysOnly);
             if (valueType != null) getOwnsReq.setValueType(valueType(valueType));
             final ConceptProto.Type.Req.Builder request = ConceptProto.Type.Req.newBuilder().setThingTypeGetOwnsReq(getOwnsReq);
-            return typeStream(request, res -> res.getThingTypeGetOwnsRes().getAttributeTypeList()).map(TypeImpl::asAttributeType);
+            return typeStream(request, res -> res.getThingTypeGetOwnsRes().getAttributeTypesList()).map(TypeImpl::asAttributeType);
         }
 
         @Override

--- a/concept/type/impl/TypeImpl.java
+++ b/concept/type/impl/TypeImpl.java
@@ -144,7 +144,7 @@ public abstract class TypeImpl implements Type {
         final RPCTransaction rpcTransaction;
         private String label;
         private final boolean isRoot;
-        private final int hash;
+        private int hash;
 
         Remote(Grakn.Transaction transaction, String label, boolean isRoot) {
             if (transaction == null) throw new GraknClientException(MISSING_TRANSACTION);
@@ -152,7 +152,7 @@ public abstract class TypeImpl implements Type {
             this.rpcTransaction = (RPCTransaction) transaction;
             this.label = label;
             this.isRoot = isRoot;
-            this.hash = Objects.hash(transaction, label);
+            this.hash = Objects.hash(this.rpcTransaction, label);
         }
 
         @Override
@@ -175,6 +175,7 @@ public abstract class TypeImpl implements Type {
             execute(ConceptProto.Type.Req.newBuilder()
                     .setTypeSetLabelReq(ConceptProto.Type.SetLabel.Req.newBuilder().setLabel(label)));
             this.label = label;
+            this.hash = Objects.hash(rpcTransaction, this.label);
         }
 
         @Override

--- a/concept/type/impl/TypeImpl.java
+++ b/concept/type/impl/TypeImpl.java
@@ -239,14 +239,14 @@ public abstract class TypeImpl implements Type {
         public Stream<? extends TypeImpl> getSupertypes() {
             final ConceptProto.Type.Req.Builder method = ConceptProto.Type.Req.newBuilder()
                     .setTypeGetSupertypesReq(ConceptProto.Type.GetSupertypes.Req.getDefaultInstance());
-            return typeStream(method, res -> res.getTypeGetSupertypesRes().getTypeList());
+            return typeStream(method, res -> res.getTypeGetSupertypesRes().getTypesList());
         }
 
         @Override
         public Stream<? extends TypeImpl> getSubtypes() {
             final ConceptProto.Type.Req.Builder method = ConceptProto.Type.Req.newBuilder()
                     .setTypeGetSubtypesReq(ConceptProto.Type.GetSubtypes.Req.getDefaultInstance());
-            return typeStream(method, res -> res.getTypeGetSubtypesRes().getTypeList());
+            return typeStream(method, res -> res.getTypeGetSubtypesRes().getTypesList());
         }
 
         @Override

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -50,8 +50,8 @@ def graknlabs_dependencies():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/graknlabs/protocol",
-        commit = "917f218d432e73d00e2d685a7d55858d6229ab2e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/alexjpwalker/protocol",
+        commit = "6bf8c601ecd57a2869cde56c17eec8784a9a2804", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -50,8 +50,8 @@ def graknlabs_dependencies():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/alexjpwalker/protocol",
-        commit = "6bf8c601ecd57a2869cde56c17eec8784a9a2804", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/graknlabs/protocol",
+        commit = "1d807aeaf9e3d4939bd3d7767e5c3898103e3e82", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():

--- a/logic/impl/RuleImpl.java
+++ b/logic/impl/RuleImpl.java
@@ -169,7 +169,7 @@ public class RuleImpl implements Rule {
             if (o == null || getClass() != o.getClass()) return false;
 
             final RuleImpl.Remote that = (RuleImpl.Remote) o;
-            return this.label.equals(that.label);
+            return this.rpcTransaction.equals(that.rpcTransaction) && this.label.equals(that.label);
         }
 
         @Override

--- a/logic/impl/RuleImpl.java
+++ b/logic/impl/RuleImpl.java
@@ -117,10 +117,6 @@ public class RuleImpl implements Rule {
             this.hash = Objects.hash(transaction, label);
         }
 
-        public static RuleImpl.Remote of(Grakn.Transaction transaction, LogicProto.Rule ruleProto) {
-            return new RuleImpl.Remote(transaction, ruleProto.getLabel(), Graql.and(Graql.parsePatterns(ruleProto.getWhen())), Graql.parseVariable(ruleProto.getThen()).asThing());
-        }
-
         @Override
         public String getLabel() {
             return label;

--- a/query/QueryManager.java
+++ b/query/QueryManager.java
@@ -51,7 +51,7 @@ public final class QueryManager {
     public Stream<ConceptMap> match(GraqlMatch query, GraknOptions options) {
         final QueryProto.Query.Req.Builder request = QueryProto.Query.Req.newBuilder().setMatchReq(
                 QueryProto.Graql.Match.Req.newBuilder().setQuery(query.toString()));
-        return iterateQuery(request, options, res -> res.getQueryRes().getMatchRes().getAnswerList().stream().map(ConceptMap::of));
+        return iterateQuery(request, options, res -> res.getQueryRes().getMatchRes().getAnswersList().stream().map(ConceptMap::of));
     }
 
     public Stream<ConceptMap> insert(GraqlInsert query) {
@@ -61,7 +61,7 @@ public final class QueryManager {
     public Stream<ConceptMap> insert(GraqlInsert query, GraknOptions options) {
         final QueryProto.Query.Req.Builder request = QueryProto.Query.Req.newBuilder().setInsertReq(
                 QueryProto.Graql.Insert.Req.newBuilder().setQuery(query.toString()));
-        return iterateQuery(request, options, res -> res.getQueryRes().getInsertRes().getAnswerList().stream().map(ConceptMap::of));
+        return iterateQuery(request, options, res -> res.getQueryRes().getInsertRes().getAnswersList().stream().map(ConceptMap::of));
     }
 
     public QueryFuture<Void> delete(GraqlDelete query) {


### PR DESCRIPTION
## What is the goal of this PR?

We updated our repeated field names in our protocol, ensuring they are consistently pluralised in line with the Protocol Buffers style guide. We also fixed a couple of very minor issues.

## What are the changes implemented in this PR?

- Make all repeated protocol fields pluralised
