### PR TITLE
Print inner exception when client fails to connect to Grakn

### DIFF
--- a/common/exception/GraknClientException.java
+++ b/common/exception/GraknClientException.java
@@ -42,9 +42,9 @@ public class GraknClientException extends RuntimeException {
     public static GraknClientException of(StatusRuntimeException statusRuntimeException) {
         // "Received Rst Stream" occurs if the server is in the process of shutting down.
         if (statusRuntimeException.getStatus().getCode() == Status.Code.UNAVAILABLE || statusRuntimeException.getMessage().contains("Received Rst Stream")) {
-            return new GraknClientException(ErrorMessage.Client.UNABLE_TO_CONNECT);
+            return new GraknClientException(ErrorMessage.Client.UNABLE_TO_CONNECT.message(), statusRuntimeException);
         } else if (isReplicaNotPrimaryException(statusRuntimeException)) {
-            return new GraknClientException(ErrorMessage.Client.CLUSTER_REPLICA_NOT_PRIMARY);
+            return new GraknClientException(ErrorMessage.Client.CLUSTER_REPLICA_NOT_PRIMARY.message(), statusRuntimeException);
         }
         return new GraknClientException(statusRuntimeException.getStatus().getDescription(), statusRuntimeException);
     }

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -37,5 +37,5 @@ def graknlabs_grakn_cluster_artifacts():
         artifact_name = "grakn-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "1d2fa6dd0bfb197dc1d2f5256bc6202cc655bbc9",
+        commit = "cc3382fe6be239973f1e7d8437a71683e3dff809",
     )


### PR DESCRIPTION
## What is the goal of this PR?

We now print the inner exception for debugging purposes when the client fails to connect to Grakn, as this can be for a multitude of reasons. Also, the Grakn Cluster artifact listed in artifacts.bzl was only a temporary one - we replaced it with a deployed one.

## What are the changes implemented in this PR?

- Print inner exception when client fails to connect to Grakn
- Update Grakn Cluster artifact
