### PR TITLE
Close session when session pulse indicates server is unavailable

### DIFF
--- a/rpc/RPCSession.java
+++ b/rpc/RPCSession.java
@@ -118,10 +118,14 @@ public class RPCSession {
         Channel channel() { return channel; }
 
         public void pulse() {
-            final SessionProto.Session.Pulse.Res res = blockingGrpcStub.sessionPulse(
-                    SessionProto.Session.Pulse.Req.newBuilder().setSessionId(sessionId).build());
-
-            if (!res.getAlive()) {
+            boolean alive;
+            try {
+                alive = blockingGrpcStub.sessionPulse(
+                        SessionProto.Session.Pulse.Req.newBuilder().setSessionId(sessionId).build()).getAlive();
+            } catch (StatusRuntimeException exception) {
+                alive = false;
+            }
+            if (!alive) {
                 isOpen.set(false);
                 pulse.cancel();
             }


### PR DESCRIPTION
## What is the goal of this PR?

Session pulses to an unavailable server now closes the session instead of throwing an unhandled exception.

## What are the changes implemented in this PR?

Catch `StatusRuntimeException` in session pulse and treat it as session being closed
