### PR TITLE
Make DatabaseManager more fault tolerant in Cluster

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -20,12 +20,3 @@
 build --incompatible_strict_action_env --javacopt='--release 8'
 run --incompatible_strict_action_env
 test --incompatible_strict_action_env --test_env=PATH
-
-# what is defined in this section will be applied when bazel is invoked like this: bazel ... --config=rbe ...
-build:rbe --project_id=grakn-dev
-build:rbe --remote_cache=cloud.buildbuddy.io
-build:rbe --bes_backend=cloud.buildbuddy.io
-build:rbe --bes_results_url=https://app.buildbuddy.io/invocation/
-build:rbe --tls_client_certificate=/opt/credentials/buildbuddy-cert.pem
-build:rbe --tls_client_key=/opt/credentials/buildbuddy-key.pem
-build:rbe --remote_timeout=3600

--- a/.bazelrc
+++ b/.bazelrc
@@ -19,7 +19,7 @@
 
 build --incompatible_strict_action_env --javacopt='--release 8'
 run --incompatible_strict_action_env
-test --incompatible_strict_action_env
+test --incompatible_strict_action_env --test_env=PATH
 
 # what is defined in this section will be applied when bazel is invoked like this: bazel ... --config=rbe ...
 build:rbe --project_id=grakn-dev

--- a/GraknClient.java
+++ b/GraknClient.java
@@ -38,12 +38,8 @@ public interface GraknClient extends AutoCloseable {
         return new RPCClient(address);
     }
 
-    static GraknClient cluster() {
-        return cluster(DEFAULT_ADDRESS);
-    }
-
-    static GraknClient cluster(String address) {
-        return new RPCGraknClientCluster(address);
+    static GraknClient cluster(String... addresses) {
+        return new RPCGraknClientCluster(addresses);
     }
 
     GraknClient.Session session(String database, GraknClient.Session.Type type);

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -44,6 +44,8 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
                 new Client(9, "Unable to connect to Grakn Cluster. Attempted connecting to the cluster members, but none are available: '%s'.");
         public static final Client CLUSTER_REPLICA_NOT_PRIMARY =
                 new Client(10, "The replica is not the primary replica");
+        public static final Client CLUSTER_ALL_NODES_FAILED =
+                new Client(11, "Attempted connecting to all cluster members, but the following errors occurred: %s");
 
         private static final String codePrefix = "CLI";
         private static final String messagePrefix = "Illegal Client State";

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -37,7 +37,7 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
         public static final Client UNKNOWN_REQUEST_ID =
                 new Client(5, "Received a response with unknown request id '%s'.")  ;
         public static final Client ILLEGAL_ARGUMENT = new Client(6, "Illegal argument passed into the method: '%s'.");
-        public static final Client UNABLE_TO_CONNECT = new Client(7, "Unable to connect to Grakn Core Server.");
+        public static final Client UNABLE_TO_CONNECT = new Client(7, "Unable to connect to Grakn server.");
         public static final Client CLUSTER_NO_PRIMARY_REPLICA_YET =
                 new Client(8, "No replica has been marked as the primary replica for latest known term '%d'.");
         public static final Client CLUSTER_UNABLE_TO_CONNECT =

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -57,8 +57,8 @@ def graknlabs_protocol():
 def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
-        remote = "https://github.com/graknlabs/behaviour",
-        commit = "5a3b731b3ef154b5b1bd95b788dc374bd8873746", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        remote = "https://github.com/alexjpwalker/behaviour",
+        commit = "2033a33d17621edce938ad50c7072de14efdd3ba", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -29,8 +29,8 @@ def graknlabs_graql():
 def graknlabs_common():
     git_repository(
         name = "graknlabs_common",
-        remote = "https://github.com/graknlabs/common",
-        commit = "36564a64904eed7d06d6d7c24055ffc70a40aee8" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
+        remote = "https://github.com/alexjpwalker/common",
+        commit = "cc3cf0c42c74174fa62618b99c8153c8aef3842c" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 
 def graknlabs_bazel_distribution():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -30,7 +30,7 @@ def graknlabs_common():
     git_repository(
         name = "graknlabs_common",
         remote = "https://github.com/alexjpwalker/common",
-        commit = "a41bd3018101294eefade2e8b66be542823920be" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
+        commit = "36564a64904eed7d06d6d7c24055ffc70a40aee8" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 
 def graknlabs_bazel_distribution():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -58,7 +58,7 @@ def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
         remote = "https://github.com/alexjpwalker/behaviour",
-        commit = "2033a33d17621edce938ad50c7072de14efdd3ba", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        commit = "401b2e52b87a787fab2bc208415af1a822a17b55", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -57,8 +57,8 @@ def graknlabs_protocol():
 def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
-        remote = "https://github.com/alexjpwalker/behaviour",
-        commit = "401b2e52b87a787fab2bc208415af1a822a17b55", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        remote = "https://github.com/graknlabs/behaviour",
+        commit = "9f1cf29952dddaaee96a9ce3b982a8e4d6d45c48", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -29,7 +29,7 @@ def graknlabs_graql():
 def graknlabs_common():
     git_repository(
         name = "graknlabs_common",
-        remote = "https://github.com/alexjpwalker/common",
+        remote = "https://github.com/graknlabs/common",
         commit = "36564a64904eed7d06d6d7c24055ffc70a40aee8" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -29,8 +29,8 @@ def graknlabs_graql():
 def graknlabs_common():
     git_repository(
         name = "graknlabs_common",
-        remote = "https://github.com/graknlabs/common",
-        tag = "2.0.0-alpha-7" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
+        remote = "https://github.com/alexjpwalker/common",
+        commit = "a41bd3018101294eefade2e8b66be542823920be" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 
 def graknlabs_bazel_distribution():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -29,8 +29,8 @@ def graknlabs_graql():
 def graknlabs_common():
     git_repository(
         name = "graknlabs_common",
-        remote = "https://github.com/alexjpwalker/common",
-        commit = "cc3cf0c42c74174fa62618b99c8153c8aef3842c" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
+        remote = "https://github.com/graknlabs/common",
+        commit = "46c419071906dd5deacb8a8acaa812c351e85549" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 
 def graknlabs_bazel_distribution():

--- a/rpc/cluster/RPCGraknClientCluster.java
+++ b/rpc/cluster/RPCGraknClientCluster.java
@@ -44,8 +44,8 @@ public class RPCGraknClientCluster implements GraknClient {
     private final RPCDatabaseManagerCluster databases;
     private boolean isOpen;
 
-    public RPCGraknClientCluster(String address) {
-        coreClients = discoverCluster(address).stream()
+    public RPCGraknClientCluster(String... addresses) {
+        coreClients = discoverCluster(addresses).stream()
                 .map(addr -> pair(addr, new RPCClient(addr.client())))
                 .collect(Collectors.toMap(Pair::first, Pair::second));
         graknClusterRPCs = coreClients.entrySet().stream()

--- a/test/behaviour/connection/database/BUILD
+++ b/test/behaviour/connection/database/BUILD
@@ -20,7 +20,7 @@
 package(default_visibility = ["//test/behaviour:__subpackages__"])
 
 load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("//test/behaviour:rules.bzl", "grakn_java_test")
+load("@graknlabs_common//test/server:rules.bzl", "grakn_java_test")
 
 java_library(
     name = "steps",

--- a/test/behaviour/connection/database/BUILD
+++ b/test/behaviour/connection/database/BUILD
@@ -20,7 +20,7 @@
 package(default_visibility = ["//test/behaviour:__subpackages__"])
 
 load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("//test/behaviour:rules.bzl", "grakn_behaviour_java_test")
+load("//test/behaviour:rules.bzl", "grakn_java_test")
 
 java_library(
     name = "steps",

--- a/test/behaviour/connection/database/BUILD
+++ b/test/behaviour/connection/database/BUILD
@@ -41,28 +41,27 @@ java_library(
     ],
 )
 
-grakn_behaviour_java_test(
-    name = "test",
+grakn_java_test(
+    name = "test-core",
     srcs = [
-        "DatabaseTest.java",
+        "DatabaseTestCore.java",
     ],
-    test_class = "grakn.client.test.behaviour.connection.database.DatabaseTest",
+    test_class = "grakn.client.test.behaviour.connection.database.DatabaseTestCore",
     data = [
         "@graknlabs_behaviour//connection:database.feature",
     ],
-    grakn_core_artifact_mac = "@graknlabs_grakn_core_artifact_mac//file",
-    grakn_core_artifact_linux = "@graknlabs_grakn_core_artifact_linux//file",
-    grakn_core_artifact_windows = "@graknlabs_grakn_core_artifact_windows//file",
-    grakn_cluster_artifact_mac = "@graknlabs_grakn_cluster_artifact_mac//file",
-    grakn_cluster_artifact_linux = "@graknlabs_grakn_cluster_artifact_linux//file",
-    grakn_cluster_artifact_windows = "@graknlabs_grakn_cluster_artifact_windows//file",
-    connection_steps_core = "//test/behaviour/connection:steps-core",
-    connection_steps_cluster = "//test/behaviour/connection:steps-cluster",
-    steps = [
+    mac_artifact = "@graknlabs_grakn_core_artifact_mac//file",
+    linux_artifact = "@graknlabs_grakn_core_artifact_linux//file",
+    windows_artifact = "@graknlabs_grakn_core_artifact_windows//file",
+    runtime_deps = [
+        "//test/behaviour/connection:steps-core",
+
         ":steps",
         "//test/behaviour/connection/session:steps",
         "//test/behaviour/connection/transaction:steps",
         "//test/behaviour/graql:steps",
+
+        "//test/behaviour/config:parameters",
     ],
     deps = [
         # Internal Package Dependencies
@@ -71,8 +70,37 @@ grakn_behaviour_java_test(
         # External dependencies from Maven
         "@maven//:io_cucumber_cucumber_junit",
     ],
+    size = "medium",
+)
+
+grakn_java_test(
+    name = "test-cluster",
+    srcs = [
+        "DatabaseTestCluster.java",
+    ],
+    test_class = "grakn.client.test.behaviour.connection.database.DatabaseTestCluster",
+    data = [
+        "@graknlabs_behaviour//connection:database.feature",
+    ],
+    mac_artifact = "@graknlabs_grakn_cluster_artifact_mac//file",
+    linux_artifact = "@graknlabs_grakn_cluster_artifact_linux//file",
+    windows_artifact = "@graknlabs_grakn_cluster_artifact_windows//file",
     runtime_deps = [
+        "//test/behaviour/connection:steps-cluster",
+
+        ":steps",
+        "//test/behaviour/connection/session:steps",
+        "//test/behaviour/connection/transaction:steps",
+        "//test/behaviour/graql:steps",
+
         "//test/behaviour/config:parameters",
+    ],
+    deps = [
+        # Internal Package Dependencies
+        "//test/behaviour",
+
+        # External dependencies from Maven
+        "@maven//:io_cucumber_cucumber_junit",
     ],
     size = "medium",
 )

--- a/test/behaviour/connection/database/DatabaseTestCluster.java
+++ b/test/behaviour/connection/database/DatabaseTestCluster.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package grakn.client.test.behaviour.connection.database;
+
+import grakn.core.test.behaviour.BehaviourTest;
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        plugin = "pretty",
+        glue = "grakn.client.test.behaviour",
+        features = "external/graknlabs_behaviour/connection/database.feature",
+        tags = "not @ignore and not @ignore-client-java and not @ignore-cluster"
+)
+public class DatabaseTestCluster extends BehaviourTest {
+    // ATTENTION:
+    // When you click RUN from within this class through Intellij IDE, it will fail.
+    // You can fix it by doing:
+    //
+    // 1) Go to 'Run'
+    // 2) Select 'Edit Configurations...'
+    // 3) Select 'Bazel test DatabaseTest'
+    //
+    // 4) Ensure 'Target Expression' is set correctly:
+    //    a) Use '//<this>/<package>/<name>:test-core' to test against grakn-core
+    //    b) Use '//<this>/<package>/<name>:test-kgms' to test against grakn-kgms
+    //
+    // 5) Update 'Bazel Flags':
+    //    a) Remove the line that says: '--test_filter=grakn.client.*'
+    //    b) Use the following Bazel flags:
+    //       --cache_test_results=no : to make sure you're not using cache
+    //       --test_output=streamed : to make sure all output is printed
+    //       --subcommands : to print the low-level commands and execution paths
+    //       --sandbox_debug : to keep the sandbox not deleted after test runs
+    //       --spawn_strategy=standalone : if you're on Mac, tests need permission to access filesystem (to run Grakn)
+    //
+    // 6) Hit the RUN button by selecting the test from the dropdown menu on the top bar
+}

--- a/test/behaviour/connection/database/DatabaseTestCore.java
+++ b/test/behaviour/connection/database/DatabaseTestCore.java
@@ -30,9 +30,9 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "grakn.client.test.behaviour",
         features = "external/graknlabs_behaviour/connection/database.feature",
-        tags = "not @ignore and not @ignore-client-java and not @ignore-grakn-2.0"
+        tags = "not @ignore and not @ignore-client-java and not @ignore-core"
 )
-public class DatabaseTest extends BehaviourTest {
+public class DatabaseTestCore extends BehaviourTest {
     // ATTENTION:
     // When you click RUN from within this class through Intellij IDE, it will fail.
     // You can fix it by doing:
@@ -54,5 +54,5 @@ public class DatabaseTest extends BehaviourTest {
     //       --sandbox_debug : to keep the sandbox not deleted after test runs
     //       --spawn_strategy=standalone : if you're on Mac, tests need permission to access filesystem (to run Grakn)
     //
-    // 6) Hit the RUN button by selecting the test from the dropdown menu on the top bar    private static GraknCoreRunner runner;
+    // 6) Hit the RUN button by selecting the test from the dropdown menu on the top bar
 }


### PR DESCRIPTION
## What is the goal of this PR?

We've introduced a couple of fault tolerance improvements into the Grakn Cluster version of DatabaseManager:

- `contains` and `all` will now try to retrieve information from every node, instead of failing if the first node is down
- `create` and `delete` will now be applied to every working node, even if some nodes are down.

For now, this means `create` will no longer throw if the database already exists, and `delete` will no longer throw if the database doesn't exist.

## What are the changes implemented in this PR?

- `contains` and `all` will now try to retrieve information from every node, instead of failing if the first node is down
- `create` and `delete` will now be applied to every working node, even if some nodes are down.