### PR TITLE
API cleanup: close on commit, isX/asX methods

### DIFF
--- a/concept/Concept.java
+++ b/concept/Concept.java
@@ -21,8 +21,16 @@ package grakn.client.concept;
 
 import grakn.client.Grakn;
 import grakn.client.common.exception.GraknClientException;
+import grakn.client.concept.thing.Attribute;
+import grakn.client.concept.thing.Entity;
+import grakn.client.concept.thing.Relation;
 import grakn.client.concept.thing.Thing;
 import grakn.client.concept.thing.impl.ThingImpl;
+import grakn.client.concept.type.AttributeType;
+import grakn.client.concept.type.EntityType;
+import grakn.client.concept.type.RelationType;
+import grakn.client.concept.type.RoleType;
+import grakn.client.concept.type.ThingType;
 import grakn.client.concept.type.Type;
 import grakn.client.concept.type.impl.TypeImpl;
 import grakn.protocol.ConceptProto;
@@ -34,11 +42,75 @@ import static grakn.common.util.Objects.className;
 
 public interface Concept {
 
+    default boolean isType() {
+        return false;
+    }
+
+    default boolean isThingType() {
+        return false;
+    }
+
+    default boolean isEntityType() {
+        return false;
+    }
+
+    default boolean isAttributeType() {
+        return false;
+    }
+
+    default boolean isRelationType() {
+        return false;
+    }
+
+    default boolean isRoleType() {
+        return false;
+    }
+
+    default boolean isThing() {
+        return false;
+    }
+
+    default boolean isEntity() {
+        return false;
+    }
+
+    default boolean isAttribute() {
+        return false;
+    }
+
+    default boolean isRelation() {
+        return false;
+    }
+
     @CheckReturnValue
     Type asType();
 
     @CheckReturnValue
+    ThingType asThingType();
+
+    @CheckReturnValue
+    EntityType asEntityType();
+
+    @CheckReturnValue
+    AttributeType asAttributeType();
+
+    @CheckReturnValue
+    RelationType asRelationType();
+
+    @CheckReturnValue
+    RoleType asRoleType();
+
+    @CheckReturnValue
     Thing asThing();
+
+    @CheckReturnValue
+    Entity asEntity();
+
+    @CheckReturnValue
+    Attribute<?> asAttribute();
+
+    @CheckReturnValue
+    Relation asRelation();
 
     @CheckReturnValue
     Remote asRemote(Grakn.Transaction transaction);
@@ -57,6 +129,30 @@ public interface Concept {
         Type.Remote asType();
 
         @Override
+        ThingType.Remote asThingType();
+
+        @Override
+        EntityType.Remote asEntityType();
+
+        @Override
+        RelationType.Remote asRelationType();
+
+        @Override
+        AttributeType.Remote asAttributeType();
+
+        @Override
+        RoleType.Remote asRoleType();
+
+        @Override
         Thing.Remote asThing();
+
+        @Override
+        Entity.Remote asEntity();
+
+        @Override
+        Relation.Remote asRelation();
+
+        @Override
+        Attribute.Remote<?> asAttribute();
     }
 }

--- a/concept/impl/ConceptImpl.java
+++ b/concept/impl/ConceptImpl.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package grakn.client.concept.impl;
 
 import grakn.client.common.exception.GraknClientException;

--- a/concept/impl/ConceptImpl.java
+++ b/concept/impl/ConceptImpl.java
@@ -1,0 +1,143 @@
+package grakn.client.concept.impl;
+
+import grakn.client.common.exception.GraknClientException;
+import grakn.client.concept.Concept;
+import grakn.client.concept.thing.Attribute;
+import grakn.client.concept.thing.Entity;
+import grakn.client.concept.thing.Relation;
+import grakn.client.concept.thing.Thing;
+import grakn.client.concept.thing.impl.AttributeImpl;
+import grakn.client.concept.thing.impl.EntityImpl;
+import grakn.client.concept.thing.impl.RelationImpl;
+import grakn.client.concept.thing.impl.ThingImpl;
+import grakn.client.concept.type.AttributeType;
+import grakn.client.concept.type.EntityType;
+import grakn.client.concept.type.RelationType;
+import grakn.client.concept.type.RoleType;
+import grakn.client.concept.type.ThingType;
+import grakn.client.concept.type.Type;
+import grakn.client.concept.type.impl.AttributeTypeImpl;
+import grakn.client.concept.type.impl.EntityTypeImpl;
+import grakn.client.concept.type.impl.RelationTypeImpl;
+import grakn.client.concept.type.impl.RoleTypeImpl;
+import grakn.client.concept.type.impl.ThingTypeImpl;
+import grakn.client.concept.type.impl.TypeImpl;
+
+import static grakn.client.common.exception.ErrorMessage.Concept.INVALID_CONCEPT_CASTING;
+import static grakn.common.util.Objects.className;
+
+public abstract class ConceptImpl implements Concept {
+
+    @Override
+    public final boolean isRemote() {
+        return false;
+    }
+
+    @Override
+    public TypeImpl asType() {
+        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Type.class)));
+    }
+
+    @Override
+    public ThingTypeImpl asThingType() {
+        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(ThingType.class)));
+    }
+
+    @Override
+    public EntityTypeImpl asEntityType() {
+        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(EntityType.class)));
+    }
+
+    @Override
+    public AttributeTypeImpl asAttributeType() {
+        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(AttributeType.class)));
+    }
+
+    @Override
+    public RelationTypeImpl asRelationType() {
+        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(RelationType.class)));
+    }
+
+    @Override
+    public RoleTypeImpl asRoleType() {
+        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(RoleType.class)));
+    }
+
+    @Override
+    public ThingImpl asThing() {
+        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Thing.class)));
+    }
+
+    @Override
+    public EntityImpl asEntity() {
+        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Entity.class)));
+    }
+
+    @Override
+    public AttributeImpl<?> asAttribute() {
+        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Attribute.class)));
+    }
+
+    @Override
+    public RelationImpl asRelation() {
+        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Relation.class)));
+    }
+
+    public abstract static class Remote implements Concept.Remote {
+
+        @Override
+        public final boolean isRemote() {
+            return true;
+        }
+
+        @Override
+        public TypeImpl.Remote asType() {
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Type.class)));
+        }
+
+        @Override
+        public ThingTypeImpl.Remote asThingType() {
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(ThingType.class)));
+        }
+
+        @Override
+        public EntityTypeImpl.Remote asEntityType() {
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(EntityType.class)));
+        }
+
+        @Override
+        public RelationTypeImpl.Remote asRelationType() {
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(RelationType.class)));
+        }
+
+        @Override
+        public AttributeTypeImpl.Remote asAttributeType() {
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(AttributeType.class)));
+        }
+
+        @Override
+        public RoleTypeImpl.Remote asRoleType() {
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(RoleType.class)));
+        }
+
+        @Override
+        public ThingImpl.Remote asThing() {
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Thing.class)));
+        }
+
+        @Override
+        public EntityImpl.Remote asEntity() {
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Entity.class)));
+        }
+
+        @Override
+        public RelationImpl.Remote asRelation() {
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Relation.class)));
+        }
+
+        @Override
+        public AttributeImpl.Remote<?> asAttribute() {
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Attribute.class)));
+        }
+    }
+}

--- a/concept/proto/ConceptProtoBuilder.java
+++ b/concept/proto/ConceptProtoBuilder.java
@@ -49,7 +49,7 @@ public abstract class ConceptProtoBuilder {
 
     public static ConceptProto.Concept concept(Concept concept) {
         final ConceptProto.Concept.Builder builder = ConceptProto.Concept.newBuilder();
-        if (concept instanceof Thing) {
+        if (concept.isThing()) {
             builder.setThing(thing(concept.asThing()));
         } else {
             builder.setType(type(concept.asType()));
@@ -69,7 +69,7 @@ public abstract class ConceptProtoBuilder {
                 .setLabel(type.getLabel())
                 .setEncoding(encoding(type));
 
-        if (type instanceof RoleType) {
+        if (type.isRoleType()) {
             builder.setScope(type.asRoleType().getScope());
         }
 
@@ -122,11 +122,11 @@ public abstract class ConceptProtoBuilder {
     }
 
     private static ConceptProto.Thing.Encoding encoding(Thing thing) {
-        if (thing instanceof Entity) {
+        if (thing.isEntity()) {
             return ConceptProto.Thing.Encoding.ENTITY;
-        } else if (thing instanceof Relation) {
+        } else if (thing.isRelation()) {
             return ConceptProto.Thing.Encoding.RELATION;
-        } else if (thing instanceof Attribute) {
+        } else if (thing.isAttribute()) {
             return ConceptProto.Thing.Encoding.ATTRIBUTE;
         } else {
             return ConceptProto.Thing.Encoding.UNRECOGNIZED;
@@ -134,15 +134,15 @@ public abstract class ConceptProtoBuilder {
     }
 
     private static ConceptProto.Type.Encoding encoding(Type type) {
-        if (type instanceof EntityType) {
+        if (type.isEntityType()) {
             return ConceptProto.Type.Encoding.ENTITY_TYPE;
-        } else if (type instanceof RelationType) {
+        } else if (type.isRelationType()) {
             return ConceptProto.Type.Encoding.RELATION_TYPE;
-        } else if (type instanceof AttributeType) {
+        } else if (type.isAttributeType()) {
             return ConceptProto.Type.Encoding.ATTRIBUTE_TYPE;
-        } else if (type instanceof RoleType) {
+        } else if (type.isRoleType()) {
             return ConceptProto.Type.Encoding.ROLE_TYPE;
-        } else if (type instanceof ThingType) {
+        } else if (type.isThingType()) {
             return ConceptProto.Type.Encoding.THING_TYPE;
         } else {
             return ConceptProto.Type.Encoding.UNRECOGNIZED;

--- a/concept/thing/Attribute.java
+++ b/concept/thing/Attribute.java
@@ -35,7 +35,6 @@ public interface Attribute<VALUE> extends Thing {
         return true;
     }
 
-    // TODO: make these default?
     Attribute.Boolean asBoolean();
 
     Attribute.Long asLong();

--- a/concept/thing/Attribute.java
+++ b/concept/thing/Attribute.java
@@ -35,6 +35,26 @@ public interface Attribute<VALUE> extends Thing {
         return true;
     }
 
+    default boolean isBoolean() {
+        return false;
+    }
+
+    default boolean isLong() {
+        return false;
+    }
+
+    default boolean isDouble() {
+        return false;
+    }
+
+    default boolean isString() {
+        return false;
+    }
+
+    default boolean isDateTime() {
+        return false;
+    }
+
     Attribute.Boolean asBoolean();
 
     Attribute.Long asLong();
@@ -79,6 +99,11 @@ public interface Attribute<VALUE> extends Thing {
     interface Boolean extends Attribute<java.lang.Boolean> {
 
         @Override
+        default boolean isBoolean() {
+            return true;
+        }
+
+        @Override
         Attribute.Boolean.Remote asRemote(Grakn.Transaction transaction);
 
         interface Remote extends Attribute.Boolean, Attribute.Remote<java.lang.Boolean> {
@@ -86,6 +111,11 @@ public interface Attribute<VALUE> extends Thing {
     }
 
     interface Long extends Attribute<java.lang.Long> {
+
+        @Override
+        default boolean isLong() {
+            return true;
+        }
 
         @Override
         Attribute.Long.Remote asRemote(Grakn.Transaction transaction);
@@ -97,6 +127,11 @@ public interface Attribute<VALUE> extends Thing {
     interface Double extends Attribute<java.lang.Double> {
 
         @Override
+        default boolean isDouble() {
+            return true;
+        }
+
+        @Override
         Attribute.Double.Remote asRemote(Grakn.Transaction transaction);
 
         interface Remote extends Attribute.Double, Attribute.Remote<java.lang.Double> {
@@ -106,6 +141,11 @@ public interface Attribute<VALUE> extends Thing {
     interface String extends Attribute<java.lang.String> {
 
         @Override
+        default boolean isString() {
+            return true;
+        }
+
+        @Override
         Attribute.String.Remote asRemote(Grakn.Transaction transaction);
 
         interface Remote extends Attribute.String, Attribute.Remote<java.lang.String> {
@@ -113,6 +153,11 @@ public interface Attribute<VALUE> extends Thing {
     }
 
     interface DateTime extends Attribute<LocalDateTime> {
+
+        @Override
+        default boolean isDateTime() {
+            return true;
+        }
 
         @Override
         Attribute.DateTime.Remote asRemote(Grakn.Transaction transaction);

--- a/concept/thing/Attribute.java
+++ b/concept/thing/Attribute.java
@@ -30,6 +30,12 @@ public interface Attribute<VALUE> extends Thing {
 
     VALUE getValue();
 
+    @Override
+    default boolean isAttribute() {
+        return true;
+    }
+
+    // TODO: make these default?
     Attribute.Boolean asBoolean();
 
     Attribute.Long asLong();

--- a/concept/thing/Entity.java
+++ b/concept/thing/Entity.java
@@ -25,6 +25,11 @@ import grakn.client.concept.type.EntityType;
 public interface Entity extends Thing {
 
     @Override
+    default boolean isEntity() {
+        return true;
+    }
+
+    @Override
     Entity.Remote asRemote(Grakn.Transaction transaction);
 
     interface Remote extends Thing.Remote, Entity {

--- a/concept/thing/Relation.java
+++ b/concept/thing/Relation.java
@@ -30,6 +30,11 @@ import java.util.stream.Stream;
 public interface Relation extends Thing {
 
     @Override
+    default boolean isRelation() {
+        return true;
+    }
+
+    @Override
     Relation.Remote asRemote(Grakn.Transaction transaction);
 
     interface Remote extends Thing.Remote, Relation {

--- a/concept/thing/Thing.java
+++ b/concept/thing/Thing.java
@@ -32,6 +32,11 @@ public interface Thing extends Concept {
     String getIID();
 
     @Override
+    default boolean isThing() {
+        return true;
+    }
+
+    @Override
     Thing.Remote asRemote(Grakn.Transaction transaction);
 
     interface Remote extends Concept.Remote, Thing {

--- a/concept/thing/Thing.java
+++ b/concept/thing/Thing.java
@@ -31,12 +31,6 @@ public interface Thing extends Concept {
 
     String getIID();
 
-    Entity asEntity();
-
-    Attribute<?> asAttribute();
-
-    Relation asRelation();
-
     @Override
     Thing.Remote asRemote(Grakn.Transaction transaction);
 
@@ -67,17 +61,5 @@ public interface Thing extends Concept {
         Stream<? extends RoleType> getPlays();
 
         Stream<? extends Relation> getRelations(RoleType... roleTypes);
-
-        @Override
-        Thing.Remote asThing();
-
-        @Override
-        Entity.Remote asEntity();
-
-        @Override
-        Relation.Remote asRelation();
-
-        @Override
-        Attribute.Remote<?> asAttribute();
     }
 }

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -21,13 +21,11 @@ package grakn.client.concept.thing.impl;
 
 import grakn.client.Grakn;
 import grakn.client.common.exception.GraknClientException;
+import grakn.client.concept.impl.ConceptImpl;
 import grakn.client.concept.thing.Attribute;
-import grakn.client.concept.thing.Entity;
-import grakn.client.concept.thing.Relation;
 import grakn.client.concept.thing.Thing;
 import grakn.client.concept.type.AttributeType;
 import grakn.client.concept.type.RoleType;
-import grakn.client.concept.type.Type;
 import grakn.client.concept.type.impl.RoleTypeImpl;
 import grakn.client.concept.type.impl.ThingTypeImpl;
 import grakn.client.concept.type.impl.TypeImpl;
@@ -41,16 +39,15 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static grakn.client.common.exception.ErrorMessage.Concept.INVALID_CONCEPT_CASTING;
+import static grakn.client.common.exception.ErrorMessage.Concept.BAD_ENCODING;
 import static grakn.client.common.exception.ErrorMessage.Concept.MISSING_IID;
 import static grakn.client.common.exception.ErrorMessage.Concept.MISSING_TRANSACTION;
-import static grakn.client.common.exception.ErrorMessage.Concept.BAD_ENCODING;
 import static grakn.client.concept.proto.ConceptProtoBuilder.iid;
 import static grakn.client.concept.proto.ConceptProtoBuilder.thing;
 import static grakn.client.concept.proto.ConceptProtoBuilder.types;
 import static grakn.common.util.Objects.className;
 
-public abstract class ThingImpl implements Thing {
+public abstract class ThingImpl extends ConceptImpl implements Thing {
 
     private final String iid;
     // TODO: private final ThingType type;
@@ -83,33 +80,8 @@ public abstract class ThingImpl implements Thing {
     }
 
     @Override
-    public boolean isRemote() {
-        return false;
-    }
-
-    @Override
     public ThingImpl asThing() {
         return this;
-    }
-
-    @Override
-    public final TypeImpl asType() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Type.class)));
-    }
-
-    @Override
-    public EntityImpl asEntity() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Entity.class)));
-    }
-
-    @Override
-    public AttributeImpl<?> asAttribute() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Attribute.class)));
-    }
-
-    @Override
-    public RelationImpl asRelation() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Relation.class)));
     }
 
     @Override
@@ -131,7 +103,7 @@ public abstract class ThingImpl implements Thing {
         return iid.hashCode();
     }
 
-    public abstract static class Remote implements Thing.Remote {
+    public abstract static class Remote extends ConceptImpl.Remote implements Thing.Remote {
 
         final RPCTransaction rpcTransaction;
         private final String iid;
@@ -246,33 +218,8 @@ public abstract class ThingImpl implements Thing {
         }
 
         @Override
-        public final boolean isRemote() {
-            return true;
-        }
-
-        @Override
         public final ThingImpl.Remote asThing() {
             return this;
-        }
-
-        @Override
-        public final TypeImpl.Remote asType() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Type.class)));
-        }
-
-        @Override
-        public EntityImpl.Remote asEntity() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Entity.class)));
-        }
-
-        @Override
-        public RelationImpl.Remote asRelation() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Relation.class)));
-        }
-
-        @Override
-        public AttributeImpl.Remote<?> asAttribute() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Attribute.class)));
         }
 
         final Grakn.Transaction tx() {

--- a/concept/type/AttributeType.java
+++ b/concept/type/AttributeType.java
@@ -64,7 +64,6 @@ public interface AttributeType extends ThingType {
     @Override
     AttributeType.Remote asRemote(Grakn.Transaction transaction);
 
-    // TODO: defaults
     AttributeType.Boolean asBoolean();
 
     AttributeType.Long asLong();

--- a/concept/type/AttributeType.java
+++ b/concept/type/AttributeType.java
@@ -41,9 +41,30 @@ public interface AttributeType extends ThingType {
         return true;
     }
 
+    default boolean isBoolean() {
+        return false;
+    }
+
+    default boolean isLong() {
+        return false;
+    }
+
+    default boolean isDouble() {
+        return false;
+    }
+
+    default boolean isString() {
+        return false;
+    }
+
+    default boolean isDateTime() {
+        return false;
+    }
+
     @Override
     AttributeType.Remote asRemote(Grakn.Transaction transaction);
 
+    // TODO: defaults
     AttributeType.Boolean asBoolean();
 
     AttributeType.Long asLong();
@@ -157,6 +178,11 @@ public interface AttributeType extends ThingType {
     interface Boolean extends AttributeType {
 
         @Override
+        default boolean isBoolean() {
+            return true;
+        }
+
+        @Override
         AttributeType.Boolean.Remote asRemote(Grakn.Transaction transaction);
 
         interface Remote extends AttributeType.Boolean, AttributeType.Remote {
@@ -180,6 +206,11 @@ public interface AttributeType extends ThingType {
     }
 
     interface Long extends AttributeType {
+
+        @Override
+        default boolean isLong() {
+            return true;
+        }
 
         @Override
         AttributeType.Long.Remote asRemote(Grakn.Transaction transaction);
@@ -207,6 +238,11 @@ public interface AttributeType extends ThingType {
     interface Double extends AttributeType {
 
         @Override
+        default boolean isDouble() {
+            return true;
+        }
+
+        @Override
         AttributeType.Double.Remote asRemote(Grakn.Transaction transaction);
 
         interface Remote extends AttributeType.Double, AttributeType.Remote {
@@ -230,6 +266,11 @@ public interface AttributeType extends ThingType {
     }
 
     interface String extends AttributeType {
+
+        @Override
+        default boolean isString() {
+            return true;
+        }
 
         @Override
         AttributeType.String.Remote asRemote(Grakn.Transaction transaction);
@@ -260,6 +301,11 @@ public interface AttributeType extends ThingType {
     }
 
     interface DateTime extends AttributeType {
+
+        @Override
+        default boolean isDateTime() {
+            return true;
+        }
 
         @Override
         AttributeType.DateTime.Remote asRemote(Grakn.Transaction transaction);

--- a/concept/type/Type.java
+++ b/concept/type/Type.java
@@ -34,40 +34,10 @@ public interface Type extends Concept {
     @CheckReturnValue
     boolean isRoot();
 
-    default boolean isThingType() {
-        return false;
+    @Override
+    default boolean isType() {
+        return true;
     }
-
-    default boolean isEntityType() {
-        return false;
-    }
-
-    default boolean isAttributeType() {
-        return false;
-    }
-
-    default boolean isRelationType() {
-        return false;
-    }
-
-    default boolean isRoleType() {
-        return false;
-    }
-
-    @CheckReturnValue
-    ThingType asThingType();
-
-    @CheckReturnValue
-    EntityType asEntityType();
-
-    @CheckReturnValue
-    AttributeType asAttributeType();
-
-    @CheckReturnValue
-    RelationType asRelationType();
-
-    @CheckReturnValue
-    RoleType asRoleType();
 
     @Override
     Remote asRemote(Grakn.Transaction transaction);
@@ -88,23 +58,5 @@ public interface Type extends Concept {
 
         @CheckReturnValue
         Stream<? extends Type> getSubtypes();
-
-        @Override
-        Type.Remote asType();
-
-        @Override
-        ThingType.Remote asThingType();
-
-        @Override
-        EntityType.Remote asEntityType();
-
-        @Override
-        RelationType.Remote asRelationType();
-
-        @Override
-        AttributeType.Remote asAttributeType();
-
-        @Override
-        RoleType.Remote asRoleType();
     }
 }

--- a/concept/type/impl/AttributeTypeImpl.java
+++ b/concept/type/impl/AttributeTypeImpl.java
@@ -28,14 +28,12 @@ import grakn.protocol.ConceptProto;
 
 import javax.annotation.Nullable;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.stream.Stream;
 
 import static grakn.client.common.exception.ErrorMessage.Concept.BAD_VALUE_TYPE;
 import static grakn.client.common.exception.ErrorMessage.Concept.INVALID_CONCEPT_CASTING;
 import static grakn.client.concept.proto.ConceptProtoBuilder.attributeValue;
 import static grakn.common.util.Objects.className;
-import static java.util.stream.Collectors.toList;
 
 public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 

--- a/concept/type/impl/AttributeTypeImpl.java
+++ b/concept/type/impl/AttributeTypeImpl.java
@@ -129,8 +129,8 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
         if (this == o) return true;
         if (!(o instanceof AttributeTypeImpl)) return false;
         // We do the above, as opposed to checking if (object == null || getClass() != object.getClass())
-        // because it is possible to compare a attribute root types wrapped in different type classes
-        // such as: root type wrapped in AttributeTypeImpl.Root and as in AttributeType.Boolean.Root
+        // because it is possible to compare attribute root types wrapped in different type classes
+        // such as: root type wrapped in AttributeTypeImpl.Root and in AttributeTypeImpl.Boolean.Root
         // We only override equals(), but not hash(), in this class, as hash() the logic from TypeImpl still applies.
 
         final AttributeTypeImpl that = (AttributeTypeImpl) o;

--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -26,7 +26,6 @@ import grakn.client.concept.type.AttributeType;
 import grakn.client.concept.type.AttributeType.ValueType;
 import grakn.client.concept.type.RoleType;
 import grakn.client.concept.type.ThingType;
-import grakn.client.concept.type.Type;
 import grakn.protocol.ConceptProto;
 
 import java.util.stream.Stream;

--- a/concept/type/impl/TypeImpl.java
+++ b/concept/type/impl/TypeImpl.java
@@ -21,7 +21,14 @@ package grakn.client.concept.type.impl;
 
 import grakn.client.Grakn;
 import grakn.client.common.exception.GraknClientException;
+import grakn.client.concept.impl.ConceptImpl;
+import grakn.client.concept.thing.Attribute;
+import grakn.client.concept.thing.Entity;
+import grakn.client.concept.thing.Relation;
 import grakn.client.concept.thing.Thing;
+import grakn.client.concept.thing.impl.AttributeImpl;
+import grakn.client.concept.thing.impl.EntityImpl;
+import grakn.client.concept.thing.impl.RelationImpl;
 import grakn.client.concept.thing.impl.ThingImpl;
 import grakn.client.concept.type.AttributeType;
 import grakn.client.concept.type.EntityType;
@@ -46,7 +53,7 @@ import static grakn.client.common.exception.ErrorMessage.Concept.BAD_ENCODING;
 import static grakn.client.concept.proto.ConceptProtoBuilder.type;
 import static grakn.common.util.Objects.className;
 
-public abstract class TypeImpl implements Type {
+public abstract class TypeImpl extends ConceptImpl implements Type {
 
     private final String label;
     private final boolean isRoot;
@@ -81,43 +88,8 @@ public abstract class TypeImpl implements Type {
     }
 
     @Override
-    public boolean isRemote() {
-        return false;
-    }
-
-    @Override
     public TypeImpl asType() {
         return this;
-    }
-
-    @Override
-    public ThingImpl asThing() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Thing.class)));
-    }
-
-    @Override
-    public ThingTypeImpl asThingType() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(ThingType.class)));
-    }
-
-    @Override
-    public EntityTypeImpl asEntityType() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(EntityType.class)));
-    }
-
-    @Override
-    public AttributeTypeImpl asAttributeType() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(AttributeType.class)));
-    }
-
-    @Override
-    public RelationTypeImpl asRelationType() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(RelationType.class)));
-    }
-
-    @Override
-    public RoleTypeImpl asRoleType() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(RoleType.class)));
     }
 
     @Override
@@ -139,7 +111,7 @@ public abstract class TypeImpl implements Type {
         return hash;
     }
 
-    public abstract static class Remote implements Type.Remote {
+    public abstract static class Remote extends ConceptImpl.Remote implements Type.Remote {
 
         final RPCTransaction rpcTransaction;
         private String label;
@@ -166,11 +138,6 @@ public abstract class TypeImpl implements Type {
         }
 
         @Override
-        public final boolean isRemote() {
-            return true;
-        }
-
-        @Override
         public final void setLabel(String label) {
             execute(ConceptProto.Type.Req.newBuilder()
                     .setTypeSetLabelReq(ConceptProto.Type.SetLabel.Req.newBuilder().setLabel(label)));
@@ -188,11 +155,6 @@ public abstract class TypeImpl implements Type {
         @Override
         public TypeImpl.Remote asType() {
             return this;
-        }
-
-        @Override
-        public ThingImpl.Remote asThing() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Thing.class)));
         }
 
         @Override
@@ -218,6 +180,26 @@ public abstract class TypeImpl implements Type {
         @Override
         public RoleTypeImpl.Remote asRoleType() {
             throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(RoleType.class)));
+        }
+
+        @Override
+        public ThingImpl.Remote asThing() {
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Thing.class)));
+        }
+
+        @Override
+        public EntityImpl.Remote asEntity() {
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Entity.class)));
+        }
+
+        @Override
+        public AttributeImpl.Remote<?> asAttribute() {
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Attribute.class)));
+        }
+
+        @Override
+        public RelationImpl.Remote asRelation() {
+            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Relation.class)));
         }
 
         // We can't declare this in Type.Remote because then (for example) EntityTypeImpl.Remote would be expected to

--- a/rpc/RPCTransaction.java
+++ b/rpc/RPCTransaction.java
@@ -114,7 +114,11 @@ public class RPCTransaction implements Transaction {
         final TransactionProto.Transaction.Req.Builder commitReq = TransactionProto.Transaction.Req.newBuilder()
                 .putAllMetadata(tracingData())
                 .setCommitReq(TransactionProto.Transaction.Commit.Req.getDefaultInstance());
-        execute(commitReq);
+        try {
+            execute(commitReq);
+        } finally {
+            close();
+        }
     }
 
     @Override

--- a/test/behaviour/graql/GraqlSteps.java
+++ b/test/behaviour/graql/GraqlSteps.java
@@ -520,7 +520,7 @@ public class GraqlSteps {
 
         @Override
         public boolean check(Concept concept) {
-            if (concept instanceof Type) {
+            if (concept.isType()) {
                 return label.equals(concept.asType().getLabel());
             }
 
@@ -550,7 +550,7 @@ public class GraqlSteps {
         }
 
         public boolean check(Concept concept) {
-            return concept instanceof Attribute
+            return concept.isAttribute()
                     && type.equals(concept.asAttribute().asRemote(tx()).getType().getLabel())
                     && value.equals(concept.asAttribute().getValue().toString());
         }
@@ -563,7 +563,7 @@ public class GraqlSteps {
 
         @Override
         public boolean check(Concept concept) {
-            if (!(concept instanceof Thing)) { return false; }
+            if (!concept.isThing()) { return false; }
 
             final Set<Attribute<?>> keys = concept.asThing().asRemote(tx()).getHas(true).collect(Collectors.toSet());
 

--- a/test/behaviour/graql/GraqlSteps.java
+++ b/test/behaviour/graql/GraqlSteps.java
@@ -551,8 +551,8 @@ public class GraqlSteps {
 
         public boolean check(Concept concept) {
             return concept instanceof Attribute
-                    && type.equals(concept.asThing().asAttribute().asRemote(tx()).getType().getLabel())
-                    && value.equals(concept.asThing().asAttribute().getValue().toString());
+                    && type.equals(concept.asAttribute().asRemote(tx()).getType().getLabel())
+                    && value.equals(concept.asAttribute().getValue().toString());
         }
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

As we close transactions on commit at the server end, it makes sense to also close transactions when they are committed at client side. This change does that. Additionally, for user experience reasons, "isX" functions have been added to the Concept interface to determine what variety of Concept an object represents.

## What are the changes implemented in this PR?

We added a try/finally to `commit()` that closes the transaction when it completes or fails.
We added is[Concept] functions to all Concepts indicating if the current Concept is an instance of that Concept variety.