### PR TITLE
Refine the logic for performing primary replica failover

### DIFF
--- a/rpc/cluster/RPCGraknClientCluster.java
+++ b/rpc/cluster/RPCGraknClientCluster.java
@@ -115,6 +115,6 @@ public class RPCGraknClientCluster implements GraknClient {
     }
 
     private GraknClientException clusterNotAvailableException(String... addresses) {
-        return new GraknClientException(CLUSTER_UNABLE_TO_CONNECT, String.join(",", addresses)); // remove ambiguity by casting to Object
+        return new GraknClientException(CLUSTER_UNABLE_TO_CONNECT, String.join(",", addresses));
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

We have refined the logic for performing primary replica failover.


## What are the changes implemented in this PR?

1. Refactor and improve the logic for opening transaction:
  - the logic for opening transaction to selected replica into the `transactionReplica` method.
  - `transactionReplicaPrimary` and `transactionReplicaSecondary` now only contains the logic for performing primary and secondary replica selection