### PR TITLE
Adapt to new grabl

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -19,13 +19,13 @@
 config:
   version-candidate: VERSION
   dependencies:
-    graql: [build]
-    common: [build]
+    graql: [build] # TODO: add 'release' once dependency-analysis works with tags
+    common: [build] # TODO: add 'release' once dependency-analysis works with tags
     bazel-distribution: [build]
     dependencies: [build]
-    protocol: [build]
+    protocol: [build] # TODO: add 'release' once dependency-analysis works with tags
     behaviour: [build]
-    grabl-tracing: [build]
+    grabl-tracing: [build] # TODO: add 'release' once dependency-analysis works with tags
 
 build:
   quality:

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -19,13 +19,13 @@
 config:
   version-candidate: VERSION
   dependencies:
-    graql: [build, release]
-    common: [build, release]
+    graql: [build]
+    common: [build]
     bazel-distribution: [build]
     dependencies: [build]
-    protocol: [build, release]
+    protocol: [build]
     behaviour: [build]
-    grabl-tracing: [build, release]
+    grabl-tracing: [build]
 
 build:
   quality:

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -33,19 +33,19 @@ build:
       owner: graknlabs
       branch: master
     build-analysis:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       script: |
         SONARCLOUD_CODE_ANALYSIS_CREDENTIAL=$SONARCLOUD_CREDENTIAL \
           bazel run @graknlabs_dependencies//tool/sonarcloud:code-analysis -- \
           --project-key=graknlabs_client_java \
           --branch=$GRABL_BRANCH --commit-id=$GRABL_COMMIT
     dependency-analysis:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       script: |
         bazel run @graknlabs_dependencies//grabl/analysis:dependency-analysis
   correctness:
     build:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       script: |
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
@@ -54,13 +54,13 @@ build:
         bazel run @graknlabs_dependencies//tool/checkstyle:test-coverage
         bazel test $(bazel query 'kind(checkstyle_test, //...)')
     build-dependency:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       script: |
         dependencies/maven/update.sh
         git diff --exit-code dependencies/maven/artifacts.snapshot
         bazel run @graknlabs_dependencies//tool/unuseddeps:unused-deps -- list
     test-integration:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       script: |
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
@@ -68,7 +68,7 @@ build:
         bazel test //test/integration/... --test_output=errors
       # TODO: use --config=rbe once Grakn Core runs in RBE
     test-behaviour:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       script: |
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
@@ -80,7 +80,7 @@ build:
       # TODO: use --config=rbe once Grakn Core runs in RBE
       # TODO: revert above tests to //test/behaviour/...
     deploy-maven-snapshot:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       dependencies: [build, build-dependency, test-behaviour]
       filter:
         owner: graknlabs
@@ -90,7 +90,7 @@ build:
         export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //:deploy-maven -- snapshot
     test-deployment-maven:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       dependencies: [deploy-maven-snapshot]
       filter:
         owner: graknlabs
@@ -111,11 +111,11 @@ release:
     branch: master
   validation:
     validate-dependencies:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       script: bazel test //:release-validate-deps --test_output=streamed
   deployment:
     deploy-github:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       script: |
         pip install certifi
         export RELEASE_NOTES_TOKEN=$REPO_GITHUB_TOKEN
@@ -123,7 +123,7 @@ release:
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
         bazel run --define version=$(cat VERSION) //:deploy-github -- $GRABL_COMMIT
     deploy-maven-release:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       dependencies: [deploy-github]
       script: |
         export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME


### PR DESCRIPTION
## What is the goal of this PR?

Grabl recently changed the `automation.yml` syntax to have `image` instead of `machine`

## What are the changes implemented in this PR?

* Replace all `machine:` usages with `image:`
* Only depend on `build` versions of other repos
