### PR TITLE
Fix possible error failing over any-replica sessions

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,7 +19,6 @@
 
 build --incompatible_strict_action_env --javacopt='--release 8'
 run --incompatible_strict_action_env
-test --incompatible_strict_action_env --test_env=PATH
+test --incompatible_strict_action_env --test_env=PATH --cache_test_results=no
 
 try-import /opt/credentials/bazel-remote-cache.rc
-

--- a/common/exception/GraknClientException.java
+++ b/common/exception/GraknClientException.java
@@ -41,7 +41,9 @@ public class GraknClientException extends RuntimeException {
 
     public static GraknClientException of(StatusRuntimeException statusRuntimeException) {
         // "Received Rst Stream" occurs if the server is in the process of shutting down.
-        if (statusRuntimeException.getStatus().getCode() == Status.Code.UNAVAILABLE || statusRuntimeException.getMessage().contains("Received Rst Stream")) {
+        if (statusRuntimeException.getStatus().getCode() == Status.Code.UNAVAILABLE
+                || statusRuntimeException.getStatus().getCode() == Status.Code.UNKNOWN
+                || statusRuntimeException.getMessage().contains("Received Rst Stream")) {
             return new GraknClientException(ErrorMessage.Client.UNABLE_TO_CONNECT);
         } else if (isReplicaNotPrimaryException(statusRuntimeException)) {
             return new GraknClientException(ErrorMessage.Client.CLUSTER_REPLICA_NOT_PRIMARY);

--- a/test/behaviour/graql/GraqlSteps.java
+++ b/test/behaviour/graql/GraqlSteps.java
@@ -113,12 +113,14 @@ public class GraqlSteps {
     }
 
     @Given("graql insert; throws exception")
+    @SuppressWarnings("ReturnValueIgnored")
     public void graql_insert_throws(String insertQueryStatements) {
         //noinspection ResultOfMethodCallIgnored
         assertThrows(() -> graql_insert(insertQueryStatements).collect(Collectors.toList()));
     }
 
     @Given("graql insert; throws exception containing {string}")
+    @SuppressWarnings("ReturnValueIgnored")
     public void graql_insert_throws_exception(String exception, String insertQueryStatements) {
         //noinspection ResultOfMethodCallIgnored
         assertThrowsWithMessage(() -> graql_insert(insertQueryStatements).collect(Collectors.toList()), exception);

--- a/test/behaviour/graql/GraqlSteps.java
+++ b/test/behaviour/graql/GraqlSteps.java
@@ -114,12 +114,12 @@ public class GraqlSteps {
 
     @Given("graql insert; throws exception")
     public void graql_insert_throws(String insertQueryStatements) {
-        assertThrows(() -> graql_insert(insertQueryStatements).iterator().next());
+        assertThrows(() -> graql_insert(insertQueryStatements).collect(Collectors.toList()));
     }
 
     @Given("graql insert; throws exception containing {string}")
     public void graql_insert_throws_exception(String exception, String insertQueryStatements) {
-        assertThrowsWithMessage(() -> graql_insert(insertQueryStatements).iterator().next(), exception);
+        assertThrowsWithMessage(() -> graql_insert(insertQueryStatements).collect(Collectors.toList()), exception);
     }
 
     @Given("graql delete")

--- a/test/behaviour/graql/GraqlSteps.java
+++ b/test/behaviour/graql/GraqlSteps.java
@@ -114,11 +114,13 @@ public class GraqlSteps {
 
     @Given("graql insert; throws exception")
     public void graql_insert_throws(String insertQueryStatements) {
+        //noinspection ResultOfMethodCallIgnored
         assertThrows(() -> graql_insert(insertQueryStatements).collect(Collectors.toList()));
     }
 
     @Given("graql insert; throws exception containing {string}")
     public void graql_insert_throws_exception(String exception, String insertQueryStatements) {
+        //noinspection ResultOfMethodCallIgnored
         assertThrowsWithMessage(() -> graql_insert(insertQueryStatements).collect(Collectors.toList()), exception);
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

We had logic to catch a gRPC "UNKNOWN" status in primary-replica sessions. Now, we replicate the logic to any-replica sessions.

## What are the changes implemented in this PR?

Fix possible error failing over any-replica sessions