### PR TITLE
Add ability to retrieve all rules

### DIFF
--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -50,8 +50,8 @@ def graknlabs_dependencies():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/alexjpwalker/protocol",
-        commit = "84e3496ff7cc433065df9b106eb7355ab336376c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/graknlabs/protocol",
+        commit = "3b8f0d6dc7cd176e59b13e447c64ba41a2ecff7e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -50,8 +50,8 @@ def graknlabs_dependencies():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/graknlabs/protocol",
-        commit = "a763a1ce558d47bcfb93b18165126403e1472912", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/alexjpwalker/protocol",
+        commit = "84e3496ff7cc433065df9b106eb7355ab336376c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():

--- a/logic/impl/RuleImpl.java
+++ b/logic/impl/RuleImpl.java
@@ -52,7 +52,7 @@ public class RuleImpl implements Rule {
     }
 
     public static RuleImpl of(LogicProto.Rule ruleProto) {
-        return new RuleImpl(ruleProto.getLabel(), Graql.and(Graql.parsePatterns(ruleProto.getWhen())), Graql.parseVariable(ruleProto.getThen()).asThing());
+        return new RuleImpl(ruleProto.getLabel(), Graql.parsePattern(ruleProto.getWhen()).asConjunction(), Graql.parseVariable(ruleProto.getThen()).asThing());
     }
 
     @Override


### PR DESCRIPTION
## What is the goal of this PR?

Since Rule was refactored in Grakn 2.0 to no longer be a subtype of Concept, we lost the ability to retrieve all rules using `match $x sub rule; get;`.

So, to allow the user to retrieve all rules, we now add `getRules` to the `LogicManager`, enabling use of `tx().logic().getRules()`.

## What are the changes implemented in this PR?

Add getRules to LogicManager
