### PR TITLE
Make DatabaseCluster.toString print the database name

### DIFF
--- a/rpc/cluster/DatabaseClusterRPC.java
+++ b/rpc/cluster/DatabaseClusterRPC.java
@@ -90,6 +90,11 @@ class DatabaseClusterRPC implements GraknClient.Database.Cluster {
         return replicas;
     }
 
+    @Override
+    public String toString() {
+        return name;
+    }
+
     static class Replica implements GraknClient.Database.Replica {
         private final Replica.Id id;
         private final DatabaseClusterRPC database;


### PR DESCRIPTION
## What is the goal of this PR?

DatabaseCluster.toString was not overridden, so it just used the default implementation. Now, we've made it return the database name.

## What are the changes implemented in this PR?

Make DatabaseCluster.toString print the database name
