### PR TITLE
Split the BDD CI job into smaller, more manageable jobs

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -102,11 +102,14 @@ build:
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        # bazel test //test/behaviour/graql/language/define/... --test_output=streamed
+
         # TODO: re-enable 'define' after fixing: https://github.com/graknlabs/grakn/issues/6112
         # TODO: delete --jobs=1 if we fix the issue with excess memory usage
         # TODO: add more Graql Language tests as they are fixed
-        bazel test //test/behaviour/graql/language/undefine/... --test_output=streamed
+        # bazel test //test/behaviour/graql/language/define/... --test_output=streamed
+
+        # TODO: enable undefine
+        # bazel test //test/behaviour/graql/language/undefine/... --test_output=streamed
 
     deploy-maven-snapshot:
       image: graknlabs-ubuntu-20.04

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -88,28 +88,30 @@ build:
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
         bazel test //test/behaviour/graql/language/match/... --test_output=streamed
         bazel test //test/behaviour/graql/language/get/... --test_output=streamed
-    test-behaviour-writable:
-      image: graknlabs-ubuntu-20.04
-      command: |
-        export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
-        bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        bazel test //test/behaviour/graql/language/insert/... --test_output=streamed
-        bazel test //test/behaviour/graql/language/delete/... --test_output=streamed
-    test-behaviour-definable:
-      image: graknlabs-ubuntu-20.04
-      command: |
-        export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
-        bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
 
-        # TODO: re-enable 'define' after fixing: https://github.com/graknlabs/grakn/issues/6112
-        # TODO: delete --jobs=1 if we fix the issue with excess memory usage
-        # TODO: add more Graql Language tests as they are fixed
-        # bazel test //test/behaviour/graql/language/define/... --test_output=streamed
+# TODO: add more Graql Language tests as they are fixed: insert, delete
+#    test-behaviour-writable:
+#      image: graknlabs-ubuntu-20.04
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
+#        bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
+#        bazel test //test/behaviour/graql/language/insert/... --test_output=streamed
+#        bazel test //test/behaviour/graql/language/delete/... --test_output=streamed
 
-        # TODO: enable undefine
-        # bazel test //test/behaviour/graql/language/undefine/... --test_output=streamed
+
+# TODO: re-enable 'define' after fixing: https://github.com/graknlabs/grakn/issues/6112
+# TODO: delete --jobs=1 if we fix the issue with excess memory usage
+# TODO: add more Graql Language tests as they are fixed: undefine
+#    test-behaviour-definable:
+#      image: graknlabs-ubuntu-20.04
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
+#        bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
+#
+#        # bazel test //test/behaviour/graql/language/define/... --test_output=streamed --jobs=1
+#        # bazel test //test/behaviour/graql/language/undefine/... --test_output=streamed
 
     deploy-maven-snapshot:
       image: graknlabs-ubuntu-20.04

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -66,23 +66,51 @@ build:
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
         bazel test //test/integration/... --test_output=streamed
-    test-behaviour:
+    test-behaviour-connection:
       image: graknlabs-ubuntu-20.04
       command: |
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        bazel test //test/behaviour/connection/... --test_output=streamed --jobs=1
+        bazel test //test/behaviour/connection/... --test_output=streamed
+    test-behaviour-concept:
+      image: graknlabs-ubuntu-20.04
+      command: |
+        export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
+        bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
         bazel test //test/behaviour/concept/... --test_output=streamed
+    test-behaviour-match:
+      image: graknlabs-ubuntu-20.04
+      command: |
+        export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
+        bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
         bazel test //test/behaviour/graql/language/match/... --test_output=streamed
         bazel test //test/behaviour/graql/language/get/... --test_output=streamed
-      # bazel test //test/behaviour/graql/language/define/... --test_output=streamed
-      # TODO: re-enable 'define' after fixing: https://github.com/graknlabs/grakn/issues/6112
-      # TODO: delete --jobs=1 if we fix the issue with excess memory usage
-      # TODO: add more Graql Language tests as they are fixed
+    test-behaviour-writable:
+      image: graknlabs-ubuntu-20.04
+      command: |
+        export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
+        bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
+        bazel test //test/behaviour/graql/language/insert/... --test_output=streamed
+        bazel test //test/behaviour/graql/language/delete/... --test_output=streamed
+    test-behaviour-definable:
+      image: graknlabs-ubuntu-20.04
+      command: |
+        export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
+        bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
+        # bazel test //test/behaviour/graql/language/define/... --test_output=streamed
+        # TODO: re-enable 'define' after fixing: https://github.com/graknlabs/grakn/issues/6112
+        # TODO: delete --jobs=1 if we fix the issue with excess memory usage
+        # TODO: add more Graql Language tests as they are fixed
+        bazel test //test/behaviour/graql/language/undefine/... --test_output=streamed
+
     deploy-maven-snapshot:
       image: graknlabs-ubuntu-20.04
-      dependencies: [build, build-dependency, test-behaviour]
+      dependencies: [build, build-dependency, test-behaviour-connection, test-behaviour-concept, test-behaviour-match, test-behaviour-writable, test-behaviour-definable]
       filter:
         owner: graknlabs
         branch: master


### PR DESCRIPTION
## What is the goal of this PR?

We've split the BDD job which has grown quite big into smaller ones in order to make them more manageable. 

## What are the changes implemented in this PR?

- Split `test-behaviour` into `test-behaviour-connection`, `test-behaviour-concept`, `test-behaviour-match`, `test-behaviour-writable`, `test-behaviour-definable` consistent with how we split it in Grakn Core