### PR TITLE
Make Database.toString always just return the DB name, even in Cluster

### DIFF
--- a/GraknClient.java
+++ b/GraknClient.java
@@ -55,6 +55,10 @@ public interface GraknClient extends AutoCloseable {
 
     void close();
 
+    boolean isCluster();
+
+    GraknClient.Cluster asCluster();
+
     interface Cluster extends GraknClient {
 
         @Override

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -28,26 +28,25 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
     public static class Client extends ErrorMessage {
         public static final Client TRANSACTION_CLOSED =
                 new Client(1, "The transaction has been closed and no further operation is allowed.");
+        public static final Client UNABLE_TO_CONNECT = new Client(2, "Unable to connect to Grakn server.");
         public static final Client NEGATIVE_VALUE_NOT_ALLOWED =
-                new Client(2, "Value cannot be less than 1, was: '%d'.");
+                new Client(3, "Value cannot be less than 1, was: '%d'.");
         public static final Client MISSING_DB_NAME =
-                new Client(3, "Database name cannot be null.");
+                new Client(4, "Database name cannot be null.");
         public static final Client DB_DOES_NOT_EXIST =
-                new Client(4, "The database '%s' does not exist.");
+                new Client(5, "The database '%s' does not exist.");
         public static final Client MISSING_RESPONSE =
-                new Client(5, "The required field 'res' of type '%s' was not set.");
+                new Client(6, "The required field 'res' of type '%s' was not set.");
         public static final Client UNKNOWN_REQUEST_ID =
-                new Client(6, "Received a response with unknown request id '%s'.")  ;
-        public static final Client ILLEGAL_ARGUMENT = new Client(7, "Illegal argument passed into the method: '%s'.");
-        public static final Client UNABLE_TO_CONNECT = new Client(8, "Unable to connect to Grakn server.");
+                new Client(7, "Received a response with unknown request id '%s'.");
         public static final Client CLUSTER_NO_PRIMARY_REPLICA_YET =
-                new Client(9, "No replica has been marked as the primary replica for latest known term '%d'.");
+                new Client(8, "No replica has been marked as the primary replica for latest known term '%d'.");
         public static final Client CLUSTER_UNABLE_TO_CONNECT =
-                new Client(10, "Unable to connect to Grakn Cluster. Attempted connecting to the cluster members, but none are available: '%s'.");
+                new Client(9, "Unable to connect to Grakn Cluster. Attempted connecting to the cluster members, but none are available: '%s'.");
         public static final Client CLUSTER_REPLICA_NOT_PRIMARY =
-                new Client(11, "The replica is not the primary replica");
+                new Client(10, "The replica is not the primary replica");
         public static final Client CLUSTER_ALL_NODES_FAILED =
-                new Client(12, "Attempted connecting to all cluster members, but the following errors occurred: %s");
+                new Client(11, "Attempted connecting to all cluster members, but the following errors occurred: %s");
 
         private static final String codePrefix = "CLI";
         private static final String messagePrefix = "Illegal Client Operation";

--- a/rpc/ClientRPC.java
+++ b/rpc/ClientRPC.java
@@ -21,11 +21,15 @@ package grakn.client.rpc;
 
 import grakn.client.GraknClient;
 import grakn.client.GraknOptions;
+import grakn.client.common.exception.GraknClientException;
 import io.grpc.Channel;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 
 import java.util.concurrent.TimeUnit;
+
+import static grakn.client.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
+import static grakn.common.util.Objects.className;
 
 public class ClientRPC implements GraknClient {
 
@@ -64,6 +68,16 @@ public class ClientRPC implements GraknClient {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
+    }
+
+    @Override
+    public boolean isCluster() {
+        return false;
+    }
+
+    @Override
+    public Cluster asCluster() {
+        throw new GraknClientException(ILLEGAL_CAST.message(className(GraknClient.class), className(GraknClient.Cluster.class)));
     }
 
     public Channel channel() {

--- a/rpc/cluster/ClientClusterRPC.java
+++ b/rpc/cluster/ClientClusterRPC.java
@@ -112,6 +112,16 @@ public class ClientClusterRPC implements GraknClient.Cluster {
         isOpen = false;
     }
 
+    @Override
+    public boolean isCluster() {
+        return true;
+    }
+
+    @Override
+    public Cluster asCluster() {
+        return this;
+    }
+
     ConcurrentMap<String, DatabaseClusterRPC> clusterDatabases() {
         return clusterDatabases;
     }

--- a/rpc/cluster/DatabaseClusterRPC.java
+++ b/rpc/cluster/DatabaseClusterRPC.java
@@ -90,11 +90,6 @@ class DatabaseClusterRPC implements GraknClient.Database.Cluster {
         return replicas;
     }
 
-    @Override
-    public String toString() {
-        return replicas.toString();
-    }
-
     static class Replica implements GraknClient.Database.Replica {
         private final Replica.Id id;
         private final DatabaseClusterRPC database;


### PR DESCRIPTION
## What is the goal of this PR?

Previously, `Database.Cluster.toString()` was returning a stringified Replica set: `"["0.0.0.1:1729:1730/grakn:P:1", "0.0.0.2:1729:1730/grakn:S:1", "0.0.0.3:1729:1730/grakn:S:1"]"`. That's too much information when stringifying a database - the database name is enough, just as it is in Core.

Also, we added methods to `GraknClient`: `isCluster` and `asCluster`.

## What are the changes implemented in this PR?

Make Database.toString always just return the db name
Add `isCluster`, `asCluster` to `GraknClient`
