### PR TITLE
Merge all JARs for deployment

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -63,6 +63,7 @@ assemble_maven(
     project_description = "Grakn Client API for Java",
     project_url = "https://github.com/graknlabs/client-java",
     scm_url = "https://github.com/graknlabs/client-java",
+    source_jar_prefix = "grakn/client",
 )
 
 deploy_maven(

--- a/api/BUILD
+++ b/api/BUILD
@@ -37,7 +37,6 @@ java_library(
         # External dependencies from Maven
         "@maven//:com_google_code_findbugs_jsr305",
     ],
-    tags = ["maven_coordinates=io.grakn.client:grakn-client-api:{pom_version}"],
 )
 
 checkstyle_test(

--- a/cluster/BUILD
+++ b/cluster/BUILD
@@ -38,7 +38,6 @@ java_library(
         "@maven//:io_grpc_grpc_api",
         "@maven//:org_slf4j_slf4j_api",
     ],
-    tags = ["maven_coordinates=io.grakn.client:grakn-client-cluster:{pom_version}"],
 )
 
 checkstyle_test(

--- a/common/BUILD
+++ b/common/BUILD
@@ -37,7 +37,6 @@ java_library(
         "@maven//:io_grpc_grpc_api",
         "@maven//:io_grpc_grpc_stub",
     ],
-    tags = ["maven_coordinates=io.grakn.client:grakn-client-common:{pom_version}"],
 )
 
 checkstyle_test(

--- a/concept/BUILD
+++ b/concept/BUILD
@@ -37,7 +37,6 @@ java_library(
         # External dependencies from Maven
         "@maven//:com_google_code_findbugs_jsr305",
     ],
-    tags = ["maven_coordinates=io.grakn.client:grakn-client-concept:{pom_version}"],
 )
 
 checkstyle_test(

--- a/core/BUILD
+++ b/core/BUILD
@@ -49,7 +49,6 @@ java_library(
         "@maven//:io_netty_netty_tcnative_boringssl_static",
         # "@maven//:io_grpc_grpc_core", // TODO: verify whether we need this or not
     ],
-    tags = ["maven_coordinates=io.grakn.client:grakn-client-core:{pom_version}"],
 )
 
 checkstyle_test(

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -37,7 +37,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "d49062d3cfe3f2ee1d9b33fa181ce9e9792d9f15", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "afb7192e104dd36776953cbd041bfc6c5802650d", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_protocol():

--- a/logic/BUILD
+++ b/logic/BUILD
@@ -38,7 +38,6 @@ java_library(
         # External dependencies from Maven
         "@maven//:com_google_code_findbugs_jsr305",
     ],
-    tags = ["maven_coordinates=io.grakn.client:grakn-client-logic:{pom_version}"],
 )
 
 checkstyle_test(

--- a/query/BUILD
+++ b/query/BUILD
@@ -36,7 +36,6 @@ java_library(
 
         # External dependencies from Maven
     ],
-    tags = ["maven_coordinates=io.grakn.client:grakn-client-query:{pom_version}"],
 )
 
 checkstyle_test(

--- a/stream/BUILD
+++ b/stream/BUILD
@@ -38,7 +38,6 @@ java_library(
         "@maven//:io_grpc_grpc_api",
         "@maven//:org_slf4j_slf4j_api"
     ],
-    tags = ["maven_coordinates=io.grakn.client:grakn-client-stream:{pom_version}"],
 )
 
 checkstyle_test(


### PR DESCRIPTION
## What is the goal of this PR?

Ease the usage of Client Java by end users by merging all small JARs together and deploying them as single package.

## What are the changes implemented in this PR?

Merge `//api`, `//cluster`, `//core`, `//common`, `//concept`, `//logic`, `//query`, `//stream` into a single JAR when deploying to Maven
