### PR TITLE
Add parallel option

### DIFF
--- a/GraknOptions.java
+++ b/GraknOptions.java
@@ -30,6 +30,7 @@ public class GraknOptions {
     private Boolean infer = null;
     private Boolean traceInference = null;
     private Boolean explain = null;
+    private Boolean parallel = null;
     private Integer batchSize = null;
     private Boolean prefetch = null;
     private Integer sessionIdleTimeout = null;
@@ -73,6 +74,15 @@ public class GraknOptions {
 
     public GraknOptions explain(boolean explain) {
         this.explain = explain;
+        return this;
+    }
+
+    public Optional<Boolean> parallel() {
+        return Optional.ofNullable(parallel);
+    }
+
+    public GraknOptions parallel(boolean parallel) {
+        this.parallel = parallel;
         return this;
     }
 

--- a/common/proto/OptionsProtoBuilder.java
+++ b/common/proto/OptionsProtoBuilder.java
@@ -29,6 +29,7 @@ public abstract class OptionsProtoBuilder {
         options.infer().ifPresent(builder::setInfer);
         options.traceInference().ifPresent(builder::setTraceInference);
         options.explain().ifPresent(builder::setExplain);
+        options.parallel().ifPresent(builder::setParallel);
         options.batchSize().ifPresent(builder::setBatchSize);
         options.prefetch().ifPresent(builder::setPrefetch);
         options.sessionIdleTimeout().ifPresent(builder::setSessionIdleTimeoutMillis);

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -28,6 +28,7 @@ def graknlabs_grakn_core_artifacts():
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
         commit = "c04b5f105914c690cbd54e6bdc6a4eb9dda2b3e7",
+        #        commit = "b8a76edfdfec0ce087d5ea299410b8354d1db5e2",
     )
 
 def graknlabs_grakn_cluster_artifacts():

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,8 +27,7 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "c04b5f105914c690cbd54e6bdc6a4eb9dda2b3e7",
-        #        commit = "b8a76edfdfec0ce087d5ea299410b8354d1db5e2",
+        commit = "bcabfd8df70e9c598307e0b3c24181ac2eb6643b",
     )
 
 def graknlabs_grakn_cluster_artifacts():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -43,8 +43,8 @@ def graknlabs_dependencies():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/flyingsilverfin/protocol",
-        commit = "6845c810abae756d3de1845aede67c13c6902919", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/graknlabs/protocol",
+        commit = "195cedd57551936d42c28b258c820263fcc1b563", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -43,8 +43,8 @@ def graknlabs_dependencies():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/graknlabs/protocol",
-        tag = "2.0.0-alpha-10", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/flyingsilverfin/protocol",
+        commit = "6845c810abae756d3de1845aede67c13c6902919", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():


### PR DESCRIPTION
## What is the goal of this PR?
We allow client-java to set the parallelism of the server explicitly (useful in conjunction with `traceInference`, which is effective only with no parallelism)

## What are the changes implemented in this PR?
* introduce the `parallel` option that allows modifying the server query parallelism settings.
