### PR TITLE
Clean up FailsafeTask

### DIFF
--- a/rpc/cluster/ClientClusterRPC.java
+++ b/rpc/cluster/ClientClusterRPC.java
@@ -79,15 +79,15 @@ public class ClientClusterRPC implements GraknClient {
     }
 
     private SessionClusterRPC sessionPrimaryReplica(String database, GraknClient.Session.Type type, GraknOptions.Cluster options) {
-        return openSessionFailsafeTask(database, type, options, this).runPrimaryReplica(database);
+        return openSessionFailsafeTask(database, type, options, this).runPrimaryReplica();
     }
 
     private SessionClusterRPC sessionAnyReplica(String database, GraknClient.Session.Type type, GraknOptions.Cluster options) {
-        return openSessionFailsafeTask(database, type, options, this).runAnyReplica(database);
+        return openSessionFailsafeTask(database, type, options, this).runAnyReplica();
     }
 
     private FailsafeTask<SessionClusterRPC> openSessionFailsafeTask(String database, Session.Type type, GraknOptions.Cluster options, ClientClusterRPC client) {
-        return new FailsafeTask<SessionClusterRPC>(this) {
+        return new FailsafeTask<SessionClusterRPC>(this, database) {
 
             @Override
             SessionClusterRPC run(ReplicaInfo.Replica replica) {

--- a/rpc/cluster/FailsafeTask.java
+++ b/rpc/cluster/FailsafeTask.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -54,10 +55,6 @@ abstract class FailsafeTask<TResult> {
         return run(replica);
     }
 
-    ClientClusterRPC client() {
-        return client;
-    }
-
     TResult runPrimaryReplica() {
         if (!client.replicaInfoMap().containsKey(database) || !client.replicaInfoMap().get(database).primaryReplica().isPresent()) {
             seekPrimaryReplica();
@@ -83,8 +80,7 @@ abstract class FailsafeTask<TResult> {
         if (replicaInfo == null) replicaInfo = fetchDatabaseReplicas();
 
         // Try the preferred secondary replica first, then go through the others
-        List<ReplicaInfo.Replica> replicas = new ArrayList<>();
-        replicas.add(replicaInfo.preferredSecondaryReplica());
+        List<ReplicaInfo.Replica> replicas = Arrays.asList(replicaInfo.preferredSecondaryReplica());
         for (ReplicaInfo.Replica replica : replicaInfo.replicas()) {
             if (!replica.isPreferredSecondary()) replicas.add(replica);
         }

--- a/rpc/cluster/ReplicaInfo.java
+++ b/rpc/cluster/ReplicaInfo.java
@@ -62,7 +62,7 @@ class ReplicaInfo {
     Replica preferredSecondaryReplica() {
         return replicas.values().stream()
                 .filter(Replica::isPreferredSecondary)
-                .max(Comparator.comparing(Replica::term))
+                .findAny()
                 .orElse(replicas.values().stream().findAny().get());
     }
 

--- a/rpc/cluster/SessionClusterRPC.java
+++ b/rpc/cluster/SessionClusterRPC.java
@@ -56,26 +56,6 @@ public class SessionClusterRPC implements GraknClient.Session {
         }
     }
 
-    @Override
-    public GraknClient.Session.Type type() {
-        return coreSession.type();
-    }
-
-    @Override
-    public boolean isOpen() {
-        return coreSession.isOpen();
-    }
-
-    @Override
-    public void close() {
-        coreSession.close();
-    }
-
-    @Override
-    public String database() {
-        return database;
-    }
-
     private GraknClient.Transaction transactionPrimaryReplica(GraknClient.Transaction.Type type, GraknOptions options) {
         return transactionFailsafeTask(type, options).runPrimaryReplica();
     }
@@ -100,5 +80,25 @@ public class SessionClusterRPC implements GraknClient.Session {
                 return coreSession.transaction(type, options);
             }
         };
+    }
+
+    @Override
+    public GraknClient.Session.Type type() {
+        return coreSession.type();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return coreSession.isOpen();
+    }
+
+    @Override
+    public void close() {
+        coreSession.close();
+    }
+
+    @Override
+    public String database() {
+        return database;
     }
 }

--- a/rpc/cluster/SessionClusterRPC.java
+++ b/rpc/cluster/SessionClusterRPC.java
@@ -77,15 +77,15 @@ public class SessionClusterRPC implements GraknClient.Session {
     }
 
     private GraknClient.Transaction transactionPrimaryReplica(GraknClient.Transaction.Type type, GraknOptions options) {
-        return transactionFailsafeTask(type, options).runPrimaryReplica(database);
+        return transactionFailsafeTask(type, options).runPrimaryReplica();
     }
 
     private GraknClient.Transaction transactionAnyReplica(GraknClient.Transaction.Type type, GraknOptions.Cluster options) {
-        return transactionFailsafeTask(type, options).runAnyReplica(database);
+        return transactionFailsafeTask(type, options).runAnyReplica();
     }
 
     private FailsafeTask<GraknClient.Transaction> transactionFailsafeTask(GraknClient.Transaction.Type type, GraknOptions options) {
-        return new FailsafeTask<GraknClient.Transaction>(clusterClient) {
+        return new FailsafeTask<GraknClient.Transaction>(clusterClient, database) {
 
             @Override
             GraknClient.Transaction run(ReplicaInfo.Replica replica) {


### PR DESCRIPTION
## What is the goal of this PR?

We did some general cleanup in FailsafeTask.

## What are the changes implemented in this PR?

- Make FailsafeTask take in the Database as a constructor parameter, instead of having it as an argument in every method
- Fix ReplicaInfo performing an unnecessary aggregate over the Replicas when finding a preferred secondary
