### PR TITLE
Delete setLabel from ThingType

### DIFF
--- a/concept/type/ThingType.java
+++ b/concept/type/ThingType.java
@@ -50,9 +50,6 @@ public interface ThingType extends Type {
         @CheckReturnValue
         Stream<? extends Thing> getInstances();
 
-        @Override
-        void setLabel(String label);
-
         void setAbstract();
 
         void unsetAbstract();


### PR DESCRIPTION
## What is the goal of this PR?

setLabel is already present in Type, and is therefore redundant in ThingType, so we delete setLabel from ThingType.

## What are the changes implemented in this PR?

Delete setLabel from ThingType
