### PR TITLE
Rename RPC classes to organise them better

### DIFF
--- a/GraknClient.java
+++ b/GraknClient.java
@@ -22,8 +22,8 @@ package grakn.client;
 import grakn.client.concept.ConceptManager;
 import grakn.client.logic.LogicManager;
 import grakn.client.query.QueryManager;
-import grakn.client.rpc.RPCClient;
-import grakn.client.rpc.cluster.RPCGraknClientCluster;
+import grakn.client.rpc.ClientRPC;
+import grakn.client.rpc.cluster.ClientClusterRPC;
 
 import java.util.List;
 
@@ -35,11 +35,11 @@ public interface GraknClient extends AutoCloseable {
     }
 
     static GraknClient core(String address) {
-        return new RPCClient(address);
+        return new ClientRPC(address);
     }
 
     static GraknClient cluster(String... addresses) {
-        return new RPCGraknClientCluster(addresses);
+        return new ClientClusterRPC(addresses);
     }
 
     GraknClient.Session session(String database, GraknClient.Session.Type type);

--- a/concept/ConceptManager.java
+++ b/concept/ConceptManager.java
@@ -25,12 +25,11 @@ import grakn.client.concept.type.AttributeType;
 import grakn.client.concept.type.EntityType;
 import grakn.client.concept.type.RelationType;
 import grakn.client.concept.type.ThingType;
-import grakn.client.concept.type.Type;
 import grakn.client.concept.type.impl.AttributeTypeImpl;
 import grakn.client.concept.type.impl.EntityTypeImpl;
 import grakn.client.concept.type.impl.RelationTypeImpl;
 import grakn.client.concept.type.impl.ThingTypeImpl;
-import grakn.client.rpc.RPCTransaction;
+import grakn.client.rpc.TransactionRPC;
 import grakn.protocol.ConceptProto;
 import grakn.protocol.TransactionProto;
 import graql.lang.common.GraqlToken;
@@ -44,10 +43,10 @@ import static grakn.client.concept.proto.ConceptProtoBuilder.valueType;
 
 public final class ConceptManager {
 
-    private final RPCTransaction rpcTransaction;
+    private final TransactionRPC transactionRPC;
 
-    public ConceptManager(RPCTransaction rpcTransaction) {
-        this.rpcTransaction = rpcTransaction;
+    public ConceptManager(TransactionRPC transactionRPC) {
+        this.transactionRPC = transactionRPC;
     }
 
     @CheckReturnValue
@@ -149,6 +148,6 @@ public final class ConceptManager {
         final TransactionProto.Transaction.Req.Builder req = TransactionProto.Transaction.Req.newBuilder()
                 .putAllMetadata(tracingData())
                 .setConceptManagerReq(request);
-        return rpcTransaction.execute(req).getConceptManagerRes();
+        return transactionRPC.execute(req).getConceptManagerRes();
     }
 }

--- a/concept/thing/impl/RelationImpl.java
+++ b/concept/thing/impl/RelationImpl.java
@@ -86,7 +86,7 @@ public class RelationImpl extends ThingImpl implements Relation {
 
             final TransactionProto.Transaction.Req.Builder request = TransactionProto.Transaction.Req.newBuilder()
                     .setThingReq(method.setIid(iid(getIID())));
-            final Stream<ConceptProto.Relation.GetPlayersByRoleType.RoleTypeWithPlayer> stream = rpcTransaction.stream(
+            final Stream<ConceptProto.Relation.GetPlayersByRoleType.RoleTypeWithPlayer> stream = transactionRPC.stream(
                     request, res -> res.getThingRes().getRelationGetPlayersByRoleTypeRes().getRoleTypesWithPlayersList().stream());
 
             final Map<RoleTypeImpl, List<ThingImpl>> rolePlayerMap = new HashMap<>();

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -29,7 +29,7 @@ import grakn.client.concept.type.RoleType;
 import grakn.client.concept.type.impl.RoleTypeImpl;
 import grakn.client.concept.type.impl.ThingTypeImpl;
 import grakn.client.concept.type.impl.TypeImpl;
-import grakn.client.rpc.RPCTransaction;
+import grakn.client.rpc.TransactionRPC;
 import grakn.protocol.ConceptProto;
 import grakn.protocol.TransactionProto;
 
@@ -105,16 +105,16 @@ public abstract class ThingImpl extends ConceptImpl implements Thing {
 
     public abstract static class Remote extends ConceptImpl.Remote implements Thing.Remote {
 
-        final RPCTransaction rpcTransaction;
+        final TransactionRPC transactionRPC;
         private final String iid;
         private final int hash;
 
         Remote(GraknClient.Transaction transaction, String iid) {
             if (transaction == null) throw new GraknClientException(MISSING_TRANSACTION);
-            this.rpcTransaction = (RPCTransaction) transaction;
+            this.transactionRPC = (TransactionRPC) transaction;
             if (iid == null || iid.isEmpty()) throw new GraknClientException(MISSING_IID);
             this.iid = iid;
-            this.hash = Objects.hash(this.rpcTransaction, this.getIID());
+            this.hash = Objects.hash(this.transactionRPC, this.getIID());
         }
 
         @Override
@@ -214,7 +214,7 @@ public abstract class ThingImpl extends ConceptImpl implements Thing {
 
         @Override
         public final boolean isDeleted() {
-            return rpcTransaction.concepts().getThing(getIID()) == null;
+            return transactionRPC.concepts().getThing(getIID()) == null;
         }
 
         @Override
@@ -223,25 +223,25 @@ public abstract class ThingImpl extends ConceptImpl implements Thing {
         }
 
         final GraknClient.Transaction tx() {
-            return rpcTransaction;
+            return transactionRPC;
         }
 
         Stream<ThingImpl> thingStream(ConceptProto.Thing.Req.Builder method, Function<ConceptProto.Thing.Res, List<ConceptProto.Thing>> thingListGetter) {
             final TransactionProto.Transaction.Req.Builder request = TransactionProto.Transaction.Req.newBuilder()
                     .setThingReq(method.setIid(iid(iid)));
-            return rpcTransaction.stream(request, res -> thingListGetter.apply(res.getThingRes()).stream().map(ThingImpl::of));
+            return transactionRPC.stream(request, res -> thingListGetter.apply(res.getThingRes()).stream().map(ThingImpl::of));
         }
 
         Stream<TypeImpl> typeStream(ConceptProto.Thing.Req.Builder method, Function<ConceptProto.Thing.Res, List<ConceptProto.Type>> typeListGetter) {
             final TransactionProto.Transaction.Req.Builder request = TransactionProto.Transaction.Req.newBuilder()
                     .setThingReq(method.setIid(iid(iid)));
-            return rpcTransaction.stream(request, res -> typeListGetter.apply(res.getThingRes()).stream().map(TypeImpl::of));
+            return transactionRPC.stream(request, res -> typeListGetter.apply(res.getThingRes()).stream().map(TypeImpl::of));
         }
 
         ConceptProto.Thing.Res execute(ConceptProto.Thing.Req.Builder method) {
             final TransactionProto.Transaction.Req.Builder request = TransactionProto.Transaction.Req.newBuilder()
                     .setThingReq(method.setIid(iid(iid)));
-            return rpcTransaction.execute(request).getThingRes();
+            return transactionRPC.execute(request).getThingRes();
         }
 
         @Override
@@ -255,7 +255,7 @@ public abstract class ThingImpl extends ConceptImpl implements Thing {
             if (o == null || getClass() != o.getClass()) return false;
 
             final ThingImpl.Remote that = (ThingImpl.Remote) o;
-            return this.rpcTransaction.equals(that.rpcTransaction) && this.iid.equals(that.iid);
+            return this.transactionRPC.equals(that.transactionRPC) && this.iid.equals(that.iid);
         }
 
         @Override

--- a/logic/LogicManager.java
+++ b/logic/LogicManager.java
@@ -19,10 +19,8 @@
 
 package grakn.client.logic;
 
-import grakn.client.concept.type.impl.TypeImpl;
 import grakn.client.logic.impl.RuleImpl;
-import grakn.client.rpc.RPCTransaction;
-import grakn.protocol.ConceptProto;
+import grakn.client.rpc.TransactionRPC;
 import grakn.protocol.LogicProto;
 import grakn.protocol.TransactionProto;
 import graql.lang.pattern.Pattern;
@@ -38,10 +36,10 @@ import static grakn.client.common.tracing.TracingProtoBuilder.tracingData;
 
 public final class LogicManager {
 
-    private final RPCTransaction rpcTransaction;
+    private final TransactionRPC transactionRPC;
 
-    public LogicManager(RPCTransaction rpcTransaction) {
-        this.rpcTransaction = rpcTransaction;
+    public LogicManager(TransactionRPC transactionRPC) {
+        this.transactionRPC = transactionRPC;
     }
 
     public Rule putRule(String label, Pattern when, Pattern then) {
@@ -81,13 +79,13 @@ public final class LogicManager {
         final TransactionProto.Transaction.Req.Builder req = TransactionProto.Transaction.Req.newBuilder()
                 .putAllMetadata(tracingData())
                 .setLogicManagerReq(request);
-        return rpcTransaction.execute(req).getLogicManagerRes();
+        return transactionRPC.execute(req).getLogicManagerRes();
     }
 
     private Stream<RuleImpl> ruleStream(LogicProto.LogicManager.Req.Builder method, Function<LogicProto.LogicManager.Res, List<LogicProto.Rule>> ruleListGetter) {
         final TransactionProto.Transaction.Req.Builder request = TransactionProto.Transaction.Req.newBuilder()
                 .putAllMetadata(tracingData())
                 .setLogicManagerReq(method);
-        return rpcTransaction.stream(request, res -> ruleListGetter.apply(res.getLogicManagerRes()).stream().map(RuleImpl::of));
+        return transactionRPC.stream(request, res -> ruleListGetter.apply(res.getLogicManagerRes()).stream().map(RuleImpl::of));
     }
 }

--- a/logic/impl/RuleImpl.java
+++ b/logic/impl/RuleImpl.java
@@ -22,7 +22,7 @@ package grakn.client.logic.impl;
 import grakn.client.GraknClient;
 import grakn.client.common.exception.GraknClientException;
 import grakn.client.logic.Rule;
-import grakn.client.rpc.RPCTransaction;
+import grakn.client.rpc.TransactionRPC;
 import grakn.protocol.LogicProto;
 import grakn.protocol.TransactionProto;
 import graql.lang.Graql;
@@ -101,7 +101,7 @@ public class RuleImpl implements Rule {
 
     public static class Remote implements Rule.Remote {
 
-        final RPCTransaction rpcTransaction;
+        final TransactionRPC transactionRPC;
         private String label;
         private final Conjunction<? extends Pattern> when;
         private final ThingVariable<?> then;
@@ -110,7 +110,7 @@ public class RuleImpl implements Rule {
         public Remote(GraknClient.Transaction transaction, String label, Conjunction<? extends Pattern> when, ThingVariable<?> then) {
             if (transaction == null) throw new GraknClientException(MISSING_TRANSACTION);
             if (label == null || label.isEmpty()) throw new GraknClientException(MISSING_LABEL);
-            this.rpcTransaction = (RPCTransaction) transaction;
+            this.transactionRPC = (TransactionRPC) transaction;
             this.label = label;
             this.when = when;
             this.then = then;
@@ -145,7 +145,7 @@ public class RuleImpl implements Rule {
 
         @Override
         public final boolean isDeleted() {
-            return rpcTransaction.logic().getRule(label) != null;
+            return transactionRPC.logic().getRule(label) != null;
         }
 
         @Override
@@ -169,7 +169,7 @@ public class RuleImpl implements Rule {
             if (o == null || getClass() != o.getClass()) return false;
 
             final RuleImpl.Remote that = (RuleImpl.Remote) o;
-            return this.rpcTransaction.equals(that.rpcTransaction) && this.label.equals(that.label);
+            return this.transactionRPC.equals(that.transactionRPC) && this.label.equals(that.label);
         }
 
         @Override
@@ -178,13 +178,13 @@ public class RuleImpl implements Rule {
         }
 
         final GraknClient.Transaction tx() {
-            return rpcTransaction;
+            return transactionRPC;
         }
 
         LogicProto.Rule.Res execute(LogicProto.Rule.Req.Builder method) {
             final TransactionProto.Transaction.Req.Builder request = TransactionProto.Transaction.Req.newBuilder()
                     .setRuleReq(method.setLabel(label));
-            return rpcTransaction.execute(request).getRuleRes();
+            return transactionRPC.execute(request).getRuleRes();
         }
     }
 }

--- a/query/QueryManager.java
+++ b/query/QueryManager.java
@@ -25,7 +25,7 @@ import grakn.client.concept.answer.ConceptMapGroup;
 import grakn.client.concept.answer.Numeric;
 import grakn.client.concept.answer.NumericGroup;
 import grakn.client.rpc.QueryFuture;
-import grakn.client.rpc.RPCTransaction;
+import grakn.client.rpc.TransactionRPC;
 import grakn.protocol.QueryProto;
 import grakn.protocol.TransactionProto;
 import graql.lang.query.GraqlDefine;
@@ -42,10 +42,10 @@ import static grakn.client.common.proto.OptionsProtoBuilder.options;
 
 public final class QueryManager {
 
-    private final RPCTransaction rpcTransaction;
+    private final TransactionRPC transactionRPC;
 
-    public QueryManager(RPCTransaction rpcTransaction) {
-        this.rpcTransaction = rpcTransaction;
+    public QueryManager(TransactionRPC transactionRPC) {
+        this.transactionRPC = transactionRPC;
     }
 
     public Stream<ConceptMap> match(GraqlMatch query) {
@@ -140,19 +140,19 @@ public final class QueryManager {
     private <T> QueryFuture<T> runQuery(QueryProto.Query.Req.Builder request, GraknOptions options, Function<TransactionProto.Transaction.Res, T> mapper) {
         final TransactionProto.Transaction.Req.Builder req = TransactionProto.Transaction.Req.newBuilder()
                 .setQueryReq(request.setOptions(options(options)));
-        return rpcTransaction.executeAsync(req, mapper);
+        return transactionRPC.executeAsync(req, mapper);
     }
 
     private QueryFuture<Void> runQuery(QueryProto.Query.Req.Builder request, GraknOptions options) {
         final TransactionProto.Transaction.Req.Builder req = TransactionProto.Transaction.Req.newBuilder()
                 .setQueryReq(request.setOptions(options(options)));
-        return rpcTransaction.executeAsync(req, res -> null);
+        return transactionRPC.executeAsync(req, res -> null);
     }
 
     private <T> Stream<T> iterateQuery(QueryProto.Query.Req.Builder request, GraknOptions options,
                                        Function<TransactionProto.Transaction.Res, Stream<T>> responseReader) {
         final TransactionProto.Transaction.Req.Builder req = TransactionProto.Transaction.Req.newBuilder()
                 .setQueryReq(request.setOptions(options(options)));
-        return rpcTransaction.stream(req, responseReader);
+        return transactionRPC.stream(req, responseReader);
     }
 }

--- a/rpc/ClientRPC.java
+++ b/rpc/ClientRPC.java
@@ -27,28 +27,28 @@ import io.grpc.ManagedChannelBuilder;
 
 import java.util.concurrent.TimeUnit;
 
-public class RPCClient implements GraknClient {
+public class ClientRPC implements GraknClient {
 
     private final ManagedChannel channel;
-    private final RPCDatabaseManager databases;
+    private final DatabaseManagerRPC databases;
 
-    public RPCClient(String address) {
+    public ClientRPC(String address) {
         channel = ManagedChannelBuilder.forTarget(address).usePlaintext().build();
-        databases = new RPCDatabaseManager(channel);
+        databases = new DatabaseManagerRPC(channel);
     }
 
     @Override
-    public RPCSession session(String database, GraknClient.Session.Type type) {
+    public SessionRPC session(String database, GraknClient.Session.Type type) {
         return session(database, type, GraknOptions.core());
     }
 
     @Override
-    public RPCSession session(String database, GraknClient.Session.Type type, GraknOptions options) {
-        return new RPCSession(this, database, type, options);
+    public SessionRPC session(String database, GraknClient.Session.Type type, GraknOptions options) {
+        return new SessionRPC(this, database, type, options);
     }
 
     @Override
-    public RPCDatabaseManager databases() {
+    public DatabaseManagerRPC databases() {
         return databases;
     }
 

--- a/rpc/DatabaseManagerRPC.java
+++ b/rpc/DatabaseManagerRPC.java
@@ -32,10 +32,10 @@ import java.util.function.Supplier;
 
 import static grakn.client.common.exception.ErrorMessage.Client.MISSING_DB_NAME;
 
-public class RPCDatabaseManager implements GraknClient.DatabaseManager {
+public class DatabaseManagerRPC implements GraknClient.DatabaseManager {
     private final GraknGrpc.GraknBlockingStub blockingGrpcStub;
 
-    public RPCDatabaseManager(Channel channel) {
+    public DatabaseManagerRPC(Channel channel) {
         blockingGrpcStub = GraknGrpc.newBlockingStub(channel);
     }
 

--- a/rpc/QueryFuture.java
+++ b/rpc/QueryFuture.java
@@ -21,7 +21,6 @@ package grakn.client.rpc;
 
 import grakn.client.common.exception.GraknClientException;
 import grakn.protocol.TransactionProto;
-import io.grpc.stub.StreamObserver;
 
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -30,10 +29,10 @@ import java.util.function.Function;
 
 public class QueryFuture<T> implements Future<T> {
 
-    private final RPCTransaction.ResponseCollector.Single collector;
+    private final TransactionRPC.ResponseCollector.Single collector;
     private final Function<TransactionProto.Transaction.Res, T> transformResponse;
 
-    QueryFuture(RPCTransaction.ResponseCollector.Single collector, Function<TransactionProto.Transaction.Res, T> transformResponse) {
+    QueryFuture(TransactionRPC.ResponseCollector.Single collector, Function<TransactionProto.Transaction.Res, T> transformResponse) {
         this.collector = collector;
         this.transformResponse = transformResponse;
     }

--- a/rpc/ResponseIterator.java
+++ b/rpc/ResponseIterator.java
@@ -36,12 +36,12 @@ class ResponseIterator<T> extends AbstractIterator<T> {
 
     private final UUID requestId;
     private final StreamObserver<TransactionProto.Transaction.Req> requestObserver;
-    private final RPCTransaction.ResponseCollector.Multiple responseCollector;
+    private final TransactionRPC.ResponseCollector.Multiple responseCollector;
     private final Function<TransactionProto.Transaction.Res, Stream<T>> transformResponse;
     private Iterator<T> currentIterator;
 
     ResponseIterator(UUID requestId, StreamObserver<TransactionProto.Transaction.Req> requestObserver,
-                     RPCTransaction.ResponseCollector.Multiple responseCollector, Function<TransactionProto.Transaction.Res, Stream<T>> transformResponse) {
+                     TransactionRPC.ResponseCollector.Multiple responseCollector, Function<TransactionProto.Transaction.Res, Stream<T>> transformResponse) {
         this.requestId = requestId;
         this.transformResponse = transformResponse;
         this.requestObserver = requestObserver;

--- a/rpc/SessionRPC.java
+++ b/rpc/SessionRPC.java
@@ -34,7 +34,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static grakn.client.common.proto.OptionsProtoBuilder.options;
 
-public class RPCSession implements GraknClient.Session {
+public class SessionRPC implements GraknClient.Session {
     private final Channel channel;
     private final String database;
     private final Type type;
@@ -43,7 +43,7 @@ public class RPCSession implements GraknClient.Session {
     private final Timer pulse;
     private final GraknGrpc.GraknBlockingStub blockingGrpcStub;
 
-    public RPCSession(RPCClient client, String database, Type type, GraknOptions options) {
+    public SessionRPC(ClientRPC client, String database, Type type, GraknOptions options) {
         try {
             this.channel = client.channel();
             this.database = database;
@@ -68,7 +68,7 @@ public class RPCSession implements GraknClient.Session {
 
     @Override
     public GraknClient.Transaction transaction(GraknClient.Transaction.Type type, GraknOptions options) {
-        return new RPCTransaction(this, sessionId, type, options);
+        return new TransactionRPC(this, sessionId, type, options);
     }
 
     @Override

--- a/rpc/TransactionRPC.java
+++ b/rpc/TransactionRPC.java
@@ -51,7 +51,7 @@ import static grakn.client.common.exception.ErrorMessage.Client.UNKNOWN_REQUEST_
 import static grakn.client.common.tracing.TracingProtoBuilder.tracingData;
 import static grakn.common.util.Objects.className;
 
-public class RPCTransaction implements Transaction {
+public class TransactionRPC implements Transaction {
 
     private final Transaction.Type type;
     private final ConceptManager conceptManager;
@@ -62,7 +62,7 @@ public class RPCTransaction implements Transaction {
     private final int networkLatencyMillis;
     private final AtomicBoolean isOpen;
 
-    RPCTransaction(RPCSession session, ByteString sessionId, Type type, GraknOptions options) {
+    TransactionRPC(SessionRPC session, ByteString sessionId, Type type, GraknOptions options) {
         try {
             this.type = type;
             conceptManager = new ConceptManager(this);

--- a/rpc/cluster/ClientClusterRPC.java
+++ b/rpc/cluster/ClientClusterRPC.java
@@ -22,7 +22,7 @@ package grakn.client.rpc.cluster;
 import grakn.client.GraknClient;
 import grakn.client.GraknOptions;
 import grakn.client.common.exception.GraknClientException;
-import grakn.client.rpc.RPCClient;
+import grakn.client.rpc.ClientRPC;
 import grakn.common.collection.Pair;
 import grakn.protocol.cluster.ClusterProto;
 import grakn.protocol.cluster.GraknClusterGrpc;
@@ -39,22 +39,22 @@ import java.util.stream.Collectors;
 import static grakn.client.common.exception.ErrorMessage.Client.CLUSTER_UNABLE_TO_CONNECT;
 import static grakn.common.collection.Collections.pair;
 
-public class RPCGraknClientCluster implements GraknClient {
-    private static final Logger LOG = LoggerFactory.getLogger(RPCGraknClientCluster.class);
-    private final Map<ServerAddress, RPCClient> coreClients;
+public class ClientClusterRPC implements GraknClient {
+    private static final Logger LOG = LoggerFactory.getLogger(ClientClusterRPC.class);
+    private final Map<ServerAddress, ClientRPC> coreClients;
     private final Map<ServerAddress, GraknClusterGrpc.GraknClusterBlockingStub> graknClusterRPCs;
-    private final RPCDatabaseManagerCluster databaseManagers;
+    private final DatabaseManagerClusterRPC databaseManagers;
     private final ConcurrentMap<String, ReplicaInfo> replicaInfoMap;
     private boolean isOpen;
 
-    public RPCGraknClientCluster(String... addresses) {
+    public ClientClusterRPC(String... addresses) {
         coreClients = discoverCluster(addresses).stream()
-                .map(addr -> pair(addr, new RPCClient(addr.client())))
+                .map(addr -> pair(addr, new ClientRPC(addr.client())))
                 .collect(Collectors.toMap(Pair::first, Pair::second));
         graknClusterRPCs = coreClients.entrySet().stream()
                 .map(client -> pair(client.getKey(), GraknClusterGrpc.newBlockingStub(client.getValue().channel())))
                 .collect(Collectors.toMap(Pair::first, Pair::second));
-        databaseManagers = new RPCDatabaseManagerCluster(
+        databaseManagers = new DatabaseManagerClusterRPC(
                 coreClients.entrySet().stream()
                         .map(client -> pair(client.getKey(), client.getValue().databases()))
                         .collect(Collectors.toMap(Pair::first, Pair::second))
@@ -64,12 +64,12 @@ public class RPCGraknClientCluster implements GraknClient {
     }
 
     @Override
-    public RPCSessionCluster session(String database, GraknClient.Session.Type type) {
+    public SessionClusterRPC session(String database, GraknClient.Session.Type type) {
         return session(database, type, GraknOptions.cluster());
     }
 
     @Override
-    public RPCSessionCluster session(String database, GraknClient.Session.Type type, GraknOptions options) {
+    public SessionClusterRPC session(String database, GraknClient.Session.Type type, GraknOptions options) {
         GraknOptions.Cluster clusterOptions = options.asCluster();
         if (clusterOptions.readAnyReplica().isPresent() && clusterOptions.readAnyReplica().get()) {
             return sessionAnyReplica(database, type, clusterOptions);
@@ -78,26 +78,26 @@ public class RPCGraknClientCluster implements GraknClient {
         }
     }
 
-    private RPCSessionCluster sessionPrimaryReplica(String database, GraknClient.Session.Type type, GraknOptions.Cluster options) {
+    private SessionClusterRPC sessionPrimaryReplica(String database, GraknClient.Session.Type type, GraknOptions.Cluster options) {
         return openSessionFailsafeTask(database, type, options, this).runPrimaryReplica(database);
     }
 
-    private RPCSessionCluster sessionAnyReplica(String database, GraknClient.Session.Type type, GraknOptions.Cluster options) {
+    private SessionClusterRPC sessionAnyReplica(String database, GraknClient.Session.Type type, GraknOptions.Cluster options) {
         return openSessionFailsafeTask(database, type, options, this).runAnyReplica(database);
     }
 
-    private FailsafeTask<RPCSessionCluster> openSessionFailsafeTask(String database, Session.Type type, GraknOptions.Cluster options, RPCGraknClientCluster client) {
-        return new FailsafeTask<RPCSessionCluster>(this) {
+    private FailsafeTask<SessionClusterRPC> openSessionFailsafeTask(String database, Session.Type type, GraknOptions.Cluster options, ClientClusterRPC client) {
+        return new FailsafeTask<SessionClusterRPC>(this) {
 
             @Override
-            RPCSessionCluster run(ReplicaInfo.Replica replica) {
-                return new RPCSessionCluster(client, replica.address(), database, type, options);
+            SessionClusterRPC run(ReplicaInfo.Replica replica) {
+                return new SessionClusterRPC(client, replica.address(), database, type, options);
             }
         };
     }
 
     @Override
-    public RPCDatabaseManagerCluster databases() {
+    public DatabaseManagerClusterRPC databases() {
         return databaseManagers;
     }
 
@@ -108,7 +108,7 @@ public class RPCGraknClientCluster implements GraknClient {
 
     @Override
     public void close() {
-        coreClients.values().forEach(RPCClient::close);
+        coreClients.values().forEach(ClientRPC::close);
         isOpen = false;
     }
 
@@ -120,7 +120,7 @@ public class RPCGraknClientCluster implements GraknClient {
         return coreClients.keySet();
     }
 
-    public RPCClient coreClient(ServerAddress address) {
+    public ClientRPC coreClient(ServerAddress address) {
         return coreClients.get(address);
     }
 
@@ -130,7 +130,7 @@ public class RPCGraknClientCluster implements GraknClient {
 
     private Set<ServerAddress> discoverCluster(String... addresses) {
         for (String address : addresses) {
-            try (RPCClient client = new RPCClient(address)) {
+            try (ClientRPC client = new ClientRPC(address)) {
                 LOG.debug("Performing cluster discovery to {}...", address);
                 GraknClusterGrpc.GraknClusterBlockingStub graknClusterRPC = GraknClusterGrpc.newBlockingStub(client.channel());
                 ClusterProto.Cluster.Servers.Res res =

--- a/rpc/cluster/DatabaseManagerClusterRPC.java
+++ b/rpc/cluster/DatabaseManagerClusterRPC.java
@@ -21,7 +21,7 @@ package grakn.client.rpc.cluster;
 
 import grakn.client.GraknClient;
 import grakn.client.common.exception.GraknClientException;
-import grakn.client.rpc.RPCDatabaseManager;
+import grakn.client.rpc.DatabaseManagerRPC;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,17 +29,17 @@ import java.util.Map;
 
 import static grakn.client.common.exception.ErrorMessage.Client.CLUSTER_ALL_NODES_FAILED;
 
-public class RPCDatabaseManagerCluster implements GraknClient.DatabaseManager {
-    private final Map<ServerAddress, RPCDatabaseManager> databaseManagers;
+public class DatabaseManagerClusterRPC implements GraknClient.DatabaseManager {
+    private final Map<ServerAddress, DatabaseManagerRPC> databaseManagers;
 
-    public RPCDatabaseManagerCluster(Map<ServerAddress, RPCDatabaseManager> databaseManagers) {
+    public DatabaseManagerClusterRPC(Map<ServerAddress, DatabaseManagerRPC> databaseManagers) {
         this.databaseManagers = databaseManagers;
     }
 
     @Override
     public boolean contains(String name) {
         List<GraknClientException> errors = new ArrayList<>();
-        for (RPCDatabaseManager databaseManager : databaseManagers.values()) {
+        for (DatabaseManagerRPC databaseManager : databaseManagers.values()) {
             try {
                 return databaseManager.contains(name);
             } catch (GraknClientException e) {
@@ -51,7 +51,7 @@ public class RPCDatabaseManagerCluster implements GraknClient.DatabaseManager {
 
     @Override
     public void create(String name) {
-        for (RPCDatabaseManager databaseManager : databaseManagers.values()) {
+        for (DatabaseManagerRPC databaseManager : databaseManagers.values()) {
             if (!databaseManager.contains(name)) {
                 databaseManager.create(name);
             }
@@ -60,7 +60,7 @@ public class RPCDatabaseManagerCluster implements GraknClient.DatabaseManager {
 
     @Override
     public void delete(String name) {
-        for (RPCDatabaseManager databaseManager : databaseManagers.values()) {
+        for (DatabaseManagerRPC databaseManager : databaseManagers.values()) {
             if (databaseManager.contains(name)) {
                 databaseManager.delete(name);
             }
@@ -70,7 +70,7 @@ public class RPCDatabaseManagerCluster implements GraknClient.DatabaseManager {
     @Override
     public List<String> all() {
         List<GraknClientException> errors = new ArrayList<>();
-        for (RPCDatabaseManager databaseManager : databaseManagers.values()) {
+        for (DatabaseManagerRPC databaseManager : databaseManagers.values()) {
             try {
                 return databaseManager.all();
             } catch (GraknClientException e) {

--- a/rpc/cluster/FailsafeTask.java
+++ b/rpc/cluster/FailsafeTask.java
@@ -40,9 +40,9 @@ abstract class FailsafeTask<TResult> {
     private static final int PRIMARY_REPLICA_TASK_MAX_RETRIES = 10;
     private static final int FETCH_REPLICAS_MAX_RETRIES = 10;
     private static final int WAIT_FOR_PRIMARY_REPLICA_SELECTION_MS = 2000;
-    private final RPCGraknClientCluster client;
+    private final ClientClusterRPC client;
 
-    FailsafeTask(RPCGraknClientCluster client) {
+    FailsafeTask(ClientClusterRPC client) {
         this.client = client;
     }
 
@@ -52,7 +52,7 @@ abstract class FailsafeTask<TResult> {
         return run(replica);
     }
 
-    RPCGraknClientCluster client() {
+    ClientClusterRPC client() {
         return client;
     }
 

--- a/rpc/cluster/SessionClusterRPC.java
+++ b/rpc/cluster/SessionClusterRPC.java
@@ -21,19 +21,19 @@ package grakn.client.rpc.cluster;
 
 import grakn.client.GraknClient;
 import grakn.client.GraknOptions;
-import grakn.client.rpc.RPCClient;
-import grakn.client.rpc.RPCSession;
+import grakn.client.rpc.ClientRPC;
+import grakn.client.rpc.SessionRPC;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class RPCSessionCluster implements GraknClient.Session {
+public class SessionClusterRPC implements GraknClient.Session {
     private static final Logger LOG = LoggerFactory.getLogger(GraknClient.Session.class);
-    private final RPCGraknClientCluster clusterClient;
-    private RPCClient coreClient;
+    private final ClientClusterRPC clusterClient;
+    private ClientRPC coreClient;
     private final String database;
-    private RPCSession coreSession;
+    private SessionRPC coreSession;
 
-    public RPCSessionCluster(RPCGraknClientCluster clusterClient, ServerAddress serverAddress, String database, GraknClient.Session.Type type, GraknOptions.Cluster options) {
+    public SessionClusterRPC(ClientClusterRPC clusterClient, ServerAddress serverAddress, String database, GraknClient.Session.Type type, GraknOptions.Cluster options) {
         this.clusterClient = clusterClient;
         this.coreClient = clusterClient.coreClient(serverAddress);
         this.database = database;


### PR DESCRIPTION
## What is the goal of this PR?

Our RPC classes used the prefix "RPC", but for autocompletion purposes, it's better for that to be a suffix. So we made it a suffix.

## What are the changes implemented in this PR?

Rename RPC* to *RPC across the rpc package.
