### PR TITLE
Fix invalid cast for the super type of root types

### DIFF
--- a/concept/type/AttributeType.java
+++ b/concept/type/AttributeType.java
@@ -143,9 +143,6 @@ public interface AttributeType extends ThingType {
         void setSupertype(AttributeType attributeType);
 
         @Override
-        AttributeType getSupertype();
-
-        @Override
         Stream<? extends AttributeType> getSubtypes();
 
         @Override
@@ -189,9 +186,6 @@ public interface AttributeType extends ThingType {
             void setSupertype(AttributeType.Boolean booleanAttributeType);
 
             @Override
-            AttributeType.Boolean getSupertype();
-
-            @Override
             Stream<? extends AttributeType.Boolean> getSubtypes();
 
             @Override
@@ -217,9 +211,6 @@ public interface AttributeType extends ThingType {
         interface Remote extends AttributeType.Long, AttributeType.Remote {
 
             void setSupertype(AttributeType.Long longAttributeType);
-
-            @Override
-            AttributeType.Long getSupertype();
 
             @Override
             Stream<? extends AttributeType.Long> getSubtypes();
@@ -249,9 +240,6 @@ public interface AttributeType extends ThingType {
             void setSupertype(AttributeType.Double doubleAttributeType);
 
             @Override
-            AttributeType.Double getSupertype();
-
-            @Override
             Stream<? extends AttributeType.Double> getSubtypes();
 
             @Override
@@ -277,9 +265,6 @@ public interface AttributeType extends ThingType {
         interface Remote extends AttributeType.String, AttributeType.Remote {
 
             void setSupertype(AttributeType.String stringAttributeType);
-
-            @Override
-            AttributeType.String getSupertype();
 
             @Override
             Stream<? extends AttributeType.String> getSubtypes();
@@ -312,9 +297,6 @@ public interface AttributeType extends ThingType {
         interface Remote extends AttributeType.DateTime, AttributeType.Remote {
 
             void setSupertype(AttributeType.DateTime dateTimeAttributeType);
-
-            @Override
-            AttributeType.DateTime getSupertype();
 
             @Override
             Stream<? extends AttributeType.DateTime> getSubtypes();

--- a/concept/type/EntityType.java
+++ b/concept/type/EntityType.java
@@ -41,9 +41,6 @@ public interface EntityType extends ThingType {
         void setSupertype(EntityType superEntityType);
 
         @Override
-        EntityType getSupertype();
-
-        @Override
         Stream<? extends EntityType> getSubtypes();
 
         @Override

--- a/concept/type/RelationType.java
+++ b/concept/type/RelationType.java
@@ -53,9 +53,6 @@ public interface RelationType extends ThingType {
         void setSupertype(RelationType superRelationType);
 
         @Override
-        RelationType getSupertype();
-
-        @Override
         Stream<? extends RelationType> getSubtypes();
 
         @Override

--- a/concept/type/impl/AttributeTypeImpl.java
+++ b/concept/type/impl/AttributeTypeImpl.java
@@ -163,13 +163,6 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
             super.setSupertype(attributeType);
         }
 
-        @Nullable
-        @Override
-        public AttributeTypeImpl getSupertype() {
-            final ThingTypeImpl supertype = super.getSupertype();
-            return supertype != null ? supertype.asAttributeType() : null;
-        }
-
         @Override
         public Stream<? extends AttributeTypeImpl> getSubtypes() {
             final Stream<AttributeTypeImpl> stream = super.getSubtypes().map(TypeImpl::asAttributeType);
@@ -317,12 +310,6 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
             }
 
             @Override
-            public final AttributeTypeImpl.Boolean getSupertype() {
-                final AttributeTypeImpl supertype = super.getSupertype();
-                return supertype != null ? supertype.asBoolean() : null;
-            }
-
-            @Override
             public final Stream<AttributeTypeImpl.Boolean> getSubtypes() {
                 return super.getSubtypes().map(AttributeTypeImpl::asBoolean);
             }
@@ -395,12 +382,6 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
             @Override
             public AttributeTypeImpl.Long.Remote asRemote(Grakn.Transaction transaction) {
                 return new AttributeTypeImpl.Long.Remote(transaction, getLabel(), isRoot());
-            }
-
-            @Override
-            public final AttributeTypeImpl.Long getSupertype() {
-                final AttributeTypeImpl supertype = super.getSupertype();
-                return supertype != null ? supertype.asLong() : null;
             }
 
             @Override
@@ -479,12 +460,6 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
             }
 
             @Override
-            public final AttributeTypeImpl.Double getSupertype() {
-                final AttributeTypeImpl supertype = super.getSupertype();
-                return supertype != null ? supertype.asDouble() : null;
-            }
-
-            @Override
             public final Stream<AttributeTypeImpl.Double> getSubtypes() {
                 return super.getSubtypes().map(AttributeTypeImpl::asDouble);
             }
@@ -557,12 +532,6 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
             @Override
             public AttributeTypeImpl.String.Remote asRemote(Grakn.Transaction transaction) {
                 return new AttributeTypeImpl.String.Remote(transaction, getLabel(), isRoot());
-            }
-
-            @Override
-            public final AttributeTypeImpl.String getSupertype() {
-                final AttributeTypeImpl supertype = super.getSupertype();
-                return supertype != null ? supertype.asString() : null;
             }
 
             @Override
@@ -656,12 +625,6 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
             @Override
             public AttributeTypeImpl.DateTime.Remote asRemote(Grakn.Transaction transaction) {
                 return new AttributeTypeImpl.DateTime.Remote(transaction, getLabel(), isRoot());
-            }
-
-            @Override
-            public final AttributeTypeImpl.DateTime getSupertype() {
-                final AttributeTypeImpl supertype = super.getSupertype();
-                return supertype != null ? supertype.asDateTime() : null;
             }
 
             @Override

--- a/concept/type/impl/EntityTypeImpl.java
+++ b/concept/type/impl/EntityTypeImpl.java
@@ -71,12 +71,6 @@ public class EntityTypeImpl extends ThingTypeImpl implements EntityType {
         }
 
         @Override
-        public EntityTypeImpl getSupertype() {
-            final ThingTypeImpl supertype = super.getSupertype();
-            return supertype != null ? supertype.asEntityType() : null;
-        }
-
-        @Override
         public final Stream<EntityTypeImpl> getSubtypes() {
             return super.getSubtypes().map(ThingTypeImpl::asEntityType);
         }

--- a/concept/type/impl/RelationTypeImpl.java
+++ b/concept/type/impl/RelationTypeImpl.java
@@ -107,12 +107,6 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
         }
 
         @Override
-        public RelationTypeImpl getSupertype() {
-            final ThingTypeImpl supertype = super.getSupertype();
-            return supertype != null ? supertype.asRelationType() : null;
-        }
-
-        @Override
         public final Stream<RelationTypeImpl> getSubtypes() {
             return super.getSubtypes().map(ThingTypeImpl::asRelationType);
         }

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -58,7 +58,7 @@ def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
         remote = "https://github.com/graknlabs/behaviour",
-        commit = "af688de89fb4e706604ee122944fc5dbbf4cadda", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        commit = "5b40268e7689d213e824218c6c4fdd1fc849e593", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -58,7 +58,7 @@ def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
         remote = "https://github.com/graknlabs/behaviour",
-        commit = "5b40268e7689d213e824218c6c4fdd1fc849e593", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        commit = "b4cd87a715af84bb8ebcbc29ec10348780611165", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -58,7 +58,7 @@ def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
         remote = "https://github.com/graknlabs/behaviour",
-        commit = "23c7228f7db704291dbd288d2cdbf008df38a2d3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        commit = "af688de89fb4e706604ee122944fc5dbbf4cadda", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )
 
 def graknlabs_grabl_tracing():

--- a/test/behaviour/connection/database/DatabaseSteps.java
+++ b/test/behaviour/connection/database/DatabaseSteps.java
@@ -61,11 +61,21 @@ public class DatabaseSteps {
         CompletableFuture.allOf(creations).join();
     }
 
+    @When("connection delete database: {word}")
+    public void connection_delete_database(String name) {
+        connection_delete_databases(list(name));
+    }
+
     @When("connection delete database(s):")
     public void connection_delete_databases(List<String> names) {
         for (String databaseName : names) {
             client.databases().delete(databaseName);
         }
+    }
+
+    @Then("connection delete database; throws exception: {word}")
+    public void connection_delete_database_throws_exception(String name) {
+        connection_delete_databases_throws_exception(list(name));
     }
 
     @Then("connection delete database(s); throws exception")
@@ -91,10 +101,20 @@ public class DatabaseSteps {
         CompletableFuture.allOf(deletions).join();
     }
 
+    @When("connection has database: {word}")
+    public void connection_has_database(String name) {
+        connection_has_databases(list(name));
+    }
+
     @Then("connection has database(s):")
     public void connection_has_databases(List<String> names) {
         assertEquals(set(names), set(client.databases().all()));
     }
+    @Then("connection does not have database: {word}")
+    public void connection_does_not_have_database(String name) {
+        connection_does_not_have_databases(list(name));
+    }
+
 
     @Then("connection does not have database(s):")
     public void connection_does_not_have_databases(List<String> names) {

--- a/test/behaviour/connection/session/BUILD
+++ b/test/behaviour/connection/session/BUILD
@@ -58,6 +58,8 @@ grakn_java_test(
         ":steps",
         "//test/behaviour/config:parameters",
         "//test/behaviour/connection/database:steps",
+        "//test/behaviour/connection/transaction:steps",
+        "//test/behaviour/graql:steps",
     ],
     data = [
         "@graknlabs_behaviour//connection:session.feature",

--- a/test/behaviour/connection/session/SessionSteps.java
+++ b/test/behaviour/connection/session/SessionSteps.java
@@ -119,6 +119,11 @@ public class SessionSteps {
         CompletableFuture.allOf(assertions.toArray(CompletableFuture[]::new)).join();
     }
 
+    @Then("session(s) has/have database: {word}")
+    public void sessions_have_database(String name) {
+        sessions_have_databases(list(name));
+    }
+
     @Then("session(s) has/have database(s):")
     public void sessions_have_databases(List<String> names) {
         assertEquals(names.size(), sessions.size());

--- a/test/behaviour/connection/transaction/BUILD
+++ b/test/behaviour/connection/transaction/BUILD
@@ -62,6 +62,7 @@ grakn_java_test(
         "//test/behaviour/config:parameters",
         "//test/behaviour/connection/database:steps",
         "//test/behaviour/connection/session:steps",
+        "//test/behaviour/graql:steps",
     ],
     data = [
         "@graknlabs_behaviour//connection:transaction.feature",

--- a/test/behaviour/connection/transaction/TransactionSteps.java
+++ b/test/behaviour/connection/transaction/TransactionSteps.java
@@ -40,6 +40,7 @@ import static grakn.client.test.behaviour.connection.ConnectionSteps.sessionsToT
 import static grakn.client.test.behaviour.connection.ConnectionSteps.sessionsToTransactionsParallel;
 import static grakn.client.test.behaviour.connection.ConnectionSteps.threadPool;
 import static grakn.client.test.behaviour.util.Util.assertThrows;
+import static grakn.client.test.behaviour.util.Util.assertThrowsWithMessage;
 import static grakn.common.collection.Collections.list;
 import static java.util.Objects.isNull;
 import static org.junit.Assert.assertEquals;
@@ -53,12 +54,12 @@ public class TransactionSteps {
     // sequential sessions, sequential transactions //
     // =============================================//
 
-    @When("session open(s) transaction of type: {transaction_type}")
+    @When("(for each )session(,) open(s) transaction(s) of type: {transaction_type}")
     public void session_opens_transaction_of_type(Transaction.Type type) {
         for_each_session_open_transactions_of_type(list(type));
     }
 
-    @When("for each session, open transaction(s) of type:")
+    @When("(for each )session(,) open transaction(s) of type:")
     public void for_each_session_open_transactions_of_type(List<Transaction.Type> types) {
         for (Session session : sessions) {
             List<Transaction> transactions = new ArrayList<>();
@@ -75,7 +76,7 @@ public class TransactionSteps {
         for_each_session_open_transactions_of_type_throws_exception(list(type));
     }
 
-    @Then("for each session, open transaction(s) of type; throws exception")
+    @Then("(for each )session(,) open transaction(s) of type; throws exception")
     public void for_each_session_open_transactions_of_type_throws_exception(List<Transaction.Type> types) {
         for (Session session : sessions) {
             for (Transaction.Type type : types) {
@@ -84,12 +85,12 @@ public class TransactionSteps {
         }
     }
 
-    @Then("for each session, transaction(s) is/are null: {bool}")
+    @Then("(for each )session(,) transaction(s) is/are null: {bool}")
     public void for_each_session_transactions_are_null(boolean isNull) {
         for_each_session_transactions_are(transaction -> assertEquals(isNull, isNull(transaction)));
     }
 
-    @Then("for each session, transaction(s) is/are open: {bool}")
+    @Then("(for each )session(,) transaction(s) is/are open: {bool}")
     public void for_each_session_transactions_are_open(boolean isOpen) {
         for_each_session_transactions_are(transaction -> assertEquals(isOpen, transaction.isOpen()));
     }
@@ -104,7 +105,12 @@ public class TransactionSteps {
         assertThrows(() -> sessionsToTransactions.get(sessions.get(0)).get(0).commit());
     }
 
-    @Then("for each session, transaction(s) commit(s)")
+    @Then("transaction commits; throws exception containing {string}")
+    public void transaction_commits_throws_exception(String exception) {
+        assertThrowsWithMessage(() -> sessionsToTransactions.get(sessions.get(0)).get(0).commit(), exception);
+    }
+
+    @Then("(for each )session(,) transaction(s) commit(s)")
     public void for_each_session_transactions_commit() {
         for (Session session : sessions) {
             for (Transaction transaction : sessionsToTransactions.get(session)) {
@@ -113,7 +119,7 @@ public class TransactionSteps {
         }
     }
 
-    @Then("for each session, transaction(s) commit(s); throws exception")
+    @Then("(for each )session(,) transaction(s) commit(s); throws exception")
     public void for_each_session_transactions_commits_throws_exception() {
         for (Session session : sessions) {
             for (Transaction transaction : sessionsToTransactions.get(session)) {
@@ -122,7 +128,7 @@ public class TransactionSteps {
         }
     }
 
-    @Then("for each session, transaction close(s)")
+    @Then("(for each )session(,) transaction close(s)")
     public void for_each_session_transaction_closes() {
         for (Session session : sessions) {
             for (Transaction transaction : sessionsToTransactions.get(session)) {
@@ -139,7 +145,12 @@ public class TransactionSteps {
         }
     }
 
-    @Then("for each session, transaction(s) has/have type:")
+    @Then("(for each )session(,) transaction(s) has/have type: {transaction_type}")
+    public void for_each_session_transactions_have_type(Transaction.Type type) {
+        for_each_session_transactions_have_type(list(type));
+    }
+
+    @Then("(for each )session(,) transaction(s) has/have type:")
     public void for_each_session_transactions_have_type(List<Transaction.Type> types) {
         for (Session session : sessions) {
             List<Transaction> transactions = sessionsToTransactions.get(session);

--- a/test/behaviour/connection/transaction/TransactionSteps.java
+++ b/test/behaviour/connection/transaction/TransactionSteps.java
@@ -70,6 +70,11 @@ public class TransactionSteps {
         }
     }
 
+    @When("(for each )session(,) open transaction(s) of type; throws exception: {transaction_type}")
+    public void for_each_session_open_transactions_of_type_throws_exception(Transaction.Type type) {
+        for_each_session_open_transactions_of_type_throws_exception(list(type));
+    }
+
     @Then("for each session, open transaction(s) of type; throws exception")
     public void for_each_session_open_transactions_of_type_throws_exception(List<Transaction.Type> types) {
         for (Session session : sessions) {

--- a/test/behaviour/graql/GraqlSteps.java
+++ b/test/behaviour/graql/GraqlSteps.java
@@ -102,6 +102,11 @@ public class GraqlSteps {
         assertThrows(() -> graql_insert(insertQueryStatements));
     }
 
+    @Given("graql insert; throws exception containing {string}")
+    public void graql_insert_throws_exception(String exception, String insertQueryStatements) {
+        assertThrowsWithMessage(() -> graql_insert(insertQueryStatements), exception);
+    }
+
     @Given("graql delete")
     public QueryFuture<Void> graql_delete(String deleteQueryStatements) {
         final GraqlDelete graqlQuery = Graql.parseQuery(String.join("\n", deleteQueryStatements));

--- a/test/behaviour/graql/GraqlSteps.java
+++ b/test/behaviour/graql/GraqlSteps.java
@@ -44,11 +44,8 @@ import java.util.stream.Stream;
 
 import static grakn.client.test.behaviour.connection.ConnectionSteps.tx;
 import static grakn.client.test.behaviour.util.Util.assertThrows;
+import static grakn.client.test.behaviour.util.Util.assertThrowsWithMessage;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 public class GraqlSteps {
 
@@ -82,6 +79,11 @@ public class GraqlSteps {
     public QueryFuture<Void> graql_undefine(String undefineQueryStatements) {
         final GraqlUndefine graqlQuery = Graql.parseQuery(String.join("\n", undefineQueryStatements));
         return tx().query().undefine(graqlQuery);
+    }
+
+    @Given("graql define; throws exception containing {string}")
+    public void graql_define_throws_exception(String exception, String defineQueryStatements) {
+        assertThrowsWithMessage(() -> graql_define(defineQueryStatements), exception);
     }
 
     @Given("graql undefine; throws exception")

--- a/test/behaviour/util/BUILD
+++ b/test/behaviour/util/BUILD
@@ -18,14 +18,14 @@
 #
 
 package(default_visibility = ["//test/behaviour:__subpackages__"])
+
 load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 
 java_library(
     name = "util",
     srcs = glob(["**/*.java"]),
+    visibility = ["//visibility:public"],
     deps = [
-        # Internal Package Dependencies
-        "//:client-java",
 
         # Internal Repository Dependencies
         # "@graknlabs_common//:common",
@@ -33,7 +33,6 @@ java_library(
         # External Maven Dependencies
         "@maven//:junit_junit",
     ],
-    visibility = ["//visibility:public"],
 )
 
 checkstyle_test(

--- a/test/behaviour/util/Util.java
+++ b/test/behaviour/util/Util.java
@@ -38,6 +38,7 @@ public class Util {
             function.run();
             fail();
         } catch (RuntimeException e) {
+            System.out.println(e.toString());
             assert (e.toString().contains(message));
         }
     }

--- a/test/behaviour/util/Util.java
+++ b/test/behaviour/util/Util.java
@@ -19,8 +19,6 @@
 
 package grakn.client.test.behaviour.util;
 
-import grakn.client.common.exception.GraknClientException;
-
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -32,6 +30,15 @@ public class Util {
             fail();
         } catch (RuntimeException e) {
             assertTrue(true);
+        }
+    }
+
+    public static void assertThrowsWithMessage(Runnable function, String message) {
+        try {
+            function.run();
+            fail();
+        } catch (RuntimeException e) {
+            assert (e.toString().contains(message));
         }
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

Currently the super type of entity / relation / attribute / role root type is casted to entity / relation / attribute / role type. However the actual type is thing type. Therefore we cannot cast it to the specific type but keep it as thing type.

This is consistent with server implementation.

## What are the changes implemented in this PR?

- Remove overrides of `getSuperType()` from entity / relation / attribute / role type.
