### PR TITLE
Temporarily disable dependency-analysis

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -39,10 +39,11 @@ build:
           bazel run @graknlabs_dependencies//tool/sonarcloud:code-analysis -- \
           --project-key=graknlabs_client_java \
           --branch=$GRABL_BRANCH --commit-id=$GRABL_COMMIT
-    dependency-analysis:
-      image: graknlabs-ubuntu-20.04
-      command: |
-        bazel run @graknlabs_dependencies//grabl/analysis:dependency-analysis
+      # TODO: re-enable once tags and commit hashes can be mixed
+#    dependency-analysis:
+#      image: graknlabs-ubuntu-20.04
+#      command: |
+#        bazel run @graknlabs_dependencies//grabl/analysis:dependency-analysis
   correctness:
     build:
       image: graknlabs-ubuntu-20.04


### PR DESCRIPTION
## What is the goal of this PR?

We temporarily disable dependency-analysis to try to fix the build in CI
