### PR TITLE
Add support for setting prefetch, session timeout, and schema lock timeout in GraknOptions

### DIFF
--- a/GraknOptions.java
+++ b/GraknOptions.java
@@ -30,6 +30,20 @@ public class GraknOptions {
     private Boolean infer = null;
     private Boolean explain = null;
     private Integer batchSize = null;
+    private Boolean prefetch = null;
+    private Integer sessionIdleTimeout = null;
+    private Integer schemaLockAcquireTimeout = null;
+    public static GraknOptions core() {
+        return new GraknOptions();
+    }
+
+    public static GraknOptions.Cluster cluster() {
+        return new Cluster();
+    }
+
+    public boolean isCluster() {
+        return false;
+    }
 
     GraknOptions() {}
 
@@ -63,16 +77,37 @@ public class GraknOptions {
         return this;
     }
 
-    public static GraknOptions core() {
-        return new GraknOptions();
+    public Optional<Boolean> prefetch() {
+        return Optional.ofNullable(prefetch);
     }
 
-    public static GraknOptions.Cluster cluster() {
-        return new Cluster();
+    public GraknOptions prefetch(boolean prefetch) {
+        this.prefetch = prefetch;
+        return this;
     }
 
-    public boolean isCluster() {
-        return false;
+    public Optional<Integer> sessionIdleTimeout() {
+        return Optional.ofNullable(sessionIdleTimeout);
+    }
+
+    public GraknOptions sessionIdleTimeout(int sessionIdleTimeout) {
+        if (sessionIdleTimeout < 1) {
+            throw new GraknClientException(NEGATIVE_BATCH_SIZE.message(sessionIdleTimeout));
+        }
+        this.sessionIdleTimeout = sessionIdleTimeout;
+        return this;
+    }
+
+    public Optional<Integer> schemaLockAcquireTimeout() {
+        return Optional.ofNullable(schemaLockAcquireTimeout);
+    }
+
+    public GraknOptions schemaLockAcquireTimeout(int schemaLockAcquireTimeout) {
+        if (schemaLockAcquireTimeout < 1) {
+            throw new GraknClientException(NEGATIVE_BATCH_SIZE.message(schemaLockAcquireTimeout));
+        }
+        this.schemaLockAcquireTimeout = schemaLockAcquireTimeout;
+        return this;
     }
 
     public Cluster asCluster() {

--- a/GraknOptions.java
+++ b/GraknOptions.java
@@ -23,7 +23,7 @@ import grakn.client.common.exception.GraknClientException;
 
 import java.util.Optional;
 
-import static grakn.client.common.exception.ErrorMessage.Client.NEGATIVE_BATCH_SIZE;
+import static grakn.client.common.exception.ErrorMessage.Client.NEGATIVE_VALUE;
 import static grakn.client.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
 
 public class GraknOptions {
@@ -33,7 +33,7 @@ public class GraknOptions {
     private Boolean prefetch = null;
     private Integer sessionIdleTimeout = null;
     private Integer schemaLockAcquireTimeout = null;
-    
+
     public static GraknOptions core() {
         return new GraknOptions();
     }
@@ -72,7 +72,7 @@ public class GraknOptions {
 
     public GraknOptions batchSize(int batchSize) {
         if (batchSize < 1) {
-            throw new GraknClientException(NEGATIVE_BATCH_SIZE.message(batchSize));
+            throw new GraknClientException(NEGATIVE_VALUE.message(batchSize));
         }
         this.batchSize = batchSize;
         return this;
@@ -93,7 +93,7 @@ public class GraknOptions {
 
     public GraknOptions sessionIdleTimeout(int sessionIdleTimeout) {
         if (sessionIdleTimeout < 1) {
-            throw new GraknClientException(NEGATIVE_BATCH_SIZE.message(sessionIdleTimeout));
+            throw new GraknClientException(NEGATIVE_VALUE.message(sessionIdleTimeout));
         }
         this.sessionIdleTimeout = sessionIdleTimeout;
         return this;
@@ -105,7 +105,7 @@ public class GraknOptions {
 
     public GraknOptions schemaLockAcquireTimeout(int schemaLockAcquireTimeout) {
         if (schemaLockAcquireTimeout < 1) {
-            throw new GraknClientException(NEGATIVE_BATCH_SIZE.message(schemaLockAcquireTimeout));
+            throw new GraknClientException(NEGATIVE_VALUE.message(schemaLockAcquireTimeout));
         }
         this.schemaLockAcquireTimeout = schemaLockAcquireTimeout;
         return this;

--- a/GraknOptions.java
+++ b/GraknOptions.java
@@ -33,6 +33,7 @@ public class GraknOptions {
     private Boolean prefetch = null;
     private Integer sessionIdleTimeout = null;
     private Integer schemaLockAcquireTimeout = null;
+    
     public static GraknOptions core() {
         return new GraknOptions();
     }

--- a/GraknOptions.java
+++ b/GraknOptions.java
@@ -23,7 +23,7 @@ import grakn.client.common.exception.GraknClientException;
 
 import java.util.Optional;
 
-import static grakn.client.common.exception.ErrorMessage.Client.NEGATIVE_VALUE;
+import static grakn.client.common.exception.ErrorMessage.Client.NEGATIVE_VALUE_NOT_ALLOWED;
 import static grakn.client.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
 
 public class GraknOptions {
@@ -72,7 +72,7 @@ public class GraknOptions {
 
     public GraknOptions batchSize(int batchSize) {
         if (batchSize < 1) {
-            throw new GraknClientException(NEGATIVE_VALUE.message(batchSize));
+            throw new GraknClientException(NEGATIVE_VALUE_NOT_ALLOWED.message(batchSize));
         }
         this.batchSize = batchSize;
         return this;
@@ -93,7 +93,7 @@ public class GraknOptions {
 
     public GraknOptions sessionIdleTimeout(int sessionIdleTimeout) {
         if (sessionIdleTimeout < 1) {
-            throw new GraknClientException(NEGATIVE_VALUE.message(sessionIdleTimeout));
+            throw new GraknClientException(NEGATIVE_VALUE_NOT_ALLOWED.message(sessionIdleTimeout));
         }
         this.sessionIdleTimeout = sessionIdleTimeout;
         return this;
@@ -105,7 +105,7 @@ public class GraknOptions {
 
     public GraknOptions schemaLockAcquireTimeout(int schemaLockAcquireTimeout) {
         if (schemaLockAcquireTimeout < 1) {
-            throw new GraknClientException(NEGATIVE_VALUE.message(schemaLockAcquireTimeout));
+            throw new GraknClientException(NEGATIVE_VALUE_NOT_ALLOWED.message(schemaLockAcquireTimeout));
         }
         this.schemaLockAcquireTimeout = schemaLockAcquireTimeout;
         return this;

--- a/GraknProtoBuilder.java
+++ b/GraknProtoBuilder.java
@@ -28,7 +28,9 @@ public abstract class GraknProtoBuilder {
         options.infer().ifPresent(builder::setInfer);
         options.explain().ifPresent(builder::setExplain);
         options.batchSize().ifPresent(builder::setBatchSize);
-
+        options.prefetch().ifPresent(builder::setPrefetch);
+        options.sessionIdleTimeout().ifPresent(builder::setSessionIdleTimeoutMillis);
+        options.schemaLockAcquireTimeout().ifPresent(builder::setSchemaLockAcquireTimeoutMillis);
         if (options.isCluster()) {
             options.asCluster().allowSecondaryReplica().ifPresent(builder::setAllowSecondaryReplica);
         }

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -28,7 +28,7 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
     public static class Client extends ErrorMessage {
         public static final Client TRANSACTION_CLOSED =
                 new Client(1, "The transaction has been closed and no further operation is allowed.");
-        public static final Client NEGATIVE_VALUE =
+        public static final Client NEGATIVE_VALUE_NOT_ALLOWED =
                 new Client(2, "Value cannot be less than 1, was: '%d'.");
         public static final Client MISSING_DB_NAME =
                 new Client(3, "Database name cannot be null.");

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -28,8 +28,8 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
     public static class Client extends ErrorMessage {
         public static final Client TRANSACTION_CLOSED =
                 new Client(1, "The transaction has been closed and no further operation is allowed.");
-        public static final Client NEGATIVE_BATCH_SIZE =
-                new Client(2, "Batch size cannot be less than 1, was: '%d'.");
+        public static final Client NEGATIVE_VALUE =
+                new Client(2, "Value cannot be less than 1, was: '%d'.");
         public static final Client MISSING_DB_NAME =
                 new Client(3, "Database name cannot be null.");
         public static final Client MISSING_RESPONSE =


### PR DESCRIPTION
## What is the goal of this PR?

We have added support for setting prefetch, session timeout, and schema lock timeout in GraknOptions.

## What are the changes implemented in this PR?

- Update `GraknOptions` with the new settings