### PR TITLE
Fix a race condition in the timer

### DIFF
--- a/rpc/RPCSession.java
+++ b/rpc/RPCSession.java
@@ -54,8 +54,8 @@ public class RPCSession implements Session {
 
         sessionId = blockingGrpcStub.sessionOpen(openReq).getSessionId();
         pulse = new Timer();
-        pulse.scheduleAtFixedRate(this.new PulseTask(), 0, 5000);
         isOpen = new AtomicBoolean(true);
+        pulse.scheduleAtFixedRate(this.new PulseTask(), 0, 5000);
     }
 
     @Override


### PR DESCRIPTION
## What is the goal of this PR?

Fix a `NullPointerException` issue where `isOpen` is asynchronously accessed by the timer job before it is initialised:

```
Exception in thread "Timer-0" java.lang.NullPointerException
	at grakn.client.rpc.RPCSession.isOpen(RPCSession.java:78)
	at grakn.client.rpc.RPCSession$PulseTask.run(RPCSession.java:110)
	at java.util.TimerThread.mainLoop(Timer.java:555)
	at java.util.TimerThread.run(Timer.java:505)
```