### PR TITLE
Add option to enable inference tracing

### DIFF
--- a/GraknOptions.java
+++ b/GraknOptions.java
@@ -28,7 +28,7 @@ import static grakn.client.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
 
 public class GraknOptions {
     private Boolean infer = null;
-    private Boolean inferLog = null;
+    private Boolean traceInference = null;
     private Boolean explain = null;
     private Integer batchSize = null;
     private Boolean prefetch = null;
@@ -58,12 +58,12 @@ public class GraknOptions {
         return this;
     }
 
-    public Optional<Boolean> inferLog() {
-        return Optional.ofNullable(inferLog);
+    public Optional<Boolean> traceInference() {
+        return Optional.ofNullable(traceInference);
     }
 
-    public GraknOptions inferLog(boolean inferLog) {
-        this.inferLog = inferLog;
+    public GraknOptions traceInference(boolean traceInference) {
+        this.traceInference = traceInference;
         return this;
     }
 

--- a/GraknOptions.java
+++ b/GraknOptions.java
@@ -27,8 +27,8 @@ import static grakn.client.common.exception.ErrorMessage.Client.NEGATIVE_VALUE_N
 import static grakn.client.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
 
 public class GraknOptions {
-    private Boolean inference = null;
-    private Boolean inferenceLogging = null;
+    private Boolean infer = null;
+    private Boolean inferLog = null;
     private Boolean explain = null;
     private Integer batchSize = null;
     private Boolean prefetch = null;
@@ -49,21 +49,21 @@ public class GraknOptions {
 
     GraknOptions() {}
 
-    public Optional<Boolean> inference() {
-        return Optional.ofNullable(inference);
+    public Optional<Boolean> infer() {
+        return Optional.ofNullable(infer);
     }
 
-    public GraknOptions inference(boolean inference) {
-        this.inference = inference;
+    public GraknOptions infer(boolean infer) {
+        this.infer = infer;
         return this;
     }
 
-    public Optional<Boolean> inferenceLogging() {
-        return Optional.ofNullable(inferenceLogging);
+    public Optional<Boolean> inferLog() {
+        return Optional.ofNullable(inferLog);
     }
 
-    public GraknOptions inferenceLogging(boolean inferenceLogging) {
-        this.inferenceLogging = inferenceLogging;
+    public GraknOptions inferLog(boolean inferLog) {
+        this.inferLog = inferLog;
         return this;
     }
 

--- a/GraknOptions.java
+++ b/GraknOptions.java
@@ -27,7 +27,8 @@ import static grakn.client.common.exception.ErrorMessage.Client.NEGATIVE_VALUE_N
 import static grakn.client.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
 
 public class GraknOptions {
-    private Boolean infer = null;
+    private Boolean inference = null;
+    private Boolean inferenceLogging = null;
     private Boolean explain = null;
     private Integer batchSize = null;
     private Boolean prefetch = null;
@@ -48,12 +49,21 @@ public class GraknOptions {
 
     GraknOptions() {}
 
-    public Optional<Boolean> infer() {
-        return Optional.ofNullable(infer);
+    public Optional<Boolean> inference() {
+        return Optional.ofNullable(inference);
     }
 
-    public GraknOptions infer(boolean infer) {
-        this.infer = infer;
+    public GraknOptions inference(boolean inference) {
+        this.inference = inference;
+        return this;
+    }
+
+    public Optional<Boolean> inferenceLogging() {
+        return Optional.ofNullable(inferenceLogging);
+    }
+
+    public GraknOptions inferenceLogging(boolean inferenceLogging) {
+        this.inferenceLogging = inferenceLogging;
         return this;
     }
 

--- a/common/proto/OptionsProtoBuilder.java
+++ b/common/proto/OptionsProtoBuilder.java
@@ -27,7 +27,7 @@ public abstract class OptionsProtoBuilder {
     public static OptionsProto.Options options(GraknOptions options) {
         final OptionsProto.Options.Builder builder = OptionsProto.Options.newBuilder();
         options.infer().ifPresent(builder::setInfer);
-        options.inferLog().ifPresent(builder::setInferLog);
+        options.traceInference().ifPresent(builder::setTraceInference);
         options.explain().ifPresent(builder::setExplain);
         options.batchSize().ifPresent(builder::setBatchSize);
         options.prefetch().ifPresent(builder::setPrefetch);

--- a/common/proto/OptionsProtoBuilder.java
+++ b/common/proto/OptionsProtoBuilder.java
@@ -26,8 +26,8 @@ public abstract class OptionsProtoBuilder {
 
     public static OptionsProto.Options options(GraknOptions options) {
         final OptionsProto.Options.Builder builder = OptionsProto.Options.newBuilder();
-        options.inference().ifPresent(builder::setInference);
-        options.inferenceLogging().ifPresent(builder::setInferenceLogging);
+        options.infer().ifPresent(builder::setInfer);
+        options.inferLog().ifPresent(builder::setInferLog);
         options.explain().ifPresent(builder::setExplain);
         options.batchSize().ifPresent(builder::setBatchSize);
         options.prefetch().ifPresent(builder::setPrefetch);

--- a/common/proto/OptionsProtoBuilder.java
+++ b/common/proto/OptionsProtoBuilder.java
@@ -26,7 +26,8 @@ public abstract class OptionsProtoBuilder {
 
     public static OptionsProto.Options options(GraknOptions options) {
         final OptionsProto.Options.Builder builder = OptionsProto.Options.newBuilder();
-        options.infer().ifPresent(builder::setInfer);
+        options.inference().ifPresent(builder::setInference);
+        options.inferenceLogging().ifPresent(builder::setInferenceLogging);
         options.explain().ifPresent(builder::setExplain);
         options.batchSize().ifPresent(builder::setBatchSize);
         options.prefetch().ifPresent(builder::setPrefetch);

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -43,8 +43,8 @@ def graknlabs_dependencies():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/jmsfltchr/protocol",
-        commit = "9d52b652619058d539c3edefca3714ec8f46ed25", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/graknlabs/protocol",
+        commit = "7c78ea569d33324214c9867b4952d6d4c16c45df", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -44,7 +44,7 @@ def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/jmsfltchr/protocol",
-        commit = "68f745cd4696d9f3696c7bcd310ab284c99bebc5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "d46172adcf1fcb40d82d7cfeab42d3e2a95485b8", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -44,7 +44,7 @@ def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/jmsfltchr/protocol",
-        commit = "d46172adcf1fcb40d82d7cfeab42d3e2a95485b8", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "9d52b652619058d539c3edefca3714ec8f46ed25", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -43,8 +43,8 @@ def graknlabs_dependencies():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/graknlabs/protocol",
-        commit = "b63c9b9b5027d354107dc0c22f61d5f5aaa224ed", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/jmsfltchr/protocol",
+        commit = "68f745cd4696d9f3696c7bcd310ab284c99bebc5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():


### PR DESCRIPTION
## What is the goal of this PR?

We introduce a new option to allow tracing the internals of Grakn's reasoner.

## What are the changes implemented in this PR?

- Adds a new option, the flag `traceInference`.

Requires https://github.com/graknlabs/protocol/pull/122