### PR TITLE
Add 'getType' to local Thing concepts

### DIFF
--- a/concept/proto/ConceptProtoBuilder.java
+++ b/concept/proto/ConceptProtoBuilder.java
@@ -52,7 +52,6 @@ public abstract class ConceptProtoBuilder {
     public static ConceptProto.Thing thing(Thing thing) {
         return ConceptProto.Thing.newBuilder()
                 .setIid(iid(thing.getIID()))
-                .setEncoding(encoding(thing))
                 .build();
     }
 
@@ -111,18 +110,6 @@ public abstract class ConceptProtoBuilder {
 
     public static ByteString iid(String iid) {
         return ByteString.copyFrom(hexStringToBytes(iid));
-    }
-
-    private static ConceptProto.Thing.Encoding encoding(Thing thing) {
-        if (thing.isEntity()) {
-            return ConceptProto.Thing.Encoding.ENTITY;
-        } else if (thing.isRelation()) {
-            return ConceptProto.Thing.Encoding.RELATION;
-        } else if (thing.isAttribute()) {
-            return ConceptProto.Thing.Encoding.ATTRIBUTE;
-        } else {
-            return ConceptProto.Thing.Encoding.UNRECOGNIZED;
-        }
     }
 
     private static ConceptProto.Type.Encoding encoding(Type type) {

--- a/concept/thing/Attribute.java
+++ b/concept/thing/Attribute.java
@@ -28,10 +28,12 @@ import java.util.stream.Stream;
 
 public interface Attribute<VALUE> extends Thing {
 
-    VALUE getValue();
-
     @Override
     AttributeType getType();
+
+    VALUE getValue();
+
+    AttributeType.ValueType getValueType();
 
     @Override
     default boolean isAttribute() {

--- a/concept/thing/Attribute.java
+++ b/concept/thing/Attribute.java
@@ -31,6 +31,9 @@ public interface Attribute<VALUE> extends Thing {
     VALUE getValue();
 
     @Override
+    AttributeType getType();
+
+    @Override
     default boolean isAttribute() {
         return true;
     }
@@ -75,9 +78,6 @@ public interface Attribute<VALUE> extends Thing {
         Stream<? extends Thing> getOwners(ThingType ownerType);
 
         @Override
-        AttributeType getType();
-
-        @Override
         Attribute.Remote<VALUE> asAttribute();
 
         @Override
@@ -104,6 +104,9 @@ public interface Attribute<VALUE> extends Thing {
         }
 
         @Override
+        AttributeType.Boolean getType();
+
+        @Override
         Attribute.Boolean.Remote asRemote(GraknClient.Transaction transaction);
 
         interface Remote extends Attribute.Boolean, Attribute.Remote<java.lang.Boolean> {
@@ -116,6 +119,9 @@ public interface Attribute<VALUE> extends Thing {
         default boolean isLong() {
             return true;
         }
+
+        @Override
+        AttributeType.Long getType();
 
         @Override
         Attribute.Long.Remote asRemote(GraknClient.Transaction transaction);
@@ -132,6 +138,9 @@ public interface Attribute<VALUE> extends Thing {
         }
 
         @Override
+        AttributeType.Double getType();
+
+        @Override
         Attribute.Double.Remote asRemote(GraknClient.Transaction transaction);
 
         interface Remote extends Attribute.Double, Attribute.Remote<java.lang.Double> {
@@ -146,6 +155,9 @@ public interface Attribute<VALUE> extends Thing {
         }
 
         @Override
+        AttributeType.String getType();
+
+        @Override
         Attribute.String.Remote asRemote(GraknClient.Transaction transaction);
 
         interface Remote extends Attribute.String, Attribute.Remote<java.lang.String> {
@@ -158,6 +170,9 @@ public interface Attribute<VALUE> extends Thing {
         default boolean isDateTime() {
             return true;
         }
+
+        @Override
+        AttributeType.DateTime getType();
 
         @Override
         Attribute.DateTime.Remote asRemote(GraknClient.Transaction transaction);

--- a/concept/thing/Entity.java
+++ b/concept/thing/Entity.java
@@ -30,11 +30,11 @@ public interface Entity extends Thing {
     }
 
     @Override
+    EntityType getType();
+
+    @Override
     Entity.Remote asRemote(GraknClient.Transaction transaction);
 
     interface Remote extends Thing.Remote, Entity {
-
-        @Override
-        EntityType getType();
     }
 }

--- a/concept/thing/Relation.java
+++ b/concept/thing/Relation.java
@@ -35,12 +35,12 @@ public interface Relation extends Thing {
     }
 
     @Override
+    RelationType getType();
+
+    @Override
     Relation.Remote asRemote(GraknClient.Transaction transaction);
 
     interface Remote extends Thing.Remote, Relation {
-
-        @Override
-        RelationType getType();
 
         void addPlayer(RoleType roleType, Thing player);
 

--- a/concept/thing/Thing.java
+++ b/concept/thing/Thing.java
@@ -31,6 +31,8 @@ public interface Thing extends Concept {
 
     String getIID();
 
+    ThingType getType();
+
     @Override
     default boolean isThing() {
         return true;
@@ -40,8 +42,6 @@ public interface Thing extends Concept {
     Thing.Remote asRemote(GraknClient.Transaction transaction);
 
     interface Remote extends Concept.Remote, Thing {
-
-        ThingType getType();
 
         void setHas(Attribute<?> attribute);
 

--- a/concept/thing/impl/AttributeImpl.java
+++ b/concept/thing/impl/AttributeImpl.java
@@ -44,7 +44,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
     }
 
     public static AttributeImpl<?> of(ConceptProto.Thing thingProto) {
-        switch (thingProto.getValueType()) {
+        switch (thingProto.getType().getValueType()) {
             case BOOLEAN:
                 return AttributeImpl.Boolean.of(thingProto);
             case LONG:
@@ -57,7 +57,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
                 return AttributeImpl.DateTime.of(thingProto);
             case UNRECOGNIZED:
             default:
-                throw new GraknClientException(BAD_VALUE_TYPE.message(thingProto.getValueType()));
+                throw new GraknClientException(BAD_VALUE_TYPE.message(thingProto.getType().getValueType()));
         }
     }
 

--- a/concept/thing/impl/AttributeImpl.java
+++ b/concept/thing/impl/AttributeImpl.java
@@ -22,6 +22,7 @@ package grakn.client.concept.thing.impl;
 import grakn.client.GraknClient;
 import grakn.client.common.exception.GraknClientException;
 import grakn.client.concept.thing.Attribute;
+import grakn.client.concept.type.AttributeType;
 import grakn.client.concept.type.ThingType;
 import grakn.client.concept.type.impl.AttributeTypeImpl;
 import grakn.protocol.ConceptProto;
@@ -96,6 +97,11 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
     public abstract VALUE getValue();
 
+    @Override
+    public AttributeType.ValueType getValueType() {
+        return getType().getValueType();
+    }
+
     public abstract static class Remote<VALUE> extends ThingImpl.Remote implements Attribute.Remote<VALUE> {
 
         Remote(GraknClient.Transaction transaction, java.lang.String iid) {
@@ -122,6 +128,11 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
         @Override
         public abstract AttributeTypeImpl getType();
+
+        @Override
+        public AttributeType.ValueType getValueType() {
+            return getType().getValueType();
+        }
 
         @Override
         public AttributeImpl.Remote<VALUE> asAttribute() {

--- a/concept/thing/impl/AttributeImpl.java
+++ b/concept/thing/impl/AttributeImpl.java
@@ -62,6 +62,9 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
     }
 
     @Override
+    public abstract AttributeTypeImpl getType();
+
+    @Override
     public AttributeImpl<VALUE> asAttribute() {
         return this;
     }
@@ -118,9 +121,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
         }
 
         @Override
-        public AttributeTypeImpl getType() {
-            return super.getType().asAttributeType();
-        }
+        public abstract AttributeTypeImpl getType();
 
         @Override
         public AttributeImpl.Remote<VALUE> asAttribute() {
@@ -157,18 +158,26 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
     public static class Boolean extends AttributeImpl<java.lang.Boolean> implements Attribute.Boolean {
 
+        private final AttributeTypeImpl.Boolean type;
         private final java.lang.Boolean value;
 
-        Boolean(java.lang.String iid, boolean value) {
+        Boolean(java.lang.String iid, AttributeTypeImpl.Boolean type, boolean value) {
             super(iid);
+            this.type = type;
             this.value = value;
         }
 
         public static AttributeImpl.Boolean of(ConceptProto.Thing thingProto) {
             return new AttributeImpl.Boolean(
                     bytesToHexString(thingProto.getIid().toByteArray()),
+                    AttributeTypeImpl.Boolean.of(thingProto.getType()),
                     thingProto.getValue().getBoolean()
             );
+        }
+
+        @Override
+        public final AttributeTypeImpl.Boolean getType() {
+            return type;
         }
 
         @Override
@@ -183,21 +192,23 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
         @Override
         public AttributeImpl.Boolean.Remote asRemote(GraknClient.Transaction transaction) {
-            return new AttributeImpl.Boolean.Remote(transaction, getIID(), value);
+            return new AttributeImpl.Boolean.Remote(transaction, getIID(), type, value);
         }
 
         public static class Remote extends AttributeImpl.Remote<java.lang.Boolean> implements Attribute.Boolean.Remote {
 
+            private final AttributeTypeImpl.Boolean type;
             private final java.lang.Boolean value;
 
-            Remote(GraknClient.Transaction transaction, java.lang.String iid, java.lang.Boolean value) {
+            Remote(GraknClient.Transaction transaction, java.lang.String iid, AttributeTypeImpl.Boolean type, java.lang.Boolean value) {
                 super(transaction, iid);
+                this.type = type;
                 this.value = value;
             }
 
             @Override
             public Attribute.Boolean.Remote asRemote(GraknClient.Transaction transaction) {
-                return new AttributeImpl.Boolean.Remote(transaction, getIID(), value);
+                return new AttributeImpl.Boolean.Remote(transaction, getIID(), type, value);
             }
 
             @Override
@@ -207,7 +218,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
             @Override
             public AttributeTypeImpl.Boolean getType() {
-                return super.getType().asBoolean();
+                return type;
             }
 
             @Override
@@ -219,23 +230,26 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
     public static class Long extends AttributeImpl<java.lang.Long> implements Attribute.Long {
 
+        private final AttributeTypeImpl.Long type;
         private final long value;
 
-        Long(java.lang.String iid, long value) {
+        Long(java.lang.String iid, AttributeTypeImpl.Long type, long value) {
             super(iid);
+            this.type = type;
             this.value = value;
         }
 
         public static AttributeImpl.Long of(ConceptProto.Thing thingProto) {
             return new AttributeImpl.Long(
                     bytesToHexString(thingProto.getIid().toByteArray()),
+                    AttributeTypeImpl.Long.of(thingProto.getType()),
                     thingProto.getValue().getLong()
             );
         }
 
         @Override
-        public AttributeImpl.Long.Remote asRemote(GraknClient.Transaction transaction) {
-            return new AttributeImpl.Long.Remote(transaction, getIID(), value);
+        public final AttributeTypeImpl.Long getType() {
+            return type;
         }
 
         @Override
@@ -248,18 +262,25 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
             return this;
         }
 
+        @Override
+        public AttributeImpl.Long.Remote asRemote(GraknClient.Transaction transaction) {
+            return new AttributeImpl.Long.Remote(transaction, getIID(), type, value);
+        }
+
         public static class Remote extends AttributeImpl.Remote<java.lang.Long> implements Attribute.Long.Remote {
 
+            private final AttributeTypeImpl.Long type;
             private final long value;
 
-            Remote(GraknClient.Transaction transaction, java.lang.String iid, long value) {
+            Remote(GraknClient.Transaction transaction, java.lang.String iid, AttributeTypeImpl.Long type, long value) {
                 super(transaction, iid);
+                this.type = type;
                 this.value = value;
             }
 
             @Override
             public Attribute.Long.Remote asRemote(GraknClient.Transaction transaction) {
-                return new AttributeImpl.Long.Remote(transaction, getIID(), value);
+                return new AttributeImpl.Long.Remote(transaction, getIID(), type, value);
             }
 
             @Override
@@ -269,7 +290,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
             @Override
             public AttributeTypeImpl.Long getType() {
-                return super.getType().asLong();
+                return type;
             }
 
             @Override
@@ -281,23 +302,26 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
     public static class Double extends AttributeImpl<java.lang.Double> implements Attribute.Double {
 
+        private final AttributeTypeImpl.Double type;
         private final double value;
 
-        Double(java.lang.String iid, double value) {
+        Double(java.lang.String iid, AttributeTypeImpl.Double type, double value) {
             super(iid);
+            this.type = type;
             this.value = value;
         }
 
         public static AttributeImpl.Double of(ConceptProto.Thing thingProto) {
             return new AttributeImpl.Double(
                     bytesToHexString(thingProto.getIid().toByteArray()),
+                    AttributeTypeImpl.Double.of(thingProto.getType()),
                     thingProto.getValue().getDouble()
             );
         }
 
         @Override
-        public AttributeImpl.Double.Remote asRemote(GraknClient.Transaction transaction) {
-            return new AttributeImpl.Double.Remote(transaction, getIID(), value);
+        public final AttributeTypeImpl.Double getType() {
+            return type;
         }
 
         @Override
@@ -310,18 +334,25 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
             return this;
         }
 
+        @Override
+        public AttributeImpl.Double.Remote asRemote(GraknClient.Transaction transaction) {
+            return new AttributeImpl.Double.Remote(transaction, getIID(), type, value);
+        }
+
         public static class Remote extends AttributeImpl.Remote<java.lang.Double> implements Attribute.Double.Remote {
 
+            private final AttributeTypeImpl.Double type;
             private final double value;
 
-            Remote(GraknClient.Transaction transaction, java.lang.String iid, double value) {
+            Remote(GraknClient.Transaction transaction, java.lang.String iid, AttributeTypeImpl.Double type, double value) {
                 super(transaction, iid);
+                this.type = type;
                 this.value = value;
             }
 
             @Override
             public Attribute.Double.Remote asRemote(GraknClient.Transaction transaction) {
-                return new AttributeImpl.Double.Remote(transaction, getIID(), value);
+                return new AttributeImpl.Double.Remote(transaction, getIID(), type, value);
             }
 
             @Override
@@ -331,7 +362,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
             @Override
             public AttributeTypeImpl.Double getType() {
-                return super.getType().asDouble();
+                return type;
             }
 
             @Override
@@ -343,23 +374,26 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
     public static class String extends AttributeImpl<java.lang.String> implements Attribute.String {
 
+        private final AttributeTypeImpl.String type;
         private final java.lang.String value;
 
-        String(java.lang.String iid, java.lang.String value) {
+        String(java.lang.String iid, AttributeTypeImpl.String type, java.lang.String value) {
             super(iid);
+            this.type = type;
             this.value = value;
         }
 
         public static AttributeImpl.String of(ConceptProto.Thing thingProto) {
             return new AttributeImpl.String(
                     bytesToHexString(thingProto.getIid().toByteArray()),
+                    AttributeTypeImpl.String.of(thingProto.getType()),
                     thingProto.getValue().getString()
             );
         }
 
         @Override
-        public AttributeImpl.String.Remote asRemote(GraknClient.Transaction transaction) {
-            return new AttributeImpl.String.Remote(transaction, getIID(), value);
+        public final AttributeTypeImpl.String getType() {
+            return type;
         }
 
         @Override
@@ -372,13 +406,25 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
             return this;
         }
 
+        @Override
+        public AttributeImpl.String.Remote asRemote(GraknClient.Transaction transaction) {
+            return new AttributeImpl.String.Remote(transaction, getIID(), type, value);
+        }
+
         public static class Remote extends AttributeImpl.Remote<java.lang.String> implements Attribute.String.Remote {
 
+            private final AttributeTypeImpl.String type;
             private final java.lang.String value;
 
-            Remote(GraknClient.Transaction transaction, java.lang.String iid, java.lang.String value) {
+            Remote(GraknClient.Transaction transaction, java.lang.String iid, AttributeTypeImpl.String type, java.lang.String value) {
                 super(transaction, iid);
+                this.type = type;
                 this.value = value;
+            }
+
+            @Override
+            public Attribute.String.Remote asRemote(GraknClient.Transaction transaction) {
+                return new AttributeImpl.String.Remote(transaction, getIID(), type, value);
             }
 
             @Override
@@ -387,13 +433,8 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
             }
 
             @Override
-            public Attribute.String.Remote asRemote(GraknClient.Transaction transaction) {
-                return new AttributeImpl.String.Remote(transaction, getIID(), value);
-            }
-
-            @Override
             public AttributeTypeImpl.String getType() {
-                return super.getType().asString();
+                return type;
             }
 
             @Override
@@ -405,23 +446,26 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
     public static class DateTime extends AttributeImpl<LocalDateTime> implements Attribute.DateTime {
 
+        private final AttributeTypeImpl.DateTime type;
         private final LocalDateTime value;
 
-        DateTime(java.lang.String iid, LocalDateTime value) {
+        DateTime(java.lang.String iid, AttributeTypeImpl.DateTime type, LocalDateTime value) {
             super(iid);
+            this.type = type;
             this.value = value;
         }
 
         public static AttributeImpl.DateTime of(ConceptProto.Thing thingProto) {
             return new AttributeImpl.DateTime(
                     bytesToHexString(thingProto.getIid().toByteArray()),
+                    AttributeTypeImpl.DateTime.of(thingProto.getType()),
                     toLocalDateTime(thingProto.getValue().getDateTime())
             );
         }
 
         @Override
-        public AttributeImpl.DateTime.Remote asRemote(GraknClient.Transaction transaction) {
-            return new AttributeImpl.DateTime.Remote(transaction, getIID(), value);
+        public final AttributeTypeImpl.DateTime getType() {
+            return type;
         }
 
         @Override
@@ -434,22 +478,29 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
             return this;
         }
 
+        @Override
+        public AttributeImpl.DateTime.Remote asRemote(GraknClient.Transaction transaction) {
+            return new AttributeImpl.DateTime.Remote(transaction, getIID(), type, value);
+        }
+
         private static LocalDateTime toLocalDateTime(long rpcDatetime) {
             return LocalDateTime.ofInstant(Instant.ofEpochMilli(rpcDatetime), ZoneId.of("Z"));
         }
 
         public static class Remote extends AttributeImpl.Remote<LocalDateTime> implements Attribute.DateTime.Remote {
 
+            private final AttributeTypeImpl.DateTime type;
             private final LocalDateTime value;
 
-            Remote(GraknClient.Transaction transaction, java.lang.String iid, LocalDateTime value) {
+            Remote(GraknClient.Transaction transaction, java.lang.String iid, AttributeTypeImpl.DateTime type, LocalDateTime value) {
                 super(transaction, iid);
+                this.type = type;
                 this.value = value;
             }
 
             @Override
             public Attribute.DateTime.Remote asRemote(GraknClient.Transaction transaction) {
-                return new AttributeImpl.DateTime.Remote(transaction, getIID(), value);
+                return new AttributeImpl.DateTime.Remote(transaction, getIID(), type, value);
             }
 
             @Override
@@ -459,7 +510,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
             @Override
             public AttributeTypeImpl.DateTime getType() {
-                return super.getType().asDateTime();
+                return type;
             }
 
             @Override

--- a/concept/thing/impl/EntityImpl.java
+++ b/concept/thing/impl/EntityImpl.java
@@ -27,17 +27,25 @@ import grakn.protocol.ConceptProto;
 
 public class EntityImpl extends ThingImpl implements Entity {
 
-    EntityImpl(String iid) {
+    private final EntityTypeImpl type;
+
+    EntityImpl(String iid, EntityTypeImpl type) {
         super(iid);
+        this.type = type;
     }
 
     public static EntityImpl of(ConceptProto.Thing protoThing) {
-        return new EntityImpl(Bytes.bytesToHexString(protoThing.getIid().toByteArray()));
+        return new EntityImpl(Bytes.bytesToHexString(protoThing.getIid().toByteArray()), EntityTypeImpl.of(protoThing.getType()));
+    }
+
+    @Override
+    public EntityTypeImpl getType() {
+        return type;
     }
 
     @Override
     public EntityImpl.Remote asRemote(GraknClient.Transaction transaction) {
-        return new EntityImpl.Remote(transaction, getIID());
+        return new EntityImpl.Remote(transaction, getIID(), type);
     }
 
     @Override
@@ -47,18 +55,21 @@ public class EntityImpl extends ThingImpl implements Entity {
 
     public static class Remote extends ThingImpl.Remote implements Entity.Remote {
 
-        public Remote(GraknClient.Transaction transaction, String iid) {
+        private final EntityTypeImpl type;
+
+        public Remote(GraknClient.Transaction transaction, String iid, EntityTypeImpl type) {
             super(transaction, iid);
+            this.type = type;
         }
 
         @Override
         public EntityImpl.Remote asRemote(GraknClient.Transaction transaction) {
-            return new EntityImpl.Remote(transaction, getIID());
+            return new EntityImpl.Remote(transaction, getIID(), type);
         }
 
         @Override
         public EntityTypeImpl getType() {
-            return super.getType().asEntityType();
+            return type;
         }
 
         @Override

--- a/concept/thing/impl/RelationImpl.java
+++ b/concept/thing/impl/RelationImpl.java
@@ -45,17 +45,25 @@ import static grakn.client.concept.proto.ConceptProtoBuilder.types;
 
 public class RelationImpl extends ThingImpl implements Relation {
 
-    RelationImpl(String iid) {
+    private final RelationTypeImpl type;
+
+    RelationImpl(String iid, RelationTypeImpl type) {
         super(iid);
+        this.type = type;
     }
 
     public static RelationImpl of(ConceptProto.Thing protoThing) {
-        return new RelationImpl(Bytes.bytesToHexString(protoThing.getIid().toByteArray()));
+        return new RelationImpl(Bytes.bytesToHexString(protoThing.getIid().toByteArray()), RelationTypeImpl.of(protoThing.getType()));
     }
 
     @Override
     public RelationImpl.Remote asRemote(GraknClient.Transaction transaction) {
-        return new RelationImpl.Remote(transaction, getIID());
+        return new RelationImpl.Remote(transaction, getIID(), type);
+    }
+
+    @Override
+    public RelationTypeImpl getType() {
+        return type;
     }
 
     @Override
@@ -65,18 +73,21 @@ public class RelationImpl extends ThingImpl implements Relation {
 
     public static class Remote extends ThingImpl.Remote implements Relation.Remote {
 
-        public Remote(GraknClient.Transaction transaction, String iid) {
+        private final RelationTypeImpl type;
+
+        public Remote(GraknClient.Transaction transaction, String iid, RelationTypeImpl type) {
             super(transaction, iid);
+            this.type = type;
         }
 
         @Override
         public RelationImpl.Remote asRemote(GraknClient.Transaction transaction) {
-            return new RelationImpl.Remote(transaction, getIID());
+            return new RelationImpl.Remote(transaction, getIID(), type);
         }
 
         @Override
         public RelationTypeImpl getType() {
-            return super.getType().asRelationType();
+            return type;
         }
 
         @Override

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -50,10 +50,6 @@ import static grakn.common.util.Objects.className;
 public abstract class ThingImpl extends ConceptImpl implements Thing {
 
     private final String iid;
-    // TODO: private final ThingType type;
-    // We need to store the concept Type, but we need a better way of retrieving it (currently requires a 2nd roundtrip)
-    // In 1.8 it was in a "pre-filled response" in ConceptProto.Concept, which was confusing as it was
-    // not actually prefilled when using the Concept API - only when using the Query API.
 
     ThingImpl(String iid) {
         if (iid == null || iid.isEmpty()) throw new GraknClientException(MISSING_IID);
@@ -78,6 +74,9 @@ public abstract class ThingImpl extends ConceptImpl implements Thing {
     public final String getIID() {
         return iid;
     }
+
+    @Override
+    public abstract ThingTypeImpl getType();
 
     @Override
     public ThingImpl asThing() {
@@ -122,11 +121,8 @@ public abstract class ThingImpl extends ConceptImpl implements Thing {
             return iid;
         }
 
-        public ThingTypeImpl getType() {
-            ConceptProto.Thing.Req.Builder method = ConceptProto.Thing.Req.newBuilder()
-                    .setThingGetTypeReq(ConceptProto.Thing.GetType.Req.getDefaultInstance());
-            return TypeImpl.of(execute(method).getThingGetTypeRes().getThingType()).asThingType();
-        }
+        @Override
+        public abstract ThingTypeImpl getType();
 
         @Override
         public final boolean isInferred() {

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -61,16 +61,16 @@ public abstract class ThingImpl extends ConceptImpl implements Thing {
     }
 
     public static ThingImpl of(ConceptProto.Thing thingProto) {
-        switch (thingProto.getEncoding()) {
-            case ENTITY:
+        switch (thingProto.getType().getEncoding()) {
+            case ENTITY_TYPE:
                 return EntityImpl.of(thingProto);
-            case RELATION:
+            case RELATION_TYPE:
                 return RelationImpl.of(thingProto);
-            case ATTRIBUTE:
+            case ATTRIBUTE_TYPE:
                 return AttributeImpl.of(thingProto);
             case UNRECOGNIZED:
             default:
-                throw new GraknClientException(BAD_ENCODING.message(thingProto.getEncoding()));
+                throw new GraknClientException(BAD_ENCODING.message(thingProto.getType().getEncoding()));
         }
     }
 

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -37,5 +37,5 @@ def graknlabs_grakn_cluster_artifacts():
         artifact_name = "grakn-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "ae8aeb4919887d96aca24aa9029e9827b6437b35",
+        commit = "ed8562c26788e506b43c96258c790ea80ec0387d",
     )

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,7 +27,7 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "1c9b8b51bda56f186318fd5a0fb0f22b45f20d67",
+        commit = "8a556849a42a54a0f69277da212540f00b9a783c",
     )
 
 def graknlabs_grakn_cluster_artifacts():

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -37,5 +37,5 @@ def graknlabs_grakn_cluster_artifacts():
         artifact_name = "grakn-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "ed8562c26788e506b43c96258c790ea80ec0387d",
+        commit = "e1e96cdb1d2c5cfd4309221c5003e7d54a341960",
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -44,7 +44,7 @@ def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        tag = "2.0.0-alpha-11", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "db2363760efc2db4973671cd1f550212e2055596", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():

--- a/test/behaviour/concept/thing/ThingSteps.java
+++ b/test/behaviour/concept/thing/ThingSteps.java
@@ -64,7 +64,7 @@ public class ThingSteps {
     @Then("{root_label} {var} has type: {type_label}")
     public void thing_has_type(RootLabel rootLabel, String var, String typeLabel) {
         ThingType type = get_thing_type(rootLabel, typeLabel);
-        assertEquals(type, get(var).asRemote(tx()).getType());
+        assertEquals(type, get(var).getType());
     }
 
     @When("delete entity:/attribute:/relation: {var}")

--- a/test/behaviour/concept/thing/attribute/AttributeSteps.java
+++ b/test/behaviour/concept/thing/attribute/AttributeSteps.java
@@ -51,7 +51,7 @@ public class AttributeSteps {
 
     @Then("attribute {var} has value type: {value_type}")
     public void attribute_has_value_type(String var, ValueType valueType) {
-        assertEquals(valueType, get(var).asAttribute().asRemote(tx()).getType().getValueType());
+        assertEquals(valueType, get(var).asAttribute().getValueType());
     }
 
     @When("{var} = attribute\\( ?{type_label} ?) as\\( ?boolean ?) put: {bool}")

--- a/test/behaviour/concept/thing/entity/EntitySteps.java
+++ b/test/behaviour/concept/thing/entity/EntitySteps.java
@@ -72,22 +72,19 @@ public class EntitySteps {
     @When("{var} = entity\\( ?{type_label} ?) get instance with key\\( ?{type_label} ?): {long}")
     public void entity_type_get_instance_with_key(String var1, String type, String keyType, long keyValue) {
         put(var1, tx().concepts().getAttributeType(keyType).asLong().asRemote(tx()).get(keyValue).asRemote(tx()).getOwners()
-                .filter(owner -> owner.asRemote(tx()).getType().equals(tx().concepts().getEntityType(type)))
-                .findFirst().orElse(null));
+                .filter(owner -> owner.getType().getLabel().equals(type)).findFirst().orElse(null));
     }
 
     @When("{var} = entity\\( ?{type_label} ?) get instance with key\\( ?{type_label} ?): {word}")
     public void entity_type_get_instance_with_key(String var1, String type, String keyType, String keyValue) {
         put(var1, tx().concepts().getAttributeType(keyType).asString().asRemote(tx()).get(keyValue).asRemote(tx()).getOwners()
-                .filter(owner -> owner.asRemote(tx()).getType().equals(tx().concepts().getEntityType(type)))
-                .findFirst().orElse(null));
+                .filter(owner -> owner.getType().getLabel().equals(type)).findFirst().orElse(null));
     }
 
     @When("{var} = entity\\( ?{type_label} ?) get instance with key\\( ?{type_label} ?): {datetime}")
     public void entity_type_get_instance_with_key(String var1, String type, String keyType, LocalDateTime keyValue) {
         put(var1, tx().concepts().getAttributeType(keyType).asDateTime().asRemote(tx()).get(keyValue).asRemote(tx()).getOwners()
-                .filter(owner -> owner.asRemote(tx()).getType().equals(tx().concepts().getEntityType(type)))
-                .findFirst().orElse(null));
+                .filter(owner -> owner.getType().getLabel().equals(type)).findFirst().orElse(null));
     }
 
     @Then("entity\\( ?{type_label} ?) get instances contain: {var}")

--- a/test/behaviour/concept/thing/relation/RelationSteps.java
+++ b/test/behaviour/concept/thing/relation/RelationSteps.java
@@ -76,22 +76,19 @@ public class RelationSteps {
     @When("{var} = relation\\( ?{type_label} ?) get instance with key\\( ?{type_label} ?): {long}")
     public void relation_type_get_instance_with_key(String var1, String type, String keyType, long keyValue) {
         put(var1, tx().concepts().getAttributeType(keyType).asLong().asRemote(tx()).get(keyValue).asRemote(tx()).getOwners()
-                .filter(owner -> owner.asRemote(tx()).getType().equals(tx().concepts().getRelationType(type)))
-                .findFirst().orElse(null));
+                .filter(owner -> owner.getType().getLabel().equals(type)).findFirst().orElse(null));
     }
 
     @When("{var} = relation\\( ?{type_label} ?) get instance with key\\( ?{type_label} ?): {word}")
     public void relation_type_get_instance_with_key(String var1, String type, String keyType, String keyValue) {
         put(var1, tx().concepts().getAttributeType(keyType).asString().asRemote(tx()).get(keyValue).asRemote(tx()).getOwners()
-                .filter(owner -> owner.asRemote(tx()).getType().equals(tx().concepts().getRelationType(type)))
-                .findFirst().orElse(null));
+                .filter(owner -> owner.getType().getLabel().equals(type)).findFirst().orElse(null));
     }
 
     @When("{var} = relation\\( ?{type_label} ?) get instance with key\\( ?{type_label} ?): {datetime}")
     public void relation_type_get_instance_with_key(String var1, String type, String keyType, LocalDateTime keyValue) {
         put(var1, tx().concepts().getAttributeType(keyType).asDateTime().asRemote(tx()).get(keyValue).asRemote(tx()).getOwners()
-                .filter(owner -> owner.asRemote(tx()).getType().equals(tx().concepts().getRelationType(type)))
-                .findFirst().orElse(null));
+                .filter(owner -> owner.getType().getLabel().equals(type)).findFirst().orElse(null));
     }
 
     @Then("relation\\( ?{type_label} ?) get instances contain: {var}")
@@ -111,23 +108,23 @@ public class RelationSteps {
 
     @When("relation {var} add player for role\\( ?{type_label} ?): {var}")
     public void relation_add_player_for_role(String var1, String roleTypeLabel, String var2) {
-        get(var1).asRelation().asRemote(tx()).addPlayer(get(var1).asRelation().asRemote(tx()).getType().asRemote(tx()).getRelates(roleTypeLabel), get(var2));
+        get(var1).asRelation().asRemote(tx()).addPlayer(get(var1).asRelation().getType().asRemote(tx()).getRelates(roleTypeLabel), get(var2));
     }
 
     @When("relation {var} add player for role\\( ?{type_label} ?): {var}; throws exception")
     public void relation_add_player_for_role_throws_exception(String var1, String roleTypeLabel, String var2) {
-        assertThrows(() -> get(var1).asRelation().asRemote(tx()).addPlayer(get(var1).asRelation().asRemote(tx()).getType().asRemote(tx()).getRelates(roleTypeLabel), get(var2)));
+        assertThrows(() -> get(var1).asRelation().asRemote(tx()).addPlayer(get(var1).asRelation().getType().asRemote(tx()).getRelates(roleTypeLabel), get(var2)));
     }
 
     @When("relation {var} remove player for role\\( ?{type_label} ?): {var}")
     public void relation_remove_player_for_role(String var1, String roleTypeLabel, String var2) {
-        get(var1).asRelation().asRemote(tx()).removePlayer(get(var1).asRelation().asRemote(tx()).getType().asRemote(tx()).getRelates(roleTypeLabel), get(var2));
+        get(var1).asRelation().asRemote(tx()).removePlayer(get(var1).asRelation().getType().asRemote(tx()).getRelates(roleTypeLabel), get(var2));
     }
 
     @Then("relation {var} get players contain:")
     public void relation_get_players_contain(String var, Map<String, String> players) {
         Relation relation = get(var).asRelation();
-        players.forEach((rt, var2) -> assertTrue(relation.asRemote(tx()).getPlayersByRoleType().get(relation.asRemote(tx()).getType().asRemote(tx()).getRelates(rt)).contains(get(var2.substring(1)))));
+        players.forEach((rt, var2) -> assertTrue(relation.asRemote(tx()).getPlayersByRoleType().get(relation.getType().asRemote(tx()).getRelates(rt)).contains(get(var2.substring(1)))));
     }
 
     @Then("relation {var} get players do not contain:")
@@ -135,7 +132,7 @@ public class RelationSteps {
         Relation relation = get(var).asRelation();
         players.forEach((rt, var2) -> {
             List<? extends Thing> p;
-            if ((p = relation.asRemote(tx()).getPlayersByRoleType().get(relation.asRemote(tx()).getType().asRemote(tx()).getRelates(rt))) != null) {
+            if ((p = relation.asRemote(tx()).getPlayersByRoleType().get(relation.getType().asRemote(tx()).getRelates(rt))) != null) {
                 assertFalse(p.contains(get(var2.substring(1))));
             }
         });
@@ -154,14 +151,14 @@ public class RelationSteps {
     @Then("relation {var} get players for role\\( ?{type_label} ?) contain: {var}")
     public void relation_get_player_for_role_contain(String var1, String roleTypeLabel, String var2) {
         assertTrue(get(var1).asRelation().asRemote(tx())
-                           .getPlayers(get(var1).asRelation().asRemote(tx()).getType().asRemote(tx()).getRelates(roleTypeLabel))
+                           .getPlayers(get(var1).asRelation().getType().asRemote(tx()).getRelates(roleTypeLabel))
                            .anyMatch(p -> p.equals(get(var2))));
     }
 
     @Then("relation {var} get players for role\\( ?{type_label} ?) do not contain: {var}")
     public void relation_get_player_for_role_do_not_contain(String var1, String roleTypeLabel, String var2) {
         assertTrue(get(var1).asRelation().asRemote(tx())
-                           .getPlayers(get(var1).asRelation().asRemote(tx()).getType().asRemote(tx()).getRelates(roleTypeLabel))
+                           .getPlayers(get(var1).asRelation().getType().asRemote(tx()).getRelates(roleTypeLabel))
                            .noneMatch(p -> p.equals(get(var2))));
     }
 }

--- a/test/behaviour/graql/GraqlSteps.java
+++ b/test/behaviour/graql/GraqlSteps.java
@@ -623,7 +623,7 @@ public class GraqlSteps {
             }
 
             Attribute<?> attribute = concept.asAttribute();
-            AttributeType attributeType = attribute.asRemote(tx()).getType();
+            AttributeType attributeType = attribute.getType();
 
             if (!type.equals(attributeType.getLabel())) {
                 return false;
@@ -668,8 +668,7 @@ public class GraqlSteps {
 
             for (Attribute<?> key : keys) {
                 String keyValue;
-                AttributeType keyType = key.asRemote(tx()).getType();
-                switch (keyType.getValueType()) {
+                switch (key.getValueType()) {
                     case BOOLEAN:
                         keyValue = key.asBoolean().getValue().toString();
                         break;
@@ -687,10 +686,10 @@ public class GraqlSteps {
                         break;
                     case OBJECT:
                     default:
-                        throw new ScenarioDefinitionException("Unrecognised value type " + keyType.getValueType());
+                        throw new ScenarioDefinitionException("Unrecognised value type " + key.getValueType());
                 }
 
-                keyMap.put(keyType.getLabel(), keyValue);
+                keyMap.put(key.getType().getLabel(), keyValue);
             }
             return value.equals(keyMap.get(type));
         }


### PR DESCRIPTION
## What is the goal of this PR?

Previously, `getType` was only available on remote `Thing` concepts. Now, we include type information whenever a Graql query or Concept API method returns a `Thing`, enabling users to use it without an additional network roundtrip per concept.

## What are the changes implemented in this PR?

Add 'getType' to local Thing concepts
