### PR TITLE
Rename RPCClient to RPCGraknClient for consistency

### DIFF
--- a/GraknClient.java
+++ b/GraknClient.java
@@ -22,8 +22,8 @@ package grakn.client;
 import grakn.client.concept.ConceptManager;
 import grakn.client.logic.LogicManager;
 import grakn.client.query.QueryManager;
-import grakn.client.rpc.RPCClient;
-import grakn.client.rpc.cluster.RPCClientCluster;
+import grakn.client.rpc.RPCGraknClient;
+import grakn.client.rpc.cluster.RPCGraknClientCluster;
 
 import java.util.List;
 
@@ -35,7 +35,7 @@ public interface GraknClient extends AutoCloseable {
     }
 
     static GraknClient core(String address) {
-        return new RPCClient(address);
+        return new RPCGraknClient(address);
     }
 
     static GraknClient cluster() {
@@ -43,7 +43,7 @@ public interface GraknClient extends AutoCloseable {
     }
 
     static GraknClient cluster(String address) {
-        return new RPCClientCluster(address);
+        return new RPCGraknClientCluster(address);
     }
 
     GraknClient.Session session(String database, GraknClient.Session.Type type);

--- a/rpc/RPCGraknClient.java
+++ b/rpc/RPCGraknClient.java
@@ -27,12 +27,12 @@ import io.grpc.ManagedChannelBuilder;
 
 import java.util.concurrent.TimeUnit;
 
-public class RPCClient implements GraknClient {
+public class RPCGraknClient implements GraknClient {
 
     private final ManagedChannel channel;
     private final RPCDatabaseManager databases;
 
-    public RPCClient(String address) {
+    public RPCGraknClient(String address) {
         channel = ManagedChannelBuilder.forTarget(address).usePlaintext().build();
         databases = new RPCDatabaseManager(channel);
     }

--- a/rpc/RPCSession.java
+++ b/rpc/RPCSession.java
@@ -43,7 +43,7 @@ public class RPCSession implements GraknClient.Session {
     private final Timer pulse;
     private final GraknGrpc.GraknBlockingStub blockingGrpcStub;
 
-    public RPCSession(RPCClient client, String database, Type type, GraknOptions options) {
+    public RPCSession(RPCGraknClient client, String database, Type type, GraknOptions options) {
         try {
             this.channel = client.channel();
             this.database = database;

--- a/rpc/cluster/RPCSessionCluster.java
+++ b/rpc/cluster/RPCSessionCluster.java
@@ -22,7 +22,7 @@ package grakn.client.rpc.cluster;
 import grakn.client.GraknClient;
 import grakn.client.GraknOptions;
 import grakn.client.common.exception.GraknClientException;
-import grakn.client.rpc.RPCClient;
+import grakn.client.rpc.RPCGraknClient;
 import grakn.client.rpc.RPCSession;
 import grakn.protocol.cluster.DatabaseProto;
 import io.grpc.StatusRuntimeException;
@@ -47,7 +47,7 @@ public class RPCSessionCluster implements GraknClient.Session {
     private static final Logger LOG = LoggerFactory.getLogger(GraknClient.Session.class);
     public static final int MAX_RETRY_PER_REPLICA = 10;
     public static final int WAIT_FOR_PRIMARY_REPLICA_SELECTION_MS = 2000;
-    private final RPCClientCluster clusterClient;
+    private final RPCGraknClientCluster clusterClient;
     private Database database;
     private final String dbName;
     private final GraknClient.Session.Type type;
@@ -55,7 +55,7 @@ public class RPCSessionCluster implements GraknClient.Session {
     private final ConcurrentMap<Replica.Id, RPCSession> coreSessions;
     private boolean isOpen;
 
-    public RPCSessionCluster(RPCClientCluster clusterClient, String database, GraknClient.Session.Type type, GraknOptions.Cluster options) {
+    public RPCSessionCluster(RPCGraknClientCluster clusterClient, String database, GraknClient.Session.Type type, GraknOptions.Cluster options) {
         this.clusterClient = clusterClient;
         this.dbName = database;
         this.type = type;
@@ -110,7 +110,7 @@ public class RPCSessionCluster implements GraknClient.Session {
                             database.primaryReplica().id(),
                             key -> {
                                 LOG.debug("Opening a session to primary replica '{}'", key);
-                                RPCClient primaryReplicaClient = clusterClient.coreClient(key.address());
+                                RPCGraknClient primaryReplicaClient = clusterClient.coreClient(key.address());
                                 return primaryReplicaClient.session(key.database(), this.type, this.options);
                             }
                     );


### PR DESCRIPTION
## What is the goal of this PR?

In two previous refactors, we introduced `RPCClient`, and renamed `Grakn.Client` to `GraknClient`. Now, to maintain consistency, we rename `RPCClient` to `RPCGraknClient`.

## What are the changes implemented in this PR?

Rename RPCClient to RPCGraknClient
