### PR TITLE
Store more complete cluster address information

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -103,6 +103,8 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
                 new Internal(1, "Unexpected thread interruption!");
         public static final Internal ILLEGAL_CAST =
                 new Internal(2, "Illegal casting operation to '%s'.");
+        public static final Internal ILLEGAL_ARGUMENT =
+                new Internal(3, "Illegal argument provided: '%s'");
 
         private static final String codePrefix = "INT";
         private static final String messagePrefix = "Internal Error";

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -37,5 +37,5 @@ def graknlabs_grakn_cluster_artifacts():
         artifact_name = "grakn-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "a5cf161f63b33010009c63e2b955d2fa81e4e736",
+        commit = "ae8aeb4919887d96aca24aa9029e9827b6437b35",
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -30,7 +30,7 @@ def graknlabs_common():
     git_repository(
         name = "graknlabs_common",
         remote = "https://github.com/graknlabs/common",
-        tag = "2.0.0-alpha-9" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
+        commit = "5b985e0df5356c4daead52e823e1295b9e78dd56" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 
 def graknlabs_dependencies():

--- a/rpc/cluster/ServerAddress.java
+++ b/rpc/cluster/ServerAddress.java
@@ -19,63 +19,87 @@
 
 package grakn.client.rpc.cluster;
 
+import grakn.client.common.exception.GraknClientException;
 import java.util.Objects;
 
+import static grakn.client.common.exception.ErrorMessage.Internal.ILLEGAL_ARGUMENT;
 import static java.lang.Integer.parseInt;
 
 public class ServerAddress {
-    private final String host;
+    private final String clientHost;
     private final int clientPort;
+    private final String serverHost;
     private final int serverPort;
 
     public ServerAddress(String host, int clientPort, int serverPort) {
-        this.host = host;
+        this(host, clientPort, host, serverPort);
+    }
+
+    public ServerAddress(String clientHost, int clientPort, String serverHost, int serverPort) {
+        this.clientHost = clientHost;
         this.clientPort = clientPort;
+        this.serverHost = serverHost;
         this.serverPort = serverPort;
     }
 
     static ServerAddress parse(String address) {
-        String[] split = address.split(":");
-        return new ServerAddress(split[0], parseInt(split[1]), parseInt(split[2]));
+        String[] s1 = address.split(",");
+        if (s1.length == 1) {
+            String[] s2 = address.split(":");
+            return new ServerAddress(s2[0], parseInt(s2[1]), s2[0], parseInt(s2[2]));
+        } else if (s1.length == 2) {
+            String[] clientAddress = s1[0].split(":");
+            if (clientAddress.length != 2) throw new GraknClientException(ILLEGAL_ARGUMENT.message(address));
+
+            String[] serverAddress = s1[1].split(":");
+            if (serverAddress.length != 2) throw new GraknClientException(ILLEGAL_ARGUMENT.message(address));
+
+            return new ServerAddress(clientAddress[0], parseInt(clientAddress[1]), serverAddress[0], parseInt(serverAddress[1]));
+        } else throw new GraknClientException(ILLEGAL_ARGUMENT.message(address));
     }
 
-    public String host() {
-        return host;
+    public String client() {
+        return clientHost + ":" + clientPort;
+    }
+
+    public String clientHost() {
+        return clientHost;
     }
 
     public int clientPort() {
         return clientPort;
     }
 
+    public String server() {
+        return clientHost + ":" + serverPort;
+    }
+
+    public String serverHost() {
+        return serverHost;
+    }
+
     public int serverPort() {
         return serverPort;
     }
 
-    public String server() {
-        return host + ":" + serverPort;
-    }
-
-    public String client() {
-        return host + ":" + clientPort;
+    @Override
+    public String toString() {
+        return clientHost + ":" + clientPort + "," + serverHost + ":" + serverPort;
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        ServerAddress serverAddress = (ServerAddress) o;
-        return clientPort == serverAddress.clientPort &&
-                serverPort == serverAddress.serverPort &&
-                Objects.equals(host, serverAddress.host);
+        ServerAddress that = (ServerAddress) o;
+        return clientPort == that.clientPort &&
+                serverPort == that.serverPort &&
+                Objects.equals(clientHost, that.clientHost) &&
+                Objects.equals(serverHost, that.serverHost);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(host, clientPort, serverPort);
-    }
-
-    @Override
-    public String toString() {
-        return host + ":" + clientPort + ":" + serverPort;
+        return Objects.hash(clientHost, clientPort, serverHost, serverPort);
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

We've updated `client-java` to store both "client address" and "server address". The former is the address that the client will use when connecting to the cluster, whereas the latter is the address that a cluster member use to talk to its peers.

## What are the changes implemented in this PR?

1. Update the `ServerAddress` class to also include server address