### PR TITLE
Resilient stub exception handling

### DIFF
--- a/core/CoreSession.java
+++ b/core/CoreSession.java
@@ -59,26 +59,22 @@ public class CoreSession implements GraknSession {
     private final int networkLatencyMillis;
 
     public CoreSession(CoreClient client, String database, Type type, GraknOptions options) {
-        try {
-            this.client = client;
-            this.type = type;
-            this.options = options;
-            Instant startTime = Instant.now();
-            SessionProto.Session.Open.Res res = client.stub().sessionOpen(
-                    openReq(database, type.proto(), options.proto())
-            );
-            Instant endTime = Instant.now();
-            this.database = new CoreDatabase(client.databases(), database);
-            networkLatencyMillis = (int) (Duration.between(startTime, endTime).toMillis() - res.getServerDurationMillis());
-            sessionID = res.getSessionId();
-            transactions = new ConcurrentSet<>();
-            accessLock = new StampedLock().asReadWriteLock();
-            isOpen = new AtomicBoolean(true);
-            pulse = new Timer();
-            pulse.scheduleAtFixedRate(this.new PulseTask(), 0, PULSE_INTERVAL_MILLIS);
-        } catch (StatusRuntimeException e) {
-            throw GraknClientException.of(e);
-        }
+        this.client = client;
+        this.type = type;
+        this.options = options;
+        Instant startTime = Instant.now();
+        SessionProto.Session.Open.Res res = client.stub().sessionOpen(
+                openReq(database, type.proto(), options.proto())
+        );
+        Instant endTime = Instant.now();
+        this.database = new CoreDatabase(client.databases(), database);
+        networkLatencyMillis = (int) (Duration.between(startTime, endTime).toMillis() - res.getServerDurationMillis());
+        sessionID = res.getSessionId();
+        transactions = new ConcurrentSet<>();
+        accessLock = new StampedLock().asReadWriteLock();
+        isOpen = new AtomicBoolean(true);
+        pulse = new Timer();
+        pulse.scheduleAtFixedRate(this.new PulseTask(), 0, PULSE_INTERVAL_MILLIS);
     }
 
     @Override

--- a/core/CoreSession.java
+++ b/core/CoreSession.java
@@ -39,6 +39,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.StampedLock;
 
 import static grakn.client.common.exception.ErrorMessage.Client.SESSION_CLOSED;
+import static grakn.client.common.exception.ErrorMessage.Client.UNABLE_TO_CONNECT;
 import static grakn.client.common.rpc.RequestBuilder.Session.closeReq;
 import static grakn.client.common.rpc.RequestBuilder.Session.openReq;
 import static grakn.client.common.rpc.RequestBuilder.Session.pulseReq;
@@ -129,8 +130,12 @@ public class CoreSession implements GraknSession {
                 pulse.cancel();
                 try {
                     SessionProto.Session.Close.Res ignore = stub().sessionClose(closeReq(sessionID));
-                } catch (StatusRuntimeException e) {
-                    // Most likely the session is already closed or the server is no longer running.
+                } catch (GraknClientException e) {
+                    if (e.getErrorMessage().equals(UNABLE_TO_CONNECT)) {
+                        // Most likely the session is already closed or the server is no longer running.
+                    } else {
+                        throw e;
+                    }
                 }
             }
         } catch (StatusRuntimeException e) {

--- a/core/CoreSession.java
+++ b/core/CoreSession.java
@@ -138,8 +138,6 @@ public class CoreSession implements GraknSession {
                     }
                 }
             }
-        } catch (StatusRuntimeException e) {
-            throw GraknClientException.of(e);
         } finally {
             accessLock.writeLock().unlock();
         }

--- a/core/CoreSession.java
+++ b/core/CoreSession.java
@@ -151,8 +151,12 @@ public class CoreSession implements GraknSession {
             boolean alive;
             try {
                 alive = stub().sessionPulse(pulseReq(sessionID)).getAlive();
-            } catch (StatusRuntimeException exception) {
-                alive = false;
+            }  catch (GraknClientException e) {
+                if (e.getErrorMessage().equals(UNABLE_TO_CONNECT)) {
+                    alive = false;
+                } else {
+                    throw e;
+                }
             }
             if (!alive) {
                 isOpen.set(false);

--- a/core/CoreTransaction.java
+++ b/core/CoreTransaction.java
@@ -54,17 +54,13 @@ public class CoreTransaction implements GraknTransaction.Extended {
     private final BidirectionalStream bidirectionalStream;
 
     CoreTransaction(CoreSession session, ByteString sessionId, Type type, GraknOptions options) {
-        try {
-            this.type = type;
-            this.options = options;
-            conceptMgr = new ConceptManagerImpl(this);
-            logicMgr = new LogicManagerImpl(this);
-            queryMgr = new QueryManagerImpl(this);
-            bidirectionalStream = new BidirectionalStream(session.stub(), session.transmitter());
-            execute(openReq(sessionId, type.proto(), options.proto(), session.networkLatencyMillis()), false);
-        } catch (StatusRuntimeException e) {
-            throw GraknClientException.of(e);
-        }
+        this.type = type;
+        this.options = options;
+        conceptMgr = new ConceptManagerImpl(this);
+        logicMgr = new LogicManagerImpl(this);
+        queryMgr = new QueryManagerImpl(this);
+        bidirectionalStream = new BidirectionalStream(session.stub(), session.transmitter());
+        execute(openReq(sessionId, type.proto(), options.proto(), session.networkLatencyMillis()), false);
     }
 
     @Override


### PR DESCRIPTION
## What is the goal of this PR?

The `ResilientStub` that was recently introduced wraps gRPC's `StatusRuntimeException` into `GraknClientException`. Therefore we've updated how we handle exception in various places.

## What are the changes implemented in this PR?

- Catch `GraknClientException` instead of `StatusRuntimeException` when we want to recover from the condition
- Remove code that attempts to wrap `StatusRuntimeException` into `GraknClientException` since it's already inside `ResilientStub`