### PR TITLE
Delete getValueType from Attribute

### DIFF
--- a/concept/thing/Attribute.java
+++ b/concept/thing/Attribute.java
@@ -33,8 +33,6 @@ public interface Attribute<VALUE> extends Thing {
 
     VALUE getValue();
 
-    AttributeType.ValueType getValueType();
-
     @Override
     default boolean isAttribute() {
         return true;

--- a/concept/thing/impl/AttributeImpl.java
+++ b/concept/thing/impl/AttributeImpl.java
@@ -97,11 +97,6 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
     public abstract VALUE getValue();
 
-    @Override
-    public AttributeType.ValueType getValueType() {
-        return getType().getValueType();
-    }
-
     public abstract static class Remote<VALUE> extends ThingImpl.Remote implements Attribute.Remote<VALUE> {
 
         Remote(GraknClient.Transaction transaction, java.lang.String iid) {
@@ -128,11 +123,6 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
         @Override
         public abstract AttributeTypeImpl getType();
-
-        @Override
-        public AttributeType.ValueType getValueType() {
-            return getType().getValueType();
-        }
 
         @Override
         public AttributeImpl.Remote<VALUE> asAttribute() {

--- a/test/behaviour/concept/thing/attribute/AttributeSteps.java
+++ b/test/behaviour/concept/thing/attribute/AttributeSteps.java
@@ -51,7 +51,7 @@ public class AttributeSteps {
 
     @Then("attribute {var} has value type: {value_type}")
     public void attribute_has_value_type(String var, ValueType valueType) {
-        assertEquals(valueType, get(var).asAttribute().getValueType());
+        assertEquals(valueType, get(var).asAttribute().getType().getValueType());
     }
 
     @When("{var} = attribute\\( ?{type_label} ?) as\\( ?boolean ?) put: {bool}")

--- a/test/behaviour/graql/GraqlSteps.java
+++ b/test/behaviour/graql/GraqlSteps.java
@@ -672,7 +672,7 @@ public class GraqlSteps {
 
             for (Attribute<?> key : keys) {
                 String keyValue;
-                switch (key.getValueType()) {
+                switch (key.getType().getValueType()) {
                     case BOOLEAN:
                         keyValue = key.asBoolean().getValue().toString();
                         break;
@@ -690,7 +690,7 @@ public class GraqlSteps {
                         break;
                     case OBJECT:
                     default:
-                        throw new ScenarioDefinitionException("Unrecognised value type " + key.getValueType());
+                        throw new ScenarioDefinitionException("Unrecognised value type " + key.getType().getValueType());
                 }
 
                 keyMap.put(key.getType().getLabel(), keyValue);


### PR DESCRIPTION
## What is the goal of this PR?

`getValueType` was pretty redundant on `Attribute`, as it was just a shorthand for `getType().getValueType()`. To keep the API slim, we deleted it.

## What are the changes implemented in this PR?

Delete getValueType from Attribute