### PR TITLE
Improve type safety of Grakn.Client.session

### DIFF
--- a/Grakn.java
+++ b/Grakn.java
@@ -25,24 +25,12 @@ import grakn.client.query.QueryManager;
 
 import java.util.List;
 
-interface ClientBase<TOptions extends GraknOptions> extends AutoCloseable {
-
-    Grakn.Session session(String database, Grakn.Session.Type type);
-
-    Grakn.Session session(String database, Grakn.Session.Type type, TOptions options);
-
-    Grakn.DatabaseManager databases();
-
-    boolean isOpen();
-
-    void close();
-}
 
 public interface Grakn {
 
-    interface Client extends ClientBase<GraknOptions> {
+    interface Client extends GraknBase.Client<GraknOptions> {
 
-        interface Cluster extends ClientBase<GraknOptions.Cluster> {
+        interface Cluster extends GraknBase.Client<GraknOptions.Cluster> {
         }
     }
 

--- a/Grakn.java
+++ b/Grakn.java
@@ -25,19 +25,25 @@ import grakn.client.query.QueryManager;
 
 import java.util.List;
 
+interface ClientBase<TOptions extends GraknOptions> extends AutoCloseable {
+
+    Grakn.Session session(String database, Grakn.Session.Type type);
+
+    Grakn.Session session(String database, Grakn.Session.Type type, TOptions options);
+
+    Grakn.DatabaseManager databases();
+
+    boolean isOpen();
+
+    void close();
+}
+
 public interface Grakn {
 
-    interface Client extends AutoCloseable {
+    interface Client extends ClientBase<GraknOptions> {
 
-        Session session(String database, Session.Type type);
-
-        Session session(String database, Session.Type type, GraknOptions options);
-
-        DatabaseManager databases();
-
-        boolean isOpen();
-
-        void close();
+        interface Cluster extends ClientBase<GraknOptions.Cluster> {
+        }
     }
 
     interface DatabaseManager {

--- a/GraknBase.java
+++ b/GraknBase.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package grakn.client;
 
 interface GraknBase {

--- a/GraknBase.java
+++ b/GraknBase.java
@@ -1,0 +1,17 @@
+package grakn.client;
+
+interface GraknBase {
+
+    interface Client<TOptions extends GraknOptions> extends AutoCloseable {
+
+        Grakn.Session session(String database, Grakn.Session.Type type);
+
+        Grakn.Session session(String database, Grakn.Session.Type type, TOptions options);
+
+        Grakn.DatabaseManager databases();
+
+        boolean isOpen();
+
+        void close();
+    }
+}

--- a/GraknClient.java
+++ b/GraknClient.java
@@ -39,7 +39,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static grakn.client.common.exception.ErrorMessage.Client.CLUSTER_UNABLE_TO_CONNECT;
-import static grakn.client.common.exception.ErrorMessage.Client.ILLEGAL_ARGUMENT;
 import static grakn.common.collection.Collections.pair;
 
 public class GraknClient {
@@ -104,7 +103,7 @@ public class GraknClient {
         }
     }
 
-    public static class Cluster implements Grakn.Client {
+    public static class Cluster implements Grakn.Client.Cluster {
         private static final Logger LOG = LoggerFactory.getLogger(Cluster.class);
         private final Map<Address.Cluster.Server, Core> coreClients;
         private final Map<Address.Cluster.Server, GraknClusterGrpc.GraknClusterBlockingStub> graknClusterRPCs;
@@ -132,9 +131,8 @@ public class GraknClient {
         }
 
         @Override
-        public RPCSession.Cluster session(String database, Grakn.Session.Type type, GraknOptions options) {
-            if (!options.isCluster()) throw new GraknClientException(ILLEGAL_ARGUMENT, options);
-            return new RPCSession.Cluster(this, database, type, options.asCluster());
+        public RPCSession.Cluster session(String database, Grakn.Session.Type type, GraknOptions.Cluster options) {
+            return new RPCSession.Cluster(this, database, type, options);
         }
 
         @Override


### PR DESCRIPTION
## What is the goal of this PR?

The signature of `Grakn.Client.session` was not ideal - it took in a `GraknOptions` regardless of whether we had a Core client or a Cluster client, meaning we needed a runtime type check. We introduced a package-private interface `GraknBase.Client<TOptions>`, allowing the Core and Cluster clients to implement different interfaces while reusing as much code as possible.

## What are the changes implemented in this PR?

Add `GraknBase.Client<TOptions>`

