### PR TITLE
Reenable remote build caching

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,29 +23,9 @@ test --incompatible_strict_action_env
 
 # what is defined in this section will be applied when bazel is invoked like this: bazel ... --config=rbe ...
 build:rbe --project_id=grakn-dev
-build:rbe --remote_instance_name=projects/grakn-dev/instances/default_instance
 build:rbe --remote_cache=cloud.buildbuddy.io
-build:rbe --remote_executor=cloud.buildbuddy.io
 build:rbe --bes_backend=cloud.buildbuddy.io
 build:rbe --bes_results_url=https://app.buildbuddy.io/invocation/
 build:rbe --tls_client_certificate=/opt/credentials/buildbuddy-cert.pem
 build:rbe --tls_client_key=/opt/credentials/buildbuddy-key.pem
-build:rbe --host_platform=@graknlabs_dependencies//image/rbe:ubuntu-1604
-build:rbe --platforms=@graknlabs_dependencies//image/rbe:ubuntu-1604
-build:rbe --extra_execution_platforms=@graknlabs_dependencies//image/rbe:ubuntu-1604
-build:rbe --host_javabase=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/java:jdk
-build:rbe --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/java:jdk
-build:rbe --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:rbe --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:rbe --extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/config:cc-toolchain
-build:rbe --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/cc:toolchain
-build:rbe --jobs=50
 build:rbe --remote_timeout=3600
-build:rbe --bes_timeout=600s
-build:rbe --spawn_strategy=remote
-build:rbe --strategy=Javac=remote
-build:rbe --strategy=Closure=remote
-build:rbe --genrule_strategy=remote
-build:rbe --define=EXECUTOR=remote
-build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-build:rbe --experimental_strict_action_env=true

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -66,7 +66,6 @@ build:
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
         bazel test --config=rbe //test/integration/... --test_output=streamed
-      # TODO: use --config=rbe once Grakn Core runs in RBE
     test-behaviour:
       image: graknlabs-ubuntu-20.04
       command: |
@@ -79,7 +78,6 @@ build:
         bazel test --config=rbe //test/behaviour/graql/language/get/... --test_output=streamed
         bazel test --config=rbe //test/behaviour/graql/language/define/... --test_output=streamed
       # TODO: delete --jobs=1 if we fix the issue with excess memory usage
-      # TODO: use --config=rbe once Grakn Core runs in RBE
       # TODO: add more Graql Language tests as they are fixed
     deploy-maven-snapshot:
       image: graknlabs-ubuntu-20.04

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -50,22 +50,22 @@ build:
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        bazel build //...
-        bazel run @graknlabs_dependencies//tool/checkstyle:test-coverage
-        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
+        bazel build --config=rbe //...
+        bazel run --config=rbe @graknlabs_dependencies//tool/checkstyle:test-coverage
+        bazel test --config=rbe $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
     build-dependency:
       image: graknlabs-ubuntu-20.04
       command: |
         dependencies/maven/update.sh
         git diff --exit-code dependencies/maven/artifacts.snapshot
-        bazel run @graknlabs_dependencies//tool/unuseddeps:unused-deps -- list
+        bazel run --config=rbe @graknlabs_dependencies//tool/unuseddeps:unused-deps -- list
     test-integration:
       image: graknlabs-ubuntu-20.04
       command: |
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        bazel test //test/integration/... --test_output=streamed
+        bazel test --config=rbe //test/integration/... --test_output=streamed
       # TODO: use --config=rbe once Grakn Core runs in RBE
     test-behaviour:
       image: graknlabs-ubuntu-20.04
@@ -73,11 +73,11 @@ build:
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        bazel test //test/behaviour/connection/... --test_output=streamed --jobs=1
-        bazel test //test/behaviour/concept/... --test_output=streamed
-        bazel test //test/behaviour/graql/language/match/... --test_output=streamed
-        bazel test //test/behaviour/graql/language/get/... --test_output=streamed
-        bazel test //test/behaviour/graql/language/define/... --test_output=streamed
+        bazel test --config=rbe //test/behaviour/connection/... --test_output=streamed --jobs=1
+        bazel test --config=rbe //test/behaviour/concept/... --test_output=streamed
+        bazel test --config=rbe //test/behaviour/graql/language/match/... --test_output=streamed
+        bazel test --config=rbe //test/behaviour/graql/language/get/... --test_output=streamed
+        bazel test --config=rbe //test/behaviour/graql/language/define/... --test_output=streamed
       # TODO: delete --jobs=1 if we fix the issue with excess memory usage
       # TODO: use --config=rbe once Grakn Core runs in RBE
       # TODO: add more Graql Language tests as they are fixed
@@ -90,7 +90,7 @@ build:
       command: |
         export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
-        bazel run --define version=$(git rev-parse HEAD) //:deploy-maven -- snapshot
+        bazel run --config=rbe --define version=$(git rev-parse HEAD) //:deploy-maven -- snapshot
     test-deployment-maven:
       image: graknlabs-ubuntu-20.04
       dependencies: [deploy-maven-snapshot]
@@ -123,11 +123,11 @@ release:
         export RELEASE_NOTES_TOKEN=$REPO_GITHUB_TOKEN
         bazel run @graknlabs_dependencies//tool/release:create-notes -- client-java $(cat VERSION) ./RELEASE_TEMPLATE.md
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
-        bazel run --define version=$(cat VERSION) //:deploy-github -- $GRABL_COMMIT
+        bazel run --config=rbe --define version=$(cat VERSION) //:deploy-github -- $GRABL_COMMIT
     deploy-maven-release:
       image: graknlabs-ubuntu-20.04
       dependencies: [deploy-github]
       command: |
         export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
-        bazel run --define version=$(cat VERSION) //:deploy-maven -- release
+        bazel run --config=rbe --define version=$(cat VERSION) //:deploy-maven -- release


### PR DESCRIPTION
## What is the goal of this PR?

Speed up builds by utilizing remote caching provided by BuildBuddy.

## What are the changes implemented in this PR?

Reenable build caching (without remote execution) on all CI jobs