### PR TITLE
Clear up redundant methods, reduce code duplication

### DIFF
--- a/api/GraknOptions.java
+++ b/api/GraknOptions.java
@@ -102,7 +102,7 @@ public class GraknOptions {
 
     public GraknOptions batchSize(int batchSize) {
         if (batchSize < 1) {
-            throw new GraknClientException(NEGATIVE_VALUE_NOT_ALLOWED.message(batchSize));
+            throw new GraknClientException(NEGATIVE_VALUE_NOT_ALLOWED, batchSize);
         }
         this.batchSize = batchSize;
         return this;
@@ -125,7 +125,7 @@ public class GraknOptions {
 
     public GraknOptions sessionIdleTimeoutMillis(int sessionIdleTimeoutMillis) {
         if (sessionIdleTimeoutMillis < 1) {
-            throw new GraknClientException(NEGATIVE_VALUE_NOT_ALLOWED.message(sessionIdleTimeoutMillis));
+            throw new GraknClientException(NEGATIVE_VALUE_NOT_ALLOWED, sessionIdleTimeoutMillis);
         }
         this.sessionIdleTimeoutMillis = sessionIdleTimeoutMillis;
         return this;
@@ -138,7 +138,7 @@ public class GraknOptions {
 
     public GraknOptions schemaLockAcquireTimeoutMillis(int schemaLockAcquireTimeoutMillis) {
         if (schemaLockAcquireTimeoutMillis < 1) {
-            throw new GraknClientException(NEGATIVE_VALUE_NOT_ALLOWED.message(schemaLockAcquireTimeoutMillis));
+            throw new GraknClientException(NEGATIVE_VALUE_NOT_ALLOWED, schemaLockAcquireTimeoutMillis);
         }
         this.schemaLockAcquireTimeoutMillis = schemaLockAcquireTimeoutMillis;
         return this;

--- a/api/concept/type/AttributeType.java
+++ b/api/concept/type/AttributeType.java
@@ -34,7 +34,9 @@ import static grakn.client.common.ErrorMessage.Concept.BAD_VALUE_TYPE;
 public interface AttributeType extends ThingType {
 
     @CheckReturnValue
-    ValueType getValueType();
+    default ValueType getValueType() {
+        return ValueType.OBJECT;
+    }
 
     @CheckReturnValue
     boolean isKeyable();
@@ -119,25 +121,6 @@ public interface AttributeType extends ThingType {
         }
 
         @CheckReturnValue
-        public static ValueType of(ConceptProto.AttributeType.ValueType valueType) {
-            switch (valueType) {
-                case STRING:
-                    return AttributeType.ValueType.STRING;
-                case BOOLEAN:
-                    return AttributeType.ValueType.BOOLEAN;
-                case LONG:
-                    return AttributeType.ValueType.LONG;
-                case DOUBLE:
-                    return AttributeType.ValueType.DOUBLE;
-                case DATETIME:
-                    return AttributeType.ValueType.DATETIME;
-                default:
-                case UNRECOGNIZED:
-                    throw new GraknClientException(BAD_VALUE_TYPE.message(valueType));
-            }
-        }
-
-        @CheckReturnValue
         public Class<?> valueClass() {
             return valueClass;
         }
@@ -150,11 +133,6 @@ public interface AttributeType extends ThingType {
         @CheckReturnValue
         public boolean isKeyable() {
             return isKeyable;
-        }
-
-        @Override
-        public java.lang.String toString() {
-            return valueClass.getName();
         }
 
         @CheckReturnValue
@@ -225,6 +203,12 @@ public interface AttributeType extends ThingType {
 
         @Override
         @CheckReturnValue
+        default ValueType getValueType() {
+            return ValueType.BOOLEAN;
+        }
+
+        @Override
+        @CheckReturnValue
         default boolean isBoolean() {
             return true;
         }
@@ -254,6 +238,12 @@ public interface AttributeType extends ThingType {
     }
 
     interface Long extends AttributeType {
+
+        @Override
+        @CheckReturnValue
+        default ValueType getValueType() {
+            return ValueType.LONG;
+        }
 
         @Override
         @CheckReturnValue
@@ -289,6 +279,12 @@ public interface AttributeType extends ThingType {
 
         @Override
         @CheckReturnValue
+        default ValueType getValueType() {
+            return ValueType.DOUBLE;
+        }
+
+        @Override
+        @CheckReturnValue
         default boolean isDouble() {
             return true;
         }
@@ -318,6 +314,12 @@ public interface AttributeType extends ThingType {
     }
 
     interface String extends AttributeType {
+
+        @Override
+        @CheckReturnValue
+        default ValueType getValueType() {
+            return ValueType.STRING;
+        }
 
         @Override
         @CheckReturnValue
@@ -356,6 +358,12 @@ public interface AttributeType extends ThingType {
     }
 
     interface DateTime extends AttributeType {
+
+        @Override
+        @CheckReturnValue
+        default ValueType getValueType() {
+            return ValueType.DATETIME;
+        }
 
         @Override
         @CheckReturnValue

--- a/cluster/ClusterDatabaseManager.java
+++ b/cluster/ClusterDatabaseManager.java
@@ -50,7 +50,7 @@ public class ClusterDatabaseManager implements DatabaseManager.Cluster {
                 errors.append("- ").append(address).append(": ").append(e).append("\n");
             }
         }
-        throw new GraknClientException(CLUSTER_ALL_NODES_FAILED.message(errors.toString()));
+        throw new GraknClientException(CLUSTER_ALL_NODES_FAILED, errors.toString());
     }
 
     @Override
@@ -75,7 +75,7 @@ public class ClusterDatabaseManager implements DatabaseManager.Cluster {
                 errors.append("- ").append(address).append(": ").append(e).append("\n");
             }
         }
-        throw new GraknClientException(CLUSTER_ALL_NODES_FAILED.message(errors.toString()));
+        throw new GraknClientException(CLUSTER_ALL_NODES_FAILED, errors.toString());
     }
 
     @Override
@@ -90,7 +90,7 @@ public class ClusterDatabaseManager implements DatabaseManager.Cluster {
                 errors.append("- ").append(address).append(": ").append(e).append("\n");
             }
         }
-        throw new GraknClientException(CLUSTER_ALL_NODES_FAILED.message(errors.toString()));
+        throw new GraknClientException(CLUSTER_ALL_NODES_FAILED, errors.toString());
     }
 
     Map<String, CoreDatabaseManager> databaseManagers() {

--- a/common/GraknClientException.java
+++ b/common/GraknClientException.java
@@ -35,11 +35,6 @@ public class GraknClientException extends RuntimeException {
         this.errorMessage = error;
     }
 
-    public GraknClientException(Throwable e) {
-        super(e);
-        this.errorMessage = null;
-    }
-
     public GraknClientException(String message, Throwable cause) {
         super(message, cause);
         this.errorMessage = null;

--- a/common/GraknClientException.java
+++ b/common/GraknClientException.java
@@ -35,6 +35,16 @@ public class GraknClientException extends RuntimeException {
         this.errorMessage = error;
     }
 
+    public GraknClientException(Throwable e) {
+        super(e);
+        this.errorMessage = null;
+    }
+
+    public GraknClientException(String message, Throwable cause) {
+        super(message, cause);
+        this.errorMessage = null;
+    }
+
     public static GraknClientException of(StatusRuntimeException statusRuntimeException) {
         // "Received Rst Stream" occurs if the server is in the process of shutting down.
         if (statusRuntimeException.getStatus().getCode() == Status.Code.UNAVAILABLE
@@ -45,16 +55,6 @@ public class GraknClientException extends RuntimeException {
             return new GraknClientException(ErrorMessage.Client.CLUSTER_REPLICA_NOT_PRIMARY);
         }
         return new GraknClientException(statusRuntimeException.getStatus().getDescription(), statusRuntimeException);
-    }
-
-    public GraknClientException(Exception e) {
-        super(e);
-        this.errorMessage = null;
-    }
-
-    public GraknClientException(String message, Throwable cause) {
-        super(message, cause);
-        this.errorMessage = null;
     }
 
     public String getName() {

--- a/common/GraknClientException.java
+++ b/common/GraknClientException.java
@@ -29,11 +29,6 @@ public class GraknClientException extends RuntimeException {
     @Nullable
     private final ErrorMessage errorMessage;
 
-    public GraknClientException(String error) {
-        super(error);
-        this.errorMessage = null;
-    }
-
     public GraknClientException(ErrorMessage error, Object... parameters) {
         super(error.message(parameters));
         assert !getMessage().contains("%s");

--- a/concept/ConceptImpl.java
+++ b/concept/ConceptImpl.java
@@ -62,52 +62,52 @@ public abstract class ConceptImpl implements Concept {
 
     @Override
     public TypeImpl asType() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Type.class)));
+        throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Type.class));
     }
 
     @Override
     public ThingTypeImpl asThingType() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(ThingType.class)));
+        throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(ThingType.class));
     }
 
     @Override
     public EntityTypeImpl asEntityType() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(EntityType.class)));
+        throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(EntityType.class));
     }
 
     @Override
     public AttributeTypeImpl asAttributeType() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(AttributeType.class)));
+        throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(AttributeType.class));
     }
 
     @Override
     public RelationTypeImpl asRelationType() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(RelationType.class)));
+        throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(RelationType.class));
     }
 
     @Override
     public RoleTypeImpl asRoleType() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(RoleType.class)));
+        throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(RoleType.class));
     }
 
     @Override
     public ThingImpl asThing() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Thing.class)));
+        throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Thing.class));
     }
 
     @Override
     public EntityImpl asEntity() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Entity.class)));
+        throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Entity.class));
     }
 
     @Override
     public AttributeImpl<?> asAttribute() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Attribute.class)));
+        throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Attribute.class));
     }
 
     @Override
     public RelationImpl asRelation() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Relation.class)));
+        throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Relation.class));
     }
 
     public abstract static class Remote implements Concept.Remote {
@@ -119,52 +119,52 @@ public abstract class ConceptImpl implements Concept {
 
         @Override
         public TypeImpl.Remote asType() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Type.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Type.class));
         }
 
         @Override
         public ThingTypeImpl.Remote asThingType() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(ThingType.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(ThingType.class));
         }
 
         @Override
         public EntityTypeImpl.Remote asEntityType() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(EntityType.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(EntityType.class));
         }
 
         @Override
         public RelationTypeImpl.Remote asRelationType() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(RelationType.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(RelationType.class));
         }
 
         @Override
         public AttributeTypeImpl.Remote asAttributeType() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(AttributeType.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(AttributeType.class));
         }
 
         @Override
         public RoleTypeImpl.Remote asRoleType() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(RoleType.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(RoleType.class));
         }
 
         @Override
         public ThingImpl.Remote asThing() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Thing.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Thing.class));
         }
 
         @Override
         public EntityImpl.Remote asEntity() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Entity.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Entity.class));
         }
 
         @Override
         public RelationImpl.Remote asRelation() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Relation.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Relation.class));
         }
 
         @Override
         public AttributeImpl.Remote<?> asAttribute() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Attribute.class)));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Attribute.class));
         }
     }
 }

--- a/concept/answer/ConceptMapImpl.java
+++ b/concept/answer/ConceptMapImpl.java
@@ -66,7 +66,7 @@ public class ConceptMapImpl implements ConceptMap {
     @Override
     public Concept get(String variable) {
         Concept concept = map.get(variable);
-        if (concept == null) throw new GraknClientException(VARIABLE_DOES_NOT_EXIST.message(variable));
+        if (concept == null) throw new GraknClientException(VARIABLE_DOES_NOT_EXIST, variable);
         return concept;
     }
 

--- a/concept/answer/NumericImpl.java
+++ b/concept/answer/NumericImpl.java
@@ -49,7 +49,7 @@ public class NumericImpl implements Numeric {
             case NAN:
                 return NumericImpl.ofNaN();
             default:
-                throw new GraknClientException(BAD_ANSWER_TYPE.message(numeric.getValueCase()));
+                throw new GraknClientException(BAD_ANSWER_TYPE, numeric.getValueCase());
         }
     }
 
@@ -83,19 +83,19 @@ public class NumericImpl implements Numeric {
     @Override
     public long asLong() {
         if (isLong()) return longValue;
-        else throw new GraknClientException(ILLEGAL_CAST.message(Long.class));
+        else throw new GraknClientException(ILLEGAL_CAST, Long.class);
     }
 
     @Override
     public Double asDouble() {
         if (isDouble()) return doubleValue;
-        else throw new GraknClientException(ILLEGAL_CAST.message(Double.class));
+        else throw new GraknClientException(ILLEGAL_CAST, Double.class);
     }
 
     @Override
     public Number asNumber() {
         if (isLong()) return longValue;
         else if (isDouble()) return doubleValue;
-        else throw new GraknClientException(ILLEGAL_CAST.message(Number.class));
+        else throw new GraknClientException(ILLEGAL_CAST, Number.class);
     }
 }

--- a/concept/thing/AttributeImpl.java
+++ b/concept/thing/AttributeImpl.java
@@ -58,7 +58,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
                 return AttributeImpl.DateTime.of(thingProto);
             case UNRECOGNIZED:
             default:
-                throw new GraknClientException(BAD_VALUE_TYPE.message(thingProto.getType().getValueType()));
+                throw new GraknClientException(BAD_VALUE_TYPE, thingProto.getType().getValueType());
         }
     }
 
@@ -72,27 +72,27 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
     @Override
     public AttributeImpl.Boolean asBoolean() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Attribute.Boolean.class)));
+        throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Attribute.Boolean.class));
     }
 
     @Override
     public AttributeImpl.Long asLong() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Attribute.Long.class)));
+        throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Attribute.Long.class));
     }
 
     @Override
     public AttributeImpl.Double asDouble() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Attribute.Double.class)));
+        throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Attribute.Double.class));
     }
 
     @Override
     public AttributeImpl.String asString() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Attribute.String.class)));
+        throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Attribute.String.class));
     }
 
     @Override
     public AttributeImpl.DateTime asDateTime() {
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(className(this.getClass()), className(Attribute.DateTime.class)));
+        throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Attribute.DateTime.class));
     }
 
     public abstract VALUE getValue();
@@ -127,37 +127,27 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
         @Override
         public AttributeImpl.Boolean.Remote asBoolean() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                    className(this.getClass()), className(Attribute.Boolean.class)
-            ));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Attribute.Boolean.class));
         }
 
         @Override
         public AttributeImpl.Long.Remote asLong() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                    className(this.getClass()), className(Attribute.Long.class)
-            ));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Attribute.Long.class));
         }
 
         @Override
         public AttributeImpl.Double.Remote asDouble() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                    className(this.getClass()), className(Attribute.Double.class)
-            ));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Attribute.Double.class));
         }
 
         @Override
         public AttributeImpl.String.Remote asString() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                    className(this.getClass()), className(Attribute.String.class)
-            ));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Attribute.String.class));
         }
 
         @Override
         public AttributeImpl.DateTime.Remote asDateTime() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                    className(this.getClass()), className(Attribute.DateTime.class)
-            ));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Attribute.DateTime.class));
         }
 
         public abstract VALUE getValue();

--- a/concept/thing/ThingImpl.java
+++ b/concept/thing/ThingImpl.java
@@ -68,7 +68,7 @@ public abstract class ThingImpl extends ConceptImpl implements Thing {
                 return AttributeImpl.of(thingProto);
             case UNRECOGNIZED:
             default:
-                throw new GraknClientException(BAD_ENCODING.message(thingProto.getType().getEncoding()));
+                throw new GraknClientException(BAD_ENCODING, thingProto.getType().getEncoding());
         }
     }
 

--- a/concept/type/AttributeTypeImpl.java
+++ b/concept/type/AttributeTypeImpl.java
@@ -70,7 +70,7 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
                 return new AttributeTypeImpl(type.getLabel(), type.getRoot());
             case UNRECOGNIZED:
             default:
-                throw new GraknClientException(BAD_VALUE_TYPE.message(type.getValueType()));
+                throw new GraknClientException(BAD_VALUE_TYPE, type.getValueType());
         }
     }
 
@@ -92,41 +92,31 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
     @Override
     public AttributeTypeImpl.Boolean asBoolean() {
         if (isRoot()) return new Boolean(ROOT_LABEL.name(), true);
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                className(this.getClass()), className(AttributeType.Boolean.class))
-        );
+        throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(AttributeType.Boolean.class));
     }
 
     @Override
     public AttributeTypeImpl.Long asLong() {
         if (isRoot()) return new Long(ROOT_LABEL.name(), true);
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                className(this.getClass()), className(AttributeType.Long.class)
-        ));
+        throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(AttributeType.Long.class));
     }
 
     @Override
     public AttributeTypeImpl.Double asDouble() {
         if (isRoot()) return new Double(ROOT_LABEL.name(), true);
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                className(this.getClass()), className(AttributeType.Double.class)
-        ));
+        throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(AttributeType.Double.class));
     }
 
     @Override
     public AttributeTypeImpl.String asString() {
         if (isRoot()) return new String(ROOT_LABEL.name(), true);
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                className(this.getClass()), className(AttributeType.String.class)
-        ));
+        throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(AttributeType.String.class));
     }
 
     @Override
     public AttributeTypeImpl.DateTime asDateTime() {
         if (isRoot()) return new DateTime(ROOT_LABEL.name(), true);
-        throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                className(this.getClass()), className(AttributeType.DateTime.class)
-        ));
+        throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(AttributeType.DateTime.class));
     }
 
     @Override
@@ -217,41 +207,31 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
         @Override
         public AttributeTypeImpl.Boolean.Remote asBoolean() {
             if (isRoot()) return new AttributeTypeImpl.Boolean.Remote(tx(), ROOT_LABEL, true);
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                    className(this.getClass()), className(AttributeType.Boolean.class)
-            ));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(AttributeType.Boolean.class));
         }
 
         @Override
         public AttributeTypeImpl.Long.Remote asLong() {
             if (isRoot()) return new AttributeTypeImpl.Long.Remote(tx(), ROOT_LABEL, true);
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                    className(this.getClass()), className(AttributeType.Long.class)
-            ));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(AttributeType.Long.class));
         }
 
         @Override
         public AttributeTypeImpl.Double.Remote asDouble() {
             if (isRoot()) return new AttributeTypeImpl.Double.Remote(tx(), ROOT_LABEL, true);
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                    className(this.getClass()), className(AttributeType.Double.class)
-            ));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(AttributeType.Double.class));
         }
 
         @Override
         public AttributeTypeImpl.String.Remote asString() {
             if (isRoot()) return new AttributeTypeImpl.String.Remote(tx(), ROOT_LABEL, true);
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                    className(this.getClass()), className(AttributeType.String.class)
-            ));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(AttributeType.String.class));
         }
 
         @Override
         public AttributeTypeImpl.DateTime.Remote asDateTime() {
             if (isRoot()) return new AttributeTypeImpl.DateTime.Remote(tx(), ROOT_LABEL, true);
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                    className(this.getClass()), className(AttributeType.DateTime.class)
-            ));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(AttributeType.DateTime.class));
         }
 
         @Override

--- a/concept/type/AttributeTypeImpl.java
+++ b/concept/type/AttributeTypeImpl.java
@@ -75,11 +75,6 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
     }
 
     @Override
-    public ValueType getValueType() {
-        return ValueType.OBJECT;
-    }
-
-    @Override
     public final boolean isKeyable() {
         return getValueType().isKeyable();
     }
@@ -151,11 +146,6 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
         Remote(GraknTransaction transaction, Label label, boolean isRoot) {
             super(transaction, label, isRoot);
-        }
-
-        @Override
-        public ValueType getValueType() {
-            return ValueType.OBJECT;
         }
 
         @Override
@@ -289,11 +279,6 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
         }
 
         @Override
-        public ValueType getValueType() {
-            return ValueType.BOOLEAN;
-        }
-
-        @Override
         public AttributeTypeImpl.Boolean.Remote asRemote(GraknTransaction transaction) {
             return new AttributeTypeImpl.Boolean.Remote(transaction, getLabel(), isRoot());
         }
@@ -307,11 +292,6 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
             public Remote(GraknTransaction transaction, Label label, boolean isRoot) {
                 super(transaction, label, isRoot);
-            }
-
-            @Override
-            public ValueType getValueType() {
-                return ValueType.BOOLEAN;
             }
 
             @Override
@@ -364,11 +344,6 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
         }
 
         @Override
-        public ValueType getValueType() {
-            return ValueType.LONG;
-        }
-
-        @Override
         public AttributeTypeImpl.Long.Remote asRemote(GraknTransaction transaction) {
             return new AttributeTypeImpl.Long.Remote(transaction, getLabel(), isRoot());
         }
@@ -382,11 +357,6 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
             public Remote(GraknTransaction transaction, Label label, boolean isRoot) {
                 super(transaction, label, isRoot);
-            }
-
-            @Override
-            public ValueType getValueType() {
-                return ValueType.LONG;
             }
 
             @Override
@@ -439,11 +409,6 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
         }
 
         @Override
-        public ValueType getValueType() {
-            return ValueType.DOUBLE;
-        }
-
-        @Override
         public AttributeTypeImpl.Double.Remote asRemote(GraknTransaction transaction) {
             return new AttributeTypeImpl.Double.Remote(transaction, getLabel(), isRoot());
         }
@@ -457,11 +422,6 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
             public Remote(GraknTransaction transaction, Label label, boolean isRoot) {
                 super(transaction, label, isRoot);
-            }
-
-            @Override
-            public ValueType getValueType() {
-                return ValueType.DOUBLE;
             }
 
             @Override
@@ -514,11 +474,6 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
         }
 
         @Override
-        public ValueType getValueType() {
-            return ValueType.STRING;
-        }
-
-        @Override
         public AttributeTypeImpl.String.Remote asRemote(GraknTransaction transaction) {
             return new AttributeTypeImpl.String.Remote(transaction, getLabel(), isRoot());
         }
@@ -532,11 +487,6 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
             public Remote(GraknTransaction transaction, Label label, boolean isRoot) {
                 super(transaction, label, isRoot);
-            }
-
-            @Override
-            public ValueType getValueType() {
-                return ValueType.STRING;
             }
 
             @Override
@@ -603,11 +553,6 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
         }
 
         @Override
-        public ValueType getValueType() {
-            return ValueType.DATETIME;
-        }
-
-        @Override
         public AttributeTypeImpl.DateTime.Remote asRemote(GraknTransaction transaction) {
             return new AttributeTypeImpl.DateTime.Remote(transaction, getLabel(), isRoot());
         }
@@ -621,11 +566,6 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
             public Remote(GraknTransaction transaction, Label label, boolean isRoot) {
                 super(transaction, label, isRoot);
-            }
-
-            @Override
-            public ValueType getValueType() {
-                return ValueType.DATETIME;
             }
 
             @Override

--- a/concept/type/ThingTypeImpl.java
+++ b/concept/type/ThingTypeImpl.java
@@ -64,7 +64,7 @@ public class ThingTypeImpl extends TypeImpl implements ThingType {
                 return new ThingTypeImpl(typeProto.getLabel(), typeProto.getRoot());
             case UNRECOGNIZED:
             default:
-                throw new GraknClientException(BAD_ENCODING.message(typeProto.getEncoding()));
+                throw new GraknClientException(BAD_ENCODING, typeProto.getEncoding());
         }
     }
 

--- a/concept/type/TypeImpl.java
+++ b/concept/type/TypeImpl.java
@@ -79,7 +79,7 @@ public abstract class TypeImpl extends ConceptImpl implements Type {
             case ROLE_TYPE:
                 return RoleTypeImpl.of(typeProto);
             case UNRECOGNIZED:
-                throw new GraknClientException(BAD_ENCODING.message(typeProto.getEncoding()));
+                throw new GraknClientException(BAD_ENCODING, typeProto.getEncoding());
             default:
                 return ThingTypeImpl.of(typeProto);
         }
@@ -187,65 +187,47 @@ public abstract class TypeImpl extends ConceptImpl implements Type {
 
         @Override
         public ThingTypeImpl.Remote asThingType() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                    className(this.getClass()), className(ThingType.class)
-            ));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(ThingType.class));
         }
 
         @Override
         public EntityTypeImpl.Remote asEntityType() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                    className(this.getClass()), className(EntityType.class)
-            ));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(EntityType.class));
         }
 
         @Override
         public RelationTypeImpl.Remote asRelationType() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                    className(this.getClass()), className(RelationType.class)
-            ));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(RelationType.class));
         }
 
         @Override
         public AttributeTypeImpl.Remote asAttributeType() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                    className(this.getClass()), className(AttributeType.class)
-            ));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(AttributeType.class));
         }
 
         @Override
         public RoleTypeImpl.Remote asRoleType() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                    className(this.getClass()), className(RoleType.class)
-            ));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(RoleType.class));
         }
 
         @Override
         public ThingImpl.Remote asThing() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                    className(this.getClass()), className(Thing.class)
-            ));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Thing.class));
         }
 
         @Override
         public EntityImpl.Remote asEntity() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                    className(this.getClass()), className(Entity.class)
-            ));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Entity.class));
         }
 
         @Override
         public AttributeImpl.Remote<?> asAttribute() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                    className(this.getClass()), className(Attribute.class)
-            ));
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Attribute.class));
         }
 
         @Override
         public RelationImpl.Remote asRelation() {
-            throw new GraknClientException(INVALID_CONCEPT_CASTING.message(
-                    className(this.getClass()), className(Relation.class))
-            );
+            throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Relation.class));
         }
 
         @Nullable

--- a/core/CoreClient.java
+++ b/core/CoreClient.java
@@ -109,7 +109,7 @@ public class CoreClient implements GraknClient {
 
     @Override
     public Cluster asCluster() {
-        throw new GraknClientException(ILLEGAL_CAST.message(className(GraknClient.Cluster.class)));
+        throw new GraknClientException(ILLEGAL_CAST, className(GraknClient.Cluster.class));
     }
 
     public <RES> RES call(Supplier<RES> req) {

--- a/core/CoreDatabaseManager.java
+++ b/core/CoreDatabaseManager.java
@@ -55,7 +55,7 @@ public class CoreDatabaseManager implements DatabaseManager {
     @Override
     public Database get(String name) {
         if (contains(name)) return new CoreDatabase(this, name);
-        else throw new GraknClientException(DB_DOES_NOT_EXIST.message(name));
+        else throw new GraknClientException(DB_DOES_NOT_EXIST, name);
     }
 
     @Override

--- a/stream/BidirectionalStream.java
+++ b/stream/BidirectionalStream.java
@@ -81,14 +81,14 @@ public class BidirectionalStream implements AutoCloseable {
         UUID requestID = UUID.fromString(res.getReqId());
         ResponseCollector.Queue<Res> collector = resCollector.get(requestID);
         if (collector != null) collector.put(res);
-        else throw new GraknClientException(UNKNOWN_REQUEST_ID.message(requestID));
+        else throw new GraknClientException(UNKNOWN_REQUEST_ID, requestID);
     }
 
     private void collect(ResPart resPart) {
         UUID requestID = UUID.fromString(resPart.getReqId());
         ResponseCollector.Queue<ResPart> collector = resPartCollector.get(requestID);
         if (collector != null) collector.put(resPart);
-        else throw new GraknClientException(UNKNOWN_REQUEST_ID.message(requestID));
+        else throw new GraknClientException(UNKNOWN_REQUEST_ID, requestID);
     }
 
     @Override

--- a/stream/ResponseIterator.java
+++ b/stream/ResponseIterator.java
@@ -54,7 +54,7 @@ public class ResponseIterator implements Iterator<TransactionProto.Transaction.R
         TransactionProto.Transaction.ResPart resPart = responseCollector.take();
         switch (resPart.getResCase()) {
             case RES_NOT_SET:
-                throw new GraknClientException(MISSING_RESPONSE.message(requestID));
+                throw new GraknClientException(MISSING_RESPONSE, requestID);
             case STREAM_RES_PART:
                 switch (resPart.getStreamResPart().getState()) {
                     case DONE:

--- a/test/behaviour/concept/type/attributetype/AttributeTypeSteps.java
+++ b/test/behaviour/concept/type/attributetype/AttributeTypeSteps.java
@@ -73,7 +73,7 @@ public class AttributeTypeSteps {
             case DATETIME:
                 return attributeType.asDateTime();
             default:
-                throw new GraknClientException(BAD_VALUE_TYPE.message(valueType));
+                throw new GraknClientException(BAD_VALUE_TYPE, valueType);
         }
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

We cleared up some redundant methods, reduced some code duplication by use of default interface methods, and significantly cleaned up `GraknClientException` by refactoring out some of its constructors.

## What are the changes implemented in this PR?

- Clear out some unused methods
- Use default interface methods where doing so is trivially simple and would reduce code duplication
- Clean out 2 constructors of `GraknClientException` (it had 4, making it a nightmare to replicate in other clients!!)
