### PR TITLE
Move GraknClient to root package

### DIFF
--- a/GraknClient.java
+++ b/GraknClient.java
@@ -17,12 +17,13 @@
  * under the License.
  */
 
-package grakn.client.rpc;
+package grakn.client;
 
 import grakn.client.Grakn.Client;
 import grakn.client.Grakn.DatabaseManager;
 import grakn.client.Grakn.Session;
-import grakn.client.GraknOptions;
+import grakn.client.rpc.RPCDatabaseManager;
+import grakn.client.rpc.RPCSession;
 import io.grpc.Channel;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -74,7 +75,7 @@ public class GraknClient implements Client {
         }
     }
 
-    Channel channel() {
+    public Channel channel() {
         return channel;
     }
 }

--- a/concept/answer/ConceptMap.java
+++ b/concept/answer/ConceptMap.java
@@ -38,11 +38,9 @@ import static grakn.client.common.exception.ErrorMessage.Query.VARIABLE_DOES_NOT
 public class ConceptMap implements Answer {
 
     private final Map<String, Concept> map;
-    private final Pattern queryPattern;
 
-    public ConceptMap(Map<String, Concept> map, Pattern queryPattern) {
+    public ConceptMap(Map<String, Concept> map) {
         this.map = Collections.unmodifiableMap(map);
-        this.queryPattern = queryPattern;
     }
 
     public static ConceptMap of(AnswerProto.ConceptMap res) {
@@ -53,12 +51,7 @@ public class ConceptMap implements Answer {
             else concept = TypeImpl.of(resConcept.getType());
             variableMap.put(resVar, concept);
         });
-        Pattern queryPattern = res.getPattern().equals("") ? null : Graql.parsePattern(res.getPattern());
-        return new ConceptMap(Collections.unmodifiableMap(variableMap), queryPattern);
-    }
-
-    public Pattern queryPattern() {
-        return queryPattern;
+        return new ConceptMap(Collections.unmodifiableMap(variableMap));
     }
 
     public Map<String, Concept> map() {

--- a/concept/proto/ConceptProtoBuilder.java
+++ b/concept/proto/ConceptProtoBuilder.java
@@ -155,7 +155,6 @@ public abstract class ConceptProtoBuilder {
             ConceptProto.Concept conceptProto = concept(concept);
             conceptMapProto.putMap(var, conceptProto);
         });
-        conceptMapProto.setPattern(conceptMap.queryPattern().toString());
         return conceptMapProto.build();
     }
 }

--- a/rpc/RPCDatabaseManager.java
+++ b/rpc/RPCDatabaseManager.java
@@ -32,10 +32,10 @@ import java.util.function.Supplier;
 
 import static grakn.client.common.exception.ErrorMessage.Client.MISSING_DB_NAME;
 
-class RPCDatabaseManager implements DatabaseManager {
+public class RPCDatabaseManager implements DatabaseManager {
     private final GraknGrpc.GraknBlockingStub blockingGrpcStub;
 
-    RPCDatabaseManager(Channel channel) {
+    public RPCDatabaseManager(Channel channel) {
         blockingGrpcStub = GraknGrpc.newBlockingStub(channel);
     }
 

--- a/rpc/RPCSession.java
+++ b/rpc/RPCSession.java
@@ -22,6 +22,7 @@ package grakn.client.rpc;
 import com.google.protobuf.ByteString;
 import grakn.client.Grakn.Session;
 import grakn.client.Grakn.Transaction;
+import grakn.client.GraknClient;
 import grakn.client.GraknOptions;
 import grakn.protocol.GraknGrpc;
 import grakn.protocol.SessionProto;
@@ -43,7 +44,7 @@ public class RPCSession implements Session {
     private final Timer pulse;
     private final GraknGrpc.GraknBlockingStub blockingGrpcStub;
 
-    RPCSession(GraknClient client, String database, Type type, GraknOptions options) {
+    public RPCSession(GraknClient client, String database, Type type, GraknOptions options) {
         this.channel = client.channel();
         this.database = database;
         this.type = type;

--- a/test/behaviour/connection/ConnectionSteps.java
+++ b/test/behaviour/connection/ConnectionSteps.java
@@ -22,7 +22,7 @@ package grakn.client.test.behaviour.connection;
 import grakn.client.Grakn.Client;
 import grakn.client.Grakn.Session;
 import grakn.client.Grakn.Transaction;
-import grakn.client.rpc.GraknClient;
+import grakn.client.GraknClient;
 import grakn.common.test.server.GraknSingleton;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;

--- a/test/deployment/src/test/java/application/MavenApplicationTest.java
+++ b/test/deployment/src/test/java/application/MavenApplicationTest.java
@@ -23,7 +23,7 @@ import grakn.client.Grakn;
 import grakn.client.Grakn.Session;
 import grakn.client.Grakn.Transaction;
 import grakn.client.concept.type.ThingType;
-import grakn.client.rpc.GraknClient;
+import grakn.client.GraknClient;
 import org.junit.Test;
 
 import java.util.stream.Collectors;

--- a/test/integration/ClientQueryTest.java
+++ b/test/integration/ClientQueryTest.java
@@ -22,7 +22,7 @@ package grakn.client.test.integration;
 import grakn.client.Grakn.Client;
 import grakn.client.Grakn.Session;
 import grakn.client.Grakn.Transaction;
-import grakn.client.rpc.GraknClient;
+import grakn.client.GraknClient;
 import grakn.common.test.server.GraknCoreRunner;
 import graql.lang.Graql;
 import graql.lang.common.GraqlArg;


### PR DESCRIPTION
## What is the goal of this PR?

GraknClient was previously located in the `rpc` package which is supposed to be only for internal use. We moved it to the root package, where it is easily found at `grakn.client`.

## What are the changes implemented in this PR?

- Move GraknClient to root package
