### PR TITLE
Make the exception message when unable to connect to the server more descriptive

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -43,6 +43,8 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
 
         public static final Client CLUSTER_NOT_AVAILABLE =
                 new Client(8, "Attempted connecting to these servers, but none are available: '%s'.");
+        public static final Client SERVER_UNAVAILABLE =
+                new Client(9, "Server is unavailable.");
 
         private static final String codePrefix = "CLI";
         private static final String messagePrefix = "Illegal Client State";

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -43,8 +43,8 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
 
         public static final Client CLUSTER_NOT_AVAILABLE =
                 new Client(8, "Attempted connecting to these servers, but none are available: '%s'.");
-        public static final Client SERVER_UNAVAILABLE =
-                new Client(9, "Server is unavailable.");
+        public static final Client UNABLE_TO_CONNECT =
+                new Client(9, "Unable to connect to Grakn Core Server.");
 
         private static final String codePrefix = "CLI";
         private static final String messagePrefix = "Illegal Client State";

--- a/common/exception/GraknClientException.java
+++ b/common/exception/GraknClientException.java
@@ -19,30 +19,44 @@
 
 package grakn.client.common.exception;
 
+import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 
 import javax.annotation.Nullable;
 
 public class GraknClientException extends RuntimeException {
 
+    @Nullable private final ErrorMessage errorMessage;
+
     public GraknClientException(String error) {
         super(error);
+        this.errorMessage = null;
     }
 
     public GraknClientException(ErrorMessage error) {
         super(error.toString());
         assert !getMessage().contains("%s");
+        this.errorMessage = error;
     }
 
-    public GraknClientException(StatusRuntimeException statusRuntimeException) {
-        super(statusRuntimeException.getStatus().getDescription());
+    public static GraknClientException of(StatusRuntimeException statusRuntimeException) {
+        if (statusRuntimeException.getStatus().getCode() == Status.Code.UNAVAILABLE) {
+            return new GraknClientException(ErrorMessage.Client.SERVER_UNAVAILABLE);
+        }
+        return new GraknClientException(statusRuntimeException.getStatus().getDescription());
     }
 
     public GraknClientException(Exception e) {
         super(e);
+        this.errorMessage = null;
     }
 
     public String getName() {
         return this.getClass().getName();
+    }
+
+    @Nullable
+    public ErrorMessage getErrorMessage() {
+        return errorMessage;
     }
 }

--- a/common/exception/GraknClientException.java
+++ b/common/exception/GraknClientException.java
@@ -41,7 +41,7 @@ public class GraknClientException extends RuntimeException {
 
     public static GraknClientException of(StatusRuntimeException statusRuntimeException) {
         if (statusRuntimeException.getStatus().getCode() == Status.Code.UNAVAILABLE) {
-            return new GraknClientException(ErrorMessage.Client.SERVER_UNAVAILABLE);
+            return new GraknClientException(ErrorMessage.Client.UNABLE_TO_CONNECT);
         }
         return new GraknClientException(statusRuntimeException.getStatus().getDescription());
     }

--- a/rpc/RPCDatabaseManager.java
+++ b/rpc/RPCDatabaseManager.java
@@ -71,7 +71,7 @@ public class RPCDatabaseManager {
             try {
                 return req.get();
             } catch (StatusRuntimeException e) {
-                throw new GraknClientException(e);
+                throw GraknClientException.of(e);
             }
         }
     }

--- a/rpc/RPCSession.java
+++ b/rpc/RPCSession.java
@@ -72,7 +72,7 @@ public class RPCSession {
             isOpen = new AtomicBoolean(true);
             pulse.scheduleAtFixedRate(this.new PulseTask(), 0, 5000);
         } catch (StatusRuntimeException e) {
-            throw new GraknClientException(e);
+            throw GraknClientException.of(e);
         }
     }
 
@@ -105,7 +105,7 @@ public class RPCSession {
                 try {
                     blockingGrpcStub.sessionClose(SessionProto.Session.Close.Req.newBuilder().setSessionId(sessionId).build());
                 } catch (StatusRuntimeException e) {
-                    throw new GraknClientException(e);
+                    throw GraknClientException.of(e);
                 }
             }
         }

--- a/rpc/RPCTransaction.java
+++ b/rpc/RPCTransaction.java
@@ -84,7 +84,7 @@ public class RPCTransaction implements Transaction {
             final Instant endTime = Instant.now();
             networkLatencyMillis = (int) ChronoUnit.MILLIS.between(startTime, endTime) - res.getProcessingTimeMillis();
         } catch (StatusRuntimeException e) {
-            throw new GraknClientException(e);
+            throw GraknClientException.of(e);
         }
     }
 
@@ -144,7 +144,7 @@ public class RPCTransaction implements Transaction {
             try {
                 requestObserver.onCompleted();
             } catch (StatusRuntimeException e) {
-                throw new GraknClientException(e);
+                throw GraknClientException.of(e);
             }
         }
     }


### PR DESCRIPTION
## What is the goal of this PR?

Exception message when client cannot connect to server was not descriptive enough ("io exception"). It's changed to a more user-friendly message ("Unable to connect to Grakn Core Server").

## What are the changes implemented in this PR?

Handle the special case of gRPC error - `UNAVAILABLE` (code 14) by supplying helpful `ErrorMessage`. Additionally, store and expose that `ErrorMessage` in `GraknClientException` such that user can distinguish the errors.
