### PR TITLE
Parallelise Graql Definable tests

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -122,9 +122,6 @@ build:
         owner: graknlabs
         branch: master
       command: |
-        export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
-        bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
         bazel run //test:grakn-extractor-linux -- dist/grakn-core-all-linux
         ./dist/grakn-core-all-linux/grakn server &
         sed -i -e "s/CLIENT_JAVA_VERSION_MARKER/$GRABL_COMMIT/g" test/deployment/pom.xml

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -103,11 +103,8 @@ build:
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        bazel test //test/behaviour/graql/language/define:checkstyle --test_output=streamed
-        bazel test //test/behaviour/graql/language/define:test-core --test_output=streamed --jobs=1
-        bazel test //test/behaviour/graql/language/undefine:checkstyle --test_output=streamed
-        bazel test //test/behaviour/graql/language/undefine:test-core --test_output=streamed --jobs=1
-    # TODO: turn on cluster tests once cluster tests pass for definable
+        bazel test //test/behaviour/graql/language/define/... --test_output=errors
+        bazel test //test/behaviour/graql/language/undefine/... --test_output=errors
     deploy-maven-snapshot:
       image: graknlabs-ubuntu-20.04
       dependencies: [build, build-dependency, test-behaviour-connection, test-behaviour-concept, test-behaviour-match] # , test-behaviour-writable, test-behaviour-definable

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -44,7 +44,7 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
         public static final Client CLUSTER_UNABLE_TO_CONNECT =
                 new Client(9, "Unable to connect to Grakn Cluster. Attempted connecting to the cluster members, but none are available: '%s'.");
         public static final Client CLUSTER_REPLICA_NOT_PRIMARY =
-                new Client(10, "The replica is not the primary replica");
+                new Client(10, "The replica is not the primary replica.");
         public static final Client CLUSTER_ALL_NODES_FAILED =
                 new Client(11, "Attempted connecting to all cluster members, but the following errors occurred: \n%s");
 

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -49,7 +49,7 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
                 new Client(11, "Attempted connecting to all cluster members, but the following errors occurred: \n%s");
 
         private static final String codePrefix = "CLI";
-        private static final String messagePrefix = "Illegal Client Operation";
+        private static final String messagePrefix = "Client Error";
 
         Client(int number, String message) {
             super(codePrefix, number, messagePrefix, message);


### PR DESCRIPTION
## What is the goal of this PR?

Now that our Definable tests pass in Cluster, we've enabled parallelism when running them in CI. This brings them in line with all other Graql tests.

## What are the changes implemented in this PR?

Parallelise Graql Definable tests
