### PR TITLE
Implement Explanations

### DIFF
--- a/api/answer/ConceptMap.java
+++ b/api/answer/ConceptMap.java
@@ -20,11 +20,15 @@
 package grakn.client.api.answer;
 
 import grakn.client.api.concept.Concept;
+import grakn.client.common.exception.GraknClientException;
+import grakn.common.collection.Pair;
 
 import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+
+import static grakn.client.common.exception.ErrorMessage.Concept.NONEXISTENT_EXPLAINABLE_CONCEPT;
 
 public interface ConceptMap {
 
@@ -37,13 +41,25 @@ public interface ConceptMap {
     @CheckReturnValue
     Concept get(String variable);
 
-    Set<Explainable> explainables();
+    Explainables explainables();
 
-    interface Explainable {
+    interface Explainables {
 
-        String conjunction();
+        Explainable concept(String variable);
 
-        long id();
+        Explainable ownership(String owner, String attribute);
+
+        Map<String, Explainable> explainableConcepts();
+
+        Map<Pair<String, String>, Explainable> explainableOwnerships();
+
+        interface Explainable {
+
+            String conjunction();
+
+            long id();
+
+        }
 
     }
 }

--- a/api/answer/ConceptMap.java
+++ b/api/answer/ConceptMap.java
@@ -47,11 +47,11 @@ public interface ConceptMap {
 
         Explainable ownership(String owner, String attribute);
 
-        Map<String, Explainable> explainableRelations();
+        Map<String, Explainable> relations();
 
-        Map<String, Explainable> explainableAttributes();
+        Map<String, Explainable> attributes();
 
-        Map<Pair<String, String>, Explainable> explainableOwnerships();
+        Map<Pair<String, String>, Explainable> ownerships();
 
     }
 

--- a/api/answer/ConceptMap.java
+++ b/api/answer/ConceptMap.java
@@ -20,15 +20,11 @@
 package grakn.client.api.answer;
 
 import grakn.client.api.concept.Concept;
-import grakn.client.common.exception.GraknClientException;
 import grakn.common.collection.Pair;
 
 import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
-
-import static grakn.client.common.exception.ErrorMessage.Concept.NONEXISTENT_EXPLAINABLE_CONCEPT;
 
 public interface ConceptMap {
 
@@ -45,21 +41,25 @@ public interface ConceptMap {
 
     interface Explainables {
 
-        Explainable concept(String variable);
+        Explainable relation(String variable);
+
+        Explainable attribute(String variable);
 
         Explainable ownership(String owner, String attribute);
 
-        Map<String, Explainable> explainableConcepts();
+        Map<String, Explainable> explainableRelations();
+
+        Map<String, Explainable> explainableAttributes();
 
         Map<Pair<String, String>, Explainable> explainableOwnerships();
 
-        interface Explainable {
+    }
 
-            String conjunction();
+    interface Explainable {
 
-            long id();
+        String conjunction();
 
-        }
+        long id();
 
     }
 }

--- a/api/logic/Explanation.java
+++ b/api/logic/Explanation.java
@@ -17,33 +17,21 @@
  * under the License.
  */
 
-package grakn.client.api.answer;
+package grakn.client.api.logic;
 
-import grakn.client.api.concept.Concept;
+import grakn.client.api.answer.ConceptMap;
 
-import javax.annotation.CheckReturnValue;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
-public interface ConceptMap {
+public interface Explanation {
 
-    @CheckReturnValue
-    Map<String, Concept> map();
+    Rule rule();
 
-    @CheckReturnValue
-    Collection<Concept> concepts();
+    ConceptMap thenAnswer();
 
-    @CheckReturnValue
-    Concept get(String variable);
+    ConceptMap whenAnswer();
 
-    Set<Explainable> explainables();
+    Map<String, Set<String>> variableMapping();
 
-    interface Explainable {
-
-        String conjunction();
-
-        long id();
-
-    }
 }

--- a/api/query/QueryManager.java
+++ b/api/query/QueryManager.java
@@ -22,6 +22,7 @@ package grakn.client.api.query;
 import grakn.client.api.GraknOptions;
 import grakn.client.api.answer.ConceptMap;
 import grakn.client.api.answer.ConceptMapGroup;
+import grakn.client.api.logic.Explanation;
 import grakn.client.api.answer.Numeric;
 import grakn.client.api.answer.NumericGroup;
 import graql.lang.query.GraqlDefine;
@@ -71,6 +72,10 @@ public interface QueryManager {
     Stream<ConceptMap> update(GraqlUpdate query);
 
     Stream<ConceptMap> update(GraqlUpdate query, GraknOptions options);
+
+    Stream<Explanation> explain(ConceptMap.Explainable explainable);
+
+    Stream<Explanation> explain(ConceptMap.Explainable explainable, GraknOptions options);
 
     QueryFuture<Void> define(GraqlDefine query);
 

--- a/api/query/QueryManager.java
+++ b/api/query/QueryManager.java
@@ -73,9 +73,9 @@ public interface QueryManager {
 
     Stream<ConceptMap> update(GraqlUpdate query, GraknOptions options);
 
-    Stream<Explanation> explain(ConceptMap.Explainables.Explainable explainable);
+    Stream<Explanation> explain(ConceptMap.Explainable explainable);
 
-    Stream<Explanation> explain(ConceptMap.Explainables.Explainable explainable, GraknOptions options);
+    Stream<Explanation> explain(ConceptMap.Explainable explainable, GraknOptions options);
 
     QueryFuture<Void> define(GraqlDefine query);
 

--- a/api/query/QueryManager.java
+++ b/api/query/QueryManager.java
@@ -73,9 +73,9 @@ public interface QueryManager {
 
     Stream<ConceptMap> update(GraqlUpdate query, GraknOptions options);
 
-    Stream<Explanation> explain(ConceptMap.Explainable explainable);
+    Stream<Explanation> explain(ConceptMap.Explainables.Explainable explainable);
 
-    Stream<Explanation> explain(ConceptMap.Explainable explainable, GraknOptions options);
+    Stream<Explanation> explain(ConceptMap.Explainables.Explainable explainable, GraknOptions options);
 
     QueryFuture<Void> define(GraqlDefine query);
 

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -77,9 +77,9 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
         public static final Concept BAD_ATTRIBUTE_VALUE =
                 new Concept(7, "The attribute value '%s' was not recognised.");
         public static final Concept NONEXISTENT_EXPLAINABLE_CONCEPT =
-                new Concept(8, "No explainable concept for '%s' exists.");
+                new Concept(8, "The concept identified by '%s' is not explainable.");
         public static final Concept NONEXISTENT_EXPLAINABLE_OWNERSHIP =
-                new Concept(9, "No explainable ownership between owner '%s' and attribute '%s' exists.");
+                new Concept(9, "The ownership by owner '%s' of attribute '%s' is not explainable.");
 
         private static final String codePrefix = "CON";
         private static final String messagePrefix = "Concept Error";

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -76,6 +76,10 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
                 new Concept(6, "The value type '%s' was not recognised.");
         public static final Concept BAD_ATTRIBUTE_VALUE =
                 new Concept(7, "The attribute value '%s' was not recognised.");
+        public static final Concept NONEXISTENT_EXPLAINABLE_CONCEPT =
+                new Concept(8, "No explainable concept for '%s' exists.");
+        public static final Concept NONEXISTENT_EXPLAINABLE_OWNERSHIP =
+                new Concept(9, "No explainable ownership between owner '%s' and attribute '%s' exists.");
 
         private static final String codePrefix = "CON";
         private static final String messagePrefix = "Concept Error";

--- a/common/rpc/RequestBuilder.java
+++ b/common/rpc/RequestBuilder.java
@@ -232,6 +232,12 @@ public class RequestBuilder {
                     QueryProto.QueryManager.Update.Req.newBuilder().setQuery(query)
             ), options);
         }
+
+        public static TransactionProto.Transaction.Req.Builder explainReq(long id, OptionsProto.Options options) {
+            return queryManagerReq(QueryProto.QueryManager.Req.newBuilder().setExplainReq(
+                    QueryProto.QueryManager.Explain.Req.newBuilder().setExplainableId(id)
+            ), options);
+        }
     }
 
     public static class ConceptManager {

--- a/concept/answer/ConceptMapImpl.java
+++ b/concept/answer/ConceptMapImpl.java
@@ -158,17 +158,17 @@ public class ConceptMapImpl implements ConceptMap {
         }
 
         @Override
-        public Map<String, Explainable> explainableRelations() {
+        public Map<String, Explainable> relations() {
             return this.explainableRelations;
         }
 
         @Override
-        public Map<String, Explainable> explainableAttributes() {
+        public Map<String, Explainable> attributes() {
             return this.explainableAttributes;
         }
 
         @Override
-        public Map<Pair<String, String>, Explainable> explainableOwnerships() {
+        public Map<Pair<String, String>, Explainable> ownerships() {
             return this.explainableOwnerships;
         }
 

--- a/concept/answer/ConceptMapImpl.java
+++ b/concept/answer/ConceptMapImpl.java
@@ -58,22 +58,21 @@ public class ConceptMapImpl implements ConceptMap {
     }
 
     private static Explainables of(AnswerProto.Explainables explainables) {
-        Map<String, Explainable> explainableRelations = new HashMap<>();
-        explainables.getExplainableRelationsMap().forEach((var, explainable) -> {
-            explainableRelations.put(var, ExplainableImpl.of(explainable));
+        Map<String, Explainable> relations = new HashMap<>();
+        explainables.getRelationsMap().forEach((var, explainable) -> {
+            relations.put(var, ExplainableImpl.of(explainable));
         });
-        Map<String, Explainable> explainableAttributes = new HashMap<>();
-        explainables.getExplainableAttributesMap().forEach((var, explainable) -> {
-            explainableAttributes.put(var, ExplainableImpl.of(explainable));
+        Map<String, Explainable> attributes = new HashMap<>();
+        explainables.getAttributesMap().forEach((var, explainable) -> {
+            attributes.put(var, ExplainableImpl.of(explainable));
         });
-        Map<Pair<String, String>, Explainable> explainableOwnerships = new HashMap<>();
-        explainables.getExplainableOwnershipsList().forEach((explainableOwnership) -> {
-            explainableOwnerships.put(
-                    new Pair<>(explainableOwnership.getOwner(), explainableOwnership.getAttribute()),
-                    ExplainableImpl.of(explainableOwnership.getExplainable())
-            );
+        Map<Pair<String, String>, Explainable> ownerships = new HashMap<>();
+        explainables.getOwnershipsMap().forEach((var, ownedMap) -> {
+            ownedMap.getOwnedMap().forEach((owned, explainable) -> {
+                ownerships.put(new Pair<>(var, owned), ExplainableImpl.of(explainable));
+            });
         });
-        return new ExplainablesImpl(explainableRelations, explainableAttributes, explainableOwnerships);
+        return new ExplainablesImpl(relations, attributes, ownerships);
     }
 
     @Override

--- a/concept/answer/ConceptMapImpl.java
+++ b/concept/answer/ConceptMapImpl.java
@@ -20,48 +20,57 @@
 package grakn.client.concept.answer;
 
 import grakn.client.api.answer.ConceptMap;
+import grakn.client.api.answer.ConceptMap.Explainables.Explainable;
 import grakn.client.api.concept.Concept;
 import grakn.client.common.exception.GraknClientException;
 import grakn.client.concept.ConceptImpl;
-import grakn.client.concept.thing.ThingImpl;
-import grakn.client.concept.type.TypeImpl;
+import grakn.common.collection.Pair;
 import grakn.protocol.AnswerProto;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static grakn.client.common.exception.ErrorMessage.Concept.NONEXISTENT_EXPLAINABLE_CONCEPT;
+import static grakn.client.common.exception.ErrorMessage.Concept.NONEXISTENT_EXPLAINABLE_OWNERSHIP;
 import static grakn.client.common.exception.ErrorMessage.Query.VARIABLE_DOES_NOT_EXIST;
 
 public class ConceptMapImpl implements ConceptMap {
 
     private final Map<String, Concept> map;
-    private final Set<Explainable> explainables;
+    private final Explainables explainables;
 
-    public ConceptMapImpl(Map<String, Concept> map, Set<Explainable> explainables) {
+    public ConceptMapImpl(Map<String, Concept> map) {
+        this(map, new ExplainablesImpl());
+    }
+
+    public ConceptMapImpl(Map<String, Concept> map, Explainables explainables) {
         this.map = Collections.unmodifiableMap(map);
-        this.explainables = Collections.unmodifiableSet(explainables);
+        this.explainables = explainables;
     }
 
     public static ConceptMap of(AnswerProto.ConceptMap res) {
         Map<String, Concept> variableMap = new HashMap<>();
-        res.getMapMap().forEach((resVar, resConcept) -> {
-            Concept concept = ConceptImpl.of(resConcept);
-            variableMap.put(resVar, concept);
-        });
-
-        Set<Explainable> explainables = new HashSet<>();
-        res.getExplainablesList().forEach((explainableProto) -> {
-            explainables.add(new ExplainableImpl(explainableProto.getConjunction(), explainableProto.getId()));
-        });
-
-        return new ConceptMapImpl(variableMap, explainables);
         res.getMapMap().forEach((resVar, resConcept) -> variableMap.put(resVar, ConceptImpl.of(resConcept)));
-        return new ConceptMapImpl(Collections.unmodifiableMap(variableMap));
+        return new ConceptMapImpl(Collections.unmodifiableMap(variableMap), of(res.getExplainables()));
+    }
+
+    private static Explainables of(AnswerProto.Explainables explainables) {
+        Map<String, Explainable> explainableConcepts = new HashMap<>();
+        explainables.getExplainableConceptsMap().forEach((var, explainable) -> {
+            explainableConcepts.put(var, ExplainablesImpl.ExplainableImpl.of(explainable));
+        });
+        Map<Pair<String, String>, Explainable> explainableOwnerships = new HashMap<>();
+        explainables.getExplainableOwnershipsList().forEach((explainableOwnership) -> {
+            explainableOwnerships.put(
+                    new Pair<>(explainableOwnership.getOwner(), explainableOwnership.getAttribute()),
+                    ExplainablesImpl.ExplainableImpl.of(explainableOwnership.getExplainable())
+            );
+        });
+        return new ExplainablesImpl(explainableConcepts, explainableOwnerships);
     }
 
     @Override
@@ -82,7 +91,7 @@ public class ConceptMapImpl implements ConceptMap {
     }
 
     @Override
-    public Set<Explainable> explainables() {
+    public Explainables explainables() {
         return explainables;
     }
 
@@ -104,37 +113,96 @@ public class ConceptMapImpl implements ConceptMap {
     @Override
     public int hashCode() { return map.hashCode();}
 
-    static class ExplainableImpl implements Explainable {
+    public static class ExplainablesImpl implements Explainables {
 
-        private final String conjunction;
-        private final long id;
+        Map<String, Explainable> explainableConcepts;
 
-        ExplainableImpl(String conjunction, long id) {
-            this.conjunction = conjunction;
-            this.id = id;
+        Map<Pair<String, String>, Explainable> explainableOwnerships;
+
+        ExplainablesImpl() {
+            this(new HashMap<>(), new HashMap<>());
+        }
+
+        ExplainablesImpl(Map<String, Explainable> explainableConcepts, Map<Pair<String, String>, Explainable> explainableOwnerships) {
+            this.explainableConcepts = explainableConcepts;
+            this.explainableOwnerships = explainableOwnerships;
         }
 
         @Override
-        public String conjunction() {
-            return conjunction;
+        public Explainable concept(String variable) {
+            Explainable explainable = explainableConcepts.get(variable);
+            if (explainable == null) throw new GraknClientException(NONEXISTENT_EXPLAINABLE_CONCEPT, variable);
+            return explainable;
         }
 
         @Override
-        public long id() {
-            return id;
+        public Explainable ownership(String owner, String attribute) {
+            Explainable explainable = explainableOwnerships.get(new Pair<>(owner, attribute));
+            if (explainable == null) throw new GraknClientException(NONEXISTENT_EXPLAINABLE_OWNERSHIP, owner, attribute);
+            return explainable;
         }
 
         @Override
-        public boolean equals(final Object o) {
+        public Map<String, Explainable> explainableConcepts() {
+            return this.explainableConcepts;
+        }
+
+        @Override
+        public Map<Pair<String, String>, Explainable> explainableOwnerships() {
+            return this.explainableOwnerships;
+        }
+
+        @Override
+        public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-            final ExplainableImpl that = (ExplainableImpl) o;
-            return id == that.id;
+            ExplainablesImpl that = (ExplainablesImpl) o;
+            return explainableConcepts.equals(that.explainableConcepts) &&
+                    explainableOwnerships.equals(that.explainableOwnerships);
         }
 
         @Override
         public int hashCode() {
-            return (int)id;
+            return Objects.hash(explainableConcepts, explainableOwnerships);
+        }
+
+
+        static class ExplainableImpl implements Explainable {
+
+            private final String conjunction;
+            private final long id;
+
+            ExplainableImpl(String conjunction, long id) {
+                this.conjunction = conjunction;
+                this.id = id;
+            }
+
+            public static Explainable of(AnswerProto.Explainable explainable) {
+                return new ExplainableImpl(explainable.getConjunction(), explainable.getId());
+            }
+
+            @Override
+            public String conjunction() {
+                return conjunction;
+            }
+
+            @Override
+            public long id() {
+                return id;
+            }
+
+            @Override
+            public boolean equals(final Object o) {
+                if (this == o) return true;
+                if (o == null || getClass() != o.getClass()) return false;
+                final ExplainableImpl that = (ExplainableImpl) o;
+                return id == that.id;
+            }
+
+            @Override
+            public int hashCode() {
+                return (int) id;
+            }
         }
     }
 }

--- a/concept/thing/ThingImpl.java
+++ b/concept/thing/ThingImpl.java
@@ -87,7 +87,7 @@ public abstract class ThingImpl extends ConceptImpl implements Thing {
 
     @Override
     public String toString() {
-        return className(this.getClass()) + "[iid:" + iid + "]";
+        return className(this.getClass()) + "[" + getType().getLabel() + ":" + iid + "]";
     }
 
     @Override

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,7 +27,7 @@ def graknlabs_grakn_core_artifact():
         artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "87677abacaab0813927115135fba51ede262dd22",
+        commit = "a36868f1e8a34188eb371dee329ed499399cb40f",
     )
 
 def graknlabs_grakn_cluster_artifact():

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -37,5 +37,5 @@ def graknlabs_grakn_cluster_artifact():
         artifact_name = "grakn-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "c361e8e4b3f1e14aa8fde4c284ebf2cb2113b99f",
+        commit = "f08e4d9e194ee7e1806995377c8b0a7bd56903ec",
     )

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,7 +27,7 @@ def graknlabs_grakn_core_artifact():
         artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "35e5813ee0404cc62fb9a48e7bc22452390597da",
+        commit = "d130e8afb4e9bd7c366272ac9b05931398eb9eae",
     )
 
 def graknlabs_grakn_cluster_artifact():

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,7 +27,7 @@ def graknlabs_grakn_core_artifact():
         artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "d130e8afb4e9bd7c366272ac9b05931398eb9eae",
+        commit = "87677abacaab0813927115135fba51ede262dd22",
     )
 
 def graknlabs_grakn_cluster_artifact():

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,7 +27,7 @@ def graknlabs_grakn_core_artifact():
         artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "a36868f1e8a34188eb371dee329ed499399cb40f",
+        commit = "d9c34353ca57d5e916c71077c257cde9a0f2fed7"
     )
 
 def graknlabs_grakn_cluster_artifact():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -43,8 +43,8 @@ def graknlabs_dependencies():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/graknlabs/protocol",
-        commit = "d6ded8c76861316b0fb1eb9f6fed203bd2a23849", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/flyingsilverfin/protocol",
+        commit = "a28df3375981d7f096bbd9cb7df6d1605b7a1a8f", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -44,7 +44,7 @@ def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/flyingsilverfin/protocol",
-        commit = "1343b1d48086bfa25b6b8374e1de3e4ac648ebe5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "14484ab9471a9d4d5b31466621e4b5f1cb37185b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -23,14 +23,14 @@ def graknlabs_graql():
     git_repository(
         name = "graknlabs_graql",
         remote = "https://github.com/graknlabs/graql",
-        tag = "2.0.0-alpha-9" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+        tag = "2.0.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
     )
 
 def graknlabs_common():
     git_repository(
         name = "graknlabs_common",
         remote = "https://github.com/graknlabs/common",
-        commit = "82d287bd187be1defa8bf841a2313af523bbb075" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
+        tag = "2.0.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 
 def graknlabs_dependencies():
@@ -44,7 +44,7 @@ def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        commit = "f4a784601e6af2b41695733dac0bf2ebc2ed45a5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        tag = "2.0.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():
@@ -58,5 +58,5 @@ def graknlabs_grabl_tracing():
     git_repository(
         name = "graknlabs_grabl_tracing",
         remote = "https://github.com/graknlabs/grabl-tracing",
-        tag = "2.0.0-alpha"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grabl_tracing
+        tag = "2.0.0"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grabl_tracing
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -44,7 +44,7 @@ def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/flyingsilverfin/protocol",
-        commit = "a28df3375981d7f096bbd9cb7df6d1605b7a1a8f", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "1343b1d48086bfa25b6b8374e1de3e4ac648ebe5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -44,7 +44,7 @@ def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/flyingsilverfin/protocol",
-        commit = "38d442fdb2f1a5f2f9707c3ee5625fe09efc3a97", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "db450964d23303ab73a04c781db0dd0ef53fa869", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -44,7 +44,7 @@ def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/flyingsilverfin/protocol",
-        commit = "14484ab9471a9d4d5b31466621e4b5f1cb37185b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "38d442fdb2f1a5f2f9707c3ee5625fe09efc3a97", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -43,8 +43,8 @@ def graknlabs_dependencies():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/flyingsilverfin/protocol",
-        commit = "db450964d23303ab73a04c781db0dd0ef53fa869", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/graknlabs/protocol",
+        commit = "f4a784601e6af2b41695733dac0bf2ebc2ed45a5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():

--- a/logic/BUILD
+++ b/logic/BUILD
@@ -28,6 +28,7 @@ java_library(
         # Internal dependencies
         "//api:api",
         "//common:common",
+        "//concept:concept",
 
         # External dependencies from @graknlabs
         "@graknlabs_common//:common",

--- a/logic/ExplanationImpl.java
+++ b/logic/ExplanationImpl.java
@@ -23,7 +23,6 @@ import grakn.client.api.answer.ConceptMap;
 import grakn.client.api.logic.Explanation;
 import grakn.client.api.logic.Rule;
 import grakn.client.concept.answer.ConceptMapImpl;
-import grakn.protocol.AnswerProto;
 import grakn.protocol.LogicProto;
 
 import java.util.HashMap;
@@ -36,26 +35,26 @@ public class ExplanationImpl implements Explanation {
 
     private final Rule rule;
     private final Map<String, Set<String>> variableMapping;
-    private final ConceptMap thenAnswer;
-    private final ConceptMap whenAnswer;
+    private final ConceptMap conclusion;
+    private final ConceptMap condition;
 
-    private ExplanationImpl(Rule rule, Map<String, Set<String>> variableMapping, ConceptMap thenAnswer, ConceptMap whenAnswer) {
+    private ExplanationImpl(Rule rule, Map<String, Set<String>> variableMapping, ConceptMap conclusion, ConceptMap condition) {
         this.rule = rule;
         this.variableMapping = variableMapping;
-        this.thenAnswer = thenAnswer;
-        this.whenAnswer = whenAnswer;
+        this.conclusion = conclusion;
+        this.condition = condition;
     }
 
     public static Explanation of(LogicProto.Explanation explanation) {
         return new ExplanationImpl(
                 RuleImpl.of(explanation.getRule()),
                 of(explanation.getVarMappingMap()),
-                ConceptMapImpl.of(explanation.getThenAnswer()),
-                ConceptMapImpl.of(explanation.getWhenAnswer())
+                ConceptMapImpl.of(explanation.getConclusion()),
+                ConceptMapImpl.of(explanation.getCondition())
         );
     }
 
-    private static Map<String, Set<String>> of(Map<String, LogicProto.Explanation.VarsList> varMapping) {
+    private static Map<String, Set<String>> of(Map<String, LogicProto.Explanation.VarList> varMapping) {
         Map<String, Set<String>> mapping = new HashMap<>();
         varMapping.forEach((from, tos) -> mapping.put(from, new HashSet<>(tos.getVarsList())));
         return mapping;
@@ -73,12 +72,12 @@ public class ExplanationImpl implements Explanation {
 
     @Override
     public ConceptMap thenAnswer() {
-        return thenAnswer;
+        return conclusion;
     }
 
     @Override
     public ConceptMap whenAnswer() {
-        return whenAnswer;
+        return condition;
     }
 
     @Override
@@ -87,11 +86,11 @@ public class ExplanationImpl implements Explanation {
         if (o == null || getClass() != o.getClass()) return false;
         final ExplanationImpl that = (ExplanationImpl) o;
         return rule.equals(that.rule) && variableMapping.equals(that.variableMapping) &&
-                thenAnswer.equals(that.thenAnswer) && whenAnswer.equals(that.whenAnswer);
+                conclusion.equals(that.conclusion) && condition.equals(that.condition);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(rule, variableMapping, thenAnswer, whenAnswer);
+        return Objects.hash(rule, variableMapping, conclusion, condition);
     }
 }

--- a/logic/ExplanationImpl.java
+++ b/logic/ExplanationImpl.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package grakn.client.logic;
+
+import grakn.client.api.answer.ConceptMap;
+import grakn.client.api.logic.Explanation;
+import grakn.client.api.logic.Rule;
+import grakn.client.concept.answer.ConceptMapImpl;
+import grakn.protocol.AnswerProto;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public class ExplanationImpl implements Explanation {
+
+    private final Rule rule;
+    private final Map<String, Set<String>> variableMapping;
+    private final ConceptMap thenAnswer;
+    private final ConceptMap whenAnswer;
+
+    private ExplanationImpl(Rule rule, Map<String, Set<String>> variableMapping, ConceptMap thenAnswer, ConceptMap whenAnswer) {
+        this.rule = rule; this.variableMapping = variableMapping;
+        this.thenAnswer = thenAnswer;
+        this.whenAnswer = whenAnswer;
+    }
+
+    public static Explanation of(AnswerProto.Explanation explanation) {
+        return new ExplanationImpl(
+                RuleImpl.of(explanation.getRule()),
+                of(explanation.getVarMappingMap()),
+                ConceptMapImpl.of(explanation.getThenAnswer()),
+                ConceptMapImpl.of(explanation.getWhenAnswer())
+        );
+    }
+
+    private static Map<String, Set<String>> of(Map<String, AnswerProto.Explanation.VarsList> varMapping) {
+        Map<String, Set<String>> mapping = new HashMap<>();
+        varMapping.forEach((from, tos) -> mapping.put(from, new HashSet<>(tos.getVarsList())));
+        return mapping;
+    }
+
+    @Override
+    public Rule rule() {
+        return rule;
+    }
+
+    @Override
+    public Map<String, Set<String>> variableMapping() {
+        return variableMapping;
+    }
+
+    @Override
+    public ConceptMap thenAnswer() {
+        return thenAnswer;
+    }
+
+    @Override
+    public ConceptMap whenAnswer() {
+        return whenAnswer;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true; if (o == null || getClass() != o.getClass()) return false;
+        final ExplanationImpl that = (ExplanationImpl) o;
+        return rule.equals(that.rule) && variableMapping.equals(that.variableMapping) &&
+                thenAnswer.equals(that.thenAnswer) && whenAnswer.equals(that.whenAnswer);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(rule, variableMapping, thenAnswer, whenAnswer);
+    }
+}

--- a/logic/ExplanationImpl.java
+++ b/logic/ExplanationImpl.java
@@ -24,6 +24,7 @@ import grakn.client.api.logic.Explanation;
 import grakn.client.api.logic.Rule;
 import grakn.client.concept.answer.ConceptMapImpl;
 import grakn.protocol.AnswerProto;
+import grakn.protocol.LogicProto;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -44,7 +45,7 @@ public class ExplanationImpl implements Explanation {
         this.whenAnswer = whenAnswer;
     }
 
-    public static Explanation of(AnswerProto.Explanation explanation) {
+    public static Explanation of(LogicProto.Explanation explanation) {
         return new ExplanationImpl(
                 RuleImpl.of(explanation.getRule()),
                 of(explanation.getVarMappingMap()),
@@ -53,7 +54,7 @@ public class ExplanationImpl implements Explanation {
         );
     }
 
-    private static Map<String, Set<String>> of(Map<String, AnswerProto.Explanation.VarsList> varMapping) {
+    private static Map<String, Set<String>> of(Map<String, LogicProto.Explanation.VarsList> varMapping) {
         Map<String, Set<String>> mapping = new HashMap<>();
         varMapping.forEach((from, tos) -> mapping.put(from, new HashSet<>(tos.getVarsList())));
         return mapping;

--- a/logic/ExplanationImpl.java
+++ b/logic/ExplanationImpl.java
@@ -40,7 +40,8 @@ public class ExplanationImpl implements Explanation {
     private final ConceptMap whenAnswer;
 
     private ExplanationImpl(Rule rule, Map<String, Set<String>> variableMapping, ConceptMap thenAnswer, ConceptMap whenAnswer) {
-        this.rule = rule; this.variableMapping = variableMapping;
+        this.rule = rule;
+        this.variableMapping = variableMapping;
         this.thenAnswer = thenAnswer;
         this.whenAnswer = whenAnswer;
     }
@@ -82,7 +83,8 @@ public class ExplanationImpl implements Explanation {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true; if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         final ExplanationImpl that = (ExplanationImpl) o;
         return rule.equals(that.rule) && variableMapping.equals(that.variableMapping) &&
                 thenAnswer.equals(that.thenAnswer) && whenAnswer.equals(that.whenAnswer);

--- a/query/BUILD
+++ b/query/BUILD
@@ -29,6 +29,7 @@ java_library(
         "//api:api",
         "//common:common",
         "//concept:concept",
+        "//logic:logic",
 
         # External dependencies from @graknlabs
         "@graknlabs_graql//java/query",

--- a/query/QueryManagerImpl.java
+++ b/query/QueryManagerImpl.java
@@ -23,12 +23,14 @@ import grakn.client.api.GraknOptions;
 import grakn.client.api.GraknTransaction;
 import grakn.client.api.answer.ConceptMap;
 import grakn.client.api.answer.ConceptMapGroup;
+import grakn.client.api.logic.Explanation;
 import grakn.client.api.answer.Numeric;
 import grakn.client.api.answer.NumericGroup;
 import grakn.client.api.query.QueryFuture;
 import grakn.client.api.query.QueryManager;
 import grakn.client.concept.answer.ConceptMapGroupImpl;
 import grakn.client.concept.answer.ConceptMapImpl;
+import grakn.client.logic.ExplanationImpl;
 import grakn.client.concept.answer.NumericGroupImpl;
 import grakn.client.concept.answer.NumericImpl;
 import grakn.protocol.QueryProto;
@@ -44,6 +46,7 @@ import java.util.stream.Stream;
 
 import static grakn.client.common.rpc.RequestBuilder.QueryManager.defineReq;
 import static grakn.client.common.rpc.RequestBuilder.QueryManager.deleteReq;
+import static grakn.client.common.rpc.RequestBuilder.QueryManager.explainReq;
 import static grakn.client.common.rpc.RequestBuilder.QueryManager.insertReq;
 import static grakn.client.common.rpc.RequestBuilder.QueryManager.matchAggregateReq;
 import static grakn.client.common.rpc.RequestBuilder.QueryManager.matchGroupAggregateReq;
@@ -140,6 +143,18 @@ public final class QueryManagerImpl implements QueryManager {
         return stream(updateReq(query.toString(), options.proto()))
                 .flatMap(rp -> rp.getUpdateResPart().getAnswersList().stream())
                 .map(ConceptMapImpl::of);
+    }
+
+    @Override
+    public Stream<Explanation> explain(ConceptMap.Explainable explainable) {
+        return explain(explainable, GraknOptions.core());
+    }
+
+    @Override
+    public Stream<Explanation> explain(ConceptMap.Explainable explainable, GraknOptions options) {
+        return stream(explainReq(explainable.id(), options.proto()))
+                .flatMap(rp -> rp.getExplainResPart().getExplanationsList().stream())
+                .map(ExplanationImpl::of);
     }
 
     @Override

--- a/query/QueryManagerImpl.java
+++ b/query/QueryManagerImpl.java
@@ -146,12 +146,12 @@ public final class QueryManagerImpl implements QueryManager {
     }
 
     @Override
-    public Stream<Explanation> explain(ConceptMap.Explainable explainable) {
+    public Stream<Explanation> explain(ConceptMap.Explainables.Explainable explainable) {
         return explain(explainable, GraknOptions.core());
     }
 
     @Override
-    public Stream<Explanation> explain(ConceptMap.Explainable explainable, GraknOptions options) {
+    public Stream<Explanation> explain(ConceptMap.Explainables.Explainable explainable, GraknOptions options) {
         return stream(explainReq(explainable.id(), options.proto()))
                 .flatMap(rp -> rp.getExplainResPart().getExplanationsList().stream())
                 .map(ExplanationImpl::of);

--- a/query/QueryManagerImpl.java
+++ b/query/QueryManagerImpl.java
@@ -146,12 +146,12 @@ public final class QueryManagerImpl implements QueryManager {
     }
 
     @Override
-    public Stream<Explanation> explain(ConceptMap.Explainables.Explainable explainable) {
+    public Stream<Explanation> explain(ConceptMap.Explainable explainable) {
         return explain(explainable, GraknOptions.core());
     }
 
     @Override
-    public Stream<Explanation> explain(ConceptMap.Explainables.Explainable explainable, GraknOptions options) {
+    public Stream<Explanation> explain(ConceptMap.Explainable explainable, GraknOptions options) {
         return stream(explainReq(explainable.id(), options.proto()))
                 .flatMap(rp -> rp.getExplainResPart().getExplanationsList().stream())
                 .map(ExplanationImpl::of);

--- a/stream/BidirectionalStream.java
+++ b/stream/BidirectionalStream.java
@@ -68,7 +68,7 @@ public class BidirectionalStream implements AutoCloseable {
         UUID requestID = UUID.randomUUID();
         ResponseCollector.Queue<ResPart> collector = resPartCollector.queue(requestID);
         dispatcher.dispatch(request.setReqId(requestID.toString()).build());
-        ResponseIterator iterator = new ResponseIterator(requestID, collector, dispatcher);
+        ResponsePartIterator iterator = new ResponsePartIterator(requestID, collector, dispatcher);
         return StreamSupport.stream(spliteratorUnknownSize(iterator, ORDERED | IMMUTABLE), false);
     }
 

--- a/stream/ResponsePartIterator.java
+++ b/stream/ResponsePartIterator.java
@@ -31,7 +31,7 @@ import static grakn.client.common.exception.ErrorMessage.Client.MISSING_RESPONSE
 import static grakn.client.common.exception.ErrorMessage.Internal.ILLEGAL_ARGUMENT;
 import static grakn.client.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 
-public class ResponseIterator implements Iterator<TransactionProto.Transaction.ResPart> {
+public class ResponsePartIterator implements Iterator<TransactionProto.Transaction.ResPart> {
 
     private final UUID requestID;
     private final RequestTransmitter.Dispatcher dispatcher;
@@ -41,8 +41,8 @@ public class ResponseIterator implements Iterator<TransactionProto.Transaction.R
 
     enum State {EMPTY, FETCHED, DONE}
 
-    public ResponseIterator(UUID requestID, ResponseCollector.Queue<TransactionProto.Transaction.ResPart> responseQueue,
-                            RequestTransmitter.Dispatcher requestDispatcher) {
+    public ResponsePartIterator(UUID requestID, ResponseCollector.Queue<TransactionProto.Transaction.ResPart> responseQueue,
+                                RequestTransmitter.Dispatcher requestDispatcher) {
         this.requestID = requestID;
         this.dispatcher = requestDispatcher;
         this.responseCollector = responseQueue;

--- a/test/integration/ClientQueryTest.java
+++ b/test/integration/ClientQueryTest.java
@@ -306,7 +306,7 @@ public class ClientQueryTest {
             tx.query().insert(insertCommitQuery);
             tx.commit();
             LOG.info("clientJavaE2E() - done.");
-        }, READ);
+        }, WRITE);
 
         localhostGraknTx(tx -> {
             GraqlInsert insertWorkflowQuery = Graql.insert(
@@ -508,11 +508,11 @@ public class ClientQueryTest {
                     "match (friend: $p1, friend: $p2) isa friendship; $p1 has name $na;"
             ).asMatch()).collect(toList());
 
-            assertEquals(1, answers.get(0).explainables().explainableConcepts().size());
-            assertEquals(1, answers.get(1).explainables().explainableConcepts().size());
-            List<Explanation> explanations = tx.query().explain(answers.get(0).explainables().explainableConcepts().values().iterator().next()).collect(Collectors.toList());
+            assertEquals(1, answers.get(0).explainables().explainableRelations().size());
+            assertEquals(1, answers.get(1).explainables().explainableRelations().size());
+            List<Explanation> explanations = tx.query().explain(answers.get(0).explainables().explainableRelations().values().iterator().next()).collect(Collectors.toList());
             assertEquals(3, explanations.size());
-            List<Explanation> explanations2 = tx.query().explain(answers.get(1).explainables().explainableConcepts().values().iterator().next()).collect(Collectors.toList());
+            List<Explanation> explanations2 = tx.query().explain(answers.get(1).explainables().explainableRelations().values().iterator().next()).collect(Collectors.toList());
             assertEquals(3, explanations2.size());
         }, READ, GraknOptions.core().explain(true));
     }

--- a/test/integration/ClientQueryTest.java
+++ b/test/integration/ClientQueryTest.java
@@ -65,9 +65,9 @@ public class ClientQueryTest {
 
     @BeforeClass
     public static void setUpClass() throws InterruptedException, IOException, TimeoutException {
-//        grakn = new GraknCoreRunner();
-//        grakn.start();
-        graknClient = Grakn.coreClient("localhost:1729"); //grakn.address());
+        grakn = new GraknCoreRunner();
+        grakn.start();
+        graknClient = Grakn.coreClient(grakn.address());
         if (graknClient.databases().contains("grakn")) graknClient.databases().get("grakn").delete();
         graknClient.databases().create("grakn");
     }
@@ -75,7 +75,7 @@ public class ClientQueryTest {
     @AfterClass
     public static void closeSession() {
         graknClient.close();
-//        grakn.stop();
+        grakn.stop();
     }
 
     @Test
@@ -508,11 +508,11 @@ public class ClientQueryTest {
                     "match (friend: $p1, friend: $p2) isa friendship; $p1 has name $na;"
             ).asMatch()).collect(toList());
 
-            assertEquals(1, answers.get(0).explainables().size());
-            assertEquals(1, answers.get(1).explainables().size());
-            List<Explanation> explanations = tx.query().explain(answers.get(0).explainables().iterator().next()).collect(Collectors.toList());
+            assertEquals(1, answers.get(0).explainables().explainableConcepts().size());
+            assertEquals(1, answers.get(1).explainables().explainableConcepts().size());
+            List<Explanation> explanations = tx.query().explain(answers.get(0).explainables().explainableConcepts().values().iterator().next()).collect(Collectors.toList());
             assertEquals(3, explanations.size());
-            List<Explanation> explanations2 = tx.query().explain(answers.get(1).explainables().iterator().next()).collect(Collectors.toList());
+            List<Explanation> explanations2 = tx.query().explain(answers.get(1).explainables().explainableConcepts().values().iterator().next()).collect(Collectors.toList());
             assertEquals(3, explanations2.size());
         }, READ, GraknOptions.core().explain(true));
     }

--- a/test/integration/ClientQueryTest.java
+++ b/test/integration/ClientQueryTest.java
@@ -508,11 +508,11 @@ public class ClientQueryTest {
                     "match (friend: $p1, friend: $p2) isa friendship; $p1 has name $na;"
             ).asMatch()).collect(toList());
 
-            assertEquals(1, answers.get(0).explainables().explainableRelations().size());
-            assertEquals(1, answers.get(1).explainables().explainableRelations().size());
-            List<Explanation> explanations = tx.query().explain(answers.get(0).explainables().explainableRelations().values().iterator().next()).collect(Collectors.toList());
+            assertEquals(1, answers.get(0).explainables().relations().size());
+            assertEquals(1, answers.get(1).explainables().relations().size());
+            List<Explanation> explanations = tx.query().explain(answers.get(0).explainables().relations().values().iterator().next()).collect(Collectors.toList());
             assertEquals(3, explanations.size());
-            List<Explanation> explanations2 = tx.query().explain(answers.get(1).explainables().explainableRelations().values().iterator().next()).collect(Collectors.toList());
+            List<Explanation> explanations2 = tx.query().explain(answers.get(1).explainables().relations().values().iterator().next()).collect(Collectors.toList());
             assertEquals(3, explanations2.size());
         }, READ, GraknOptions.core().explain(true));
     }


### PR DESCRIPTION
## What is the goal of this PR?
Following https://github.com/graknlabs/grakn/pull/6271 and the corresponding protocol change in https://github.com/graknlabs/protocol/pull/131 we implement Explanations, Explainable concept maps, and the explain() query API, which allows users to stream Explanations on demand **note: explain query or transaction option must be set to `true`**

## What are the changes implemented in this PR?
* Implement `Explanation` objects, and extend `ConceptMap` to contain `Explainables`
* Add the `QueryManager.explain(Explainable)` API to retrieve all direct explanations (1-rule layer) 
* update `ClientTest` to include a simple Explanation test