### PR TITLE
Enable define tests and bump grakn version

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -108,8 +108,11 @@ build:
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        bazel test //test/behaviour/graql/language/define/... --test_output=streamed --jobs=1
-        bazel test //test/behaviour/graql/language/undefine/... --test_output=streamed
+# TODO: turn on cluster tests once cluster tests pass for define
+        bazel test //test/behaviour/graql/language/define:checkstyle --test_output=streamed
+        bazel test //test/behaviour/graql/language/define:test-core --test_output=streamed --jobs=1
+        bazel test //test/behaviour/graql/language/undefine:checkstyle --test_output=streamed
+        bazel test //test/behaviour/graql/language/undefine:test-core --test_output=streamed --jobs=1
 
     deploy-maven-snapshot:
       image: graknlabs-ubuntu-20.04

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -102,13 +102,13 @@ build:
 
 # TODO: delete --jobs=1 if we fix the issue with excess memory usage
 # TODO: add more Graql Language tests as they are fixed: undefine
+# TODO: turn on cluster tests once cluster tests pass for define
     test-behaviour-definable:
       image: graknlabs-ubuntu-20.04
       command: |
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-# TODO: turn on cluster tests once cluster tests pass for define
         bazel test //test/behaviour/graql/language/define:checkstyle --test_output=streamed
         bazel test //test/behaviour/graql/language/define:test-core --test_output=streamed --jobs=1
         bazel test //test/behaviour/graql/language/undefine:checkstyle --test_output=streamed

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -100,18 +100,16 @@ build:
 #        bazel test //test/behaviour/graql/language/delete/... --test_output=streamed
 
 
-# TODO: re-enable 'define' after fixing: https://github.com/graknlabs/grakn/issues/6112
 # TODO: delete --jobs=1 if we fix the issue with excess memory usage
 # TODO: add more Graql Language tests as they are fixed: undefine
-#    test-behaviour-definable:
-#      image: graknlabs-ubuntu-20.04
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
-#        bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-#
-#        # bazel test //test/behaviour/graql/language/define/... --test_output=streamed --jobs=1
-#        # bazel test //test/behaviour/graql/language/undefine/... --test_output=streamed
+    test-behaviour-definable:
+      image: graknlabs-ubuntu-20.04
+      command: |
+        export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
+        bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
+        bazel test //test/behaviour/graql/language/define/... --test_output=streamed --jobs=1
+        bazel test //test/behaviour/graql/language/undefine/... --test_output=streamed
 
     deploy-maven-snapshot:
       image: graknlabs-ubuntu-20.04

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,7 +27,7 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "ae4939ce4a1d450fdf0b7c057ab9e2769f1717bf",
+        commit = "a8f34dfe569f518d8f80ce996c051b272094dcbe",
     )
 
 def graknlabs_grakn_cluster_artifacts():

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,7 +27,7 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "c2efc0a71a215b59650a3ea0e8b6f4c2c83737e3",
+        commit = "ae4939ce4a1d450fdf0b7c057ab9e2769f1717bf",
     )
 
 def graknlabs_grakn_cluster_artifacts():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -30,7 +30,7 @@ def graknlabs_common():
     git_repository(
         name = "graknlabs_common",
         remote = "https://github.com/graknlabs/common",
-        commit = "04e609d57781bca5c32483f0da6602f7a6d02515" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
+        commit = "15a2a883a9375e7dddca00e4c6bd55efdd357469" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 
 def graknlabs_bazel_distribution():

--- a/test/behaviour/graql/GraqlSteps.java
+++ b/test/behaviour/graql/GraqlSteps.java
@@ -413,6 +413,16 @@ public class GraqlSteps {
         this.rules = rules;
     }
 
+    @Then("rules contain: {type_label}")
+    public void rules_contain(String ruleLabel) {
+        assert(tx().logic().getRules().anyMatch(rule -> rule.getLabel().equals(ruleLabel)));
+    }
+
+    @Then("rules do not contain: {type_label}")
+    public void rules_do_not_contain(String ruleLabel) {
+        assert(tx().logic().getRules().noneMatch(rule -> rule.getLabel().equals(ruleLabel)));
+    }
+
     @Then("answers contain explanation tree")
     public void answers_contain_explanation_tree(Map<Integer, Map<String, String>> explanationTree) {
         // TODO

--- a/test/behaviour/graql/GraqlSteps.java
+++ b/test/behaviour/graql/GraqlSteps.java
@@ -112,7 +112,7 @@ public class GraqlSteps {
 
     @Given("graql insert; throws exception")
     public void graql_insert_throws(String insertQueryStatements) {
-        assertThrows(() -> graql_insert(insertQueryStatements));
+        assertThrows(() -> graql_insert(insertQueryStatements).iterator().next());
     }
 
     @Given("graql insert; throws exception containing {string}")

--- a/test/behaviour/graql/language/undefine/BUILD
+++ b/test/behaviour/graql/language/undefine/BUILD
@@ -49,6 +49,9 @@ grakn_behaviour_java_test(
         # External dependencies from Maven
         "@maven//:io_cucumber_cucumber_junit",
     ],
+    runtime_deps = [
+        "//test/behaviour/config:parameters",
+    ],
     size = "medium",
     visibility = ["//visibility:public"]
 )


### PR DESCRIPTION
## What is the goal of this PR?

Enable define tests by bumping the grakn artifact version which fixed the issue that causes define tests to fail.

## What are the changes implemented in this PR?

- Bump grakn version
- Enable define tests
