### PR TITLE
Fix error running Graql Update and clean up Concept package

### DIFF
--- a/api/concept/type/AttributeType.java
+++ b/api/concept/type/AttributeType.java
@@ -38,9 +38,6 @@ public interface AttributeType extends ThingType {
         return ValueType.OBJECT;
     }
 
-    @CheckReturnValue
-    boolean isKeyable();
-
     @Override
     @CheckReturnValue
     default boolean isAttributeType() {

--- a/common/rpc/RequestBuilder.java
+++ b/common/rpc/RequestBuilder.java
@@ -665,23 +665,23 @@ public class RequestBuilder {
                 ));
             }
 
-            public static ConceptProto.Attribute.Value attributeValueBooleanReq(boolean value) {
+            public static ConceptProto.Attribute.Value protoBooleanAttributeValue(boolean value) {
                 return ConceptProto.Attribute.Value.newBuilder().setBoolean(value).build();
             }
 
-            public static ConceptProto.Attribute.Value attributeValueLongReq(long value) {
+            public static ConceptProto.Attribute.Value protoLongAttributeValue(long value) {
                 return ConceptProto.Attribute.Value.newBuilder().setLong(value).build();
             }
 
-            public static ConceptProto.Attribute.Value attributeValueDoubleReq(double value) {
+            public static ConceptProto.Attribute.Value protoDoubleAttributeValue(double value) {
                 return ConceptProto.Attribute.Value.newBuilder().setDouble(value).build();
             }
 
-            public static ConceptProto.Attribute.Value attributeValueStringReq(String value) {
+            public static ConceptProto.Attribute.Value protoStringAttributeValue(String value) {
                 return ConceptProto.Attribute.Value.newBuilder().setString(value).build();
             }
 
-            public static ConceptProto.Attribute.Value attributeValueDateTimeReq(LocalDateTime value) {
+            public static ConceptProto.Attribute.Value protoDateTimeAttributeValue(LocalDateTime value) {
                 long epochMillis = value.atZone(ZoneId.of("Z")).toInstant().toEpochMilli();
                 return ConceptProto.Attribute.Value.newBuilder().setDateTime(epochMillis).build();
             }

--- a/concept/ConceptImpl.java
+++ b/concept/ConceptImpl.java
@@ -48,11 +48,9 @@ import static grakn.common.util.Objects.className;
 
 public abstract class ConceptImpl implements Concept {
 
-    public static Concept of(ConceptProto.Concept owner) {
-        Concept concept;
-        if (owner.hasThing()) concept = ThingImpl.of(owner.getThing());
-        else concept = TypeImpl.of(owner.getType());
-        return concept;
+    public static Concept of(ConceptProto.Concept protoConcept) {
+        if (protoConcept.hasThing()) return ThingImpl.of(protoConcept.getThing());
+        else return TypeImpl.of(protoConcept.getType());
     }
 
     @Override

--- a/concept/answer/ConceptMapImpl.java
+++ b/concept/answer/ConceptMapImpl.java
@@ -22,6 +22,7 @@ package grakn.client.concept.answer;
 import grakn.client.api.answer.ConceptMap;
 import grakn.client.api.concept.Concept;
 import grakn.client.common.exception.GraknClientException;
+import grakn.client.concept.ConceptImpl;
 import grakn.client.concept.thing.ThingImpl;
 import grakn.client.concept.type.TypeImpl;
 import grakn.protocol.AnswerProto;
@@ -44,12 +45,7 @@ public class ConceptMapImpl implements ConceptMap {
 
     public static ConceptMap of(AnswerProto.ConceptMap res) {
         Map<String, Concept> variableMap = new HashMap<>();
-        res.getMapMap().forEach((resVar, resConcept) -> {
-            Concept concept;
-            if (resConcept.hasThing()) concept = ThingImpl.of(resConcept.getThing());
-            else concept = TypeImpl.of(resConcept.getType());
-            variableMap.put(resVar, concept);
-        });
+        res.getMapMap().forEach((resVar, resConcept) -> variableMap.put(resVar, ConceptImpl.of(resConcept)));
         return new ConceptMapImpl(Collections.unmodifiableMap(variableMap));
     }
 

--- a/concept/thing/RelationImpl.java
+++ b/concept/thing/RelationImpl.java
@@ -42,7 +42,7 @@ import static grakn.client.common.rpc.RequestBuilder.Thing.Relation.getPlayersRe
 import static grakn.client.common.rpc.RequestBuilder.Thing.Relation.getRelatingReq;
 import static grakn.client.common.rpc.RequestBuilder.Thing.Relation.removePlayerReq;
 import static grakn.client.common.rpc.RequestBuilder.Thing.protoThing;
-import static grakn.client.concept.type.RoleTypeImpl.protoRoleTypes;
+import static grakn.client.concept.type.RoleTypeImpl.protoRoleType;
 import static grakn.client.concept.type.TypeImpl.protoTypes;
 import static java.util.Arrays.asList;
 
@@ -96,12 +96,12 @@ public class RelationImpl extends ThingImpl implements Relation {
 
         @Override
         public void addPlayer(RoleType roleType, Thing player) {
-            execute(addPlayerReq(getIID(), protoRoleTypes(roleType), protoThing(player.getIID())));
+            execute(addPlayerReq(getIID(), protoRoleType(roleType), protoThing(player.getIID())));
         }
 
         @Override
         public void removePlayer(RoleType roleType, Thing player) {
-            execute(removePlayerReq(getIID(), protoRoleTypes(roleType), protoThing(player.getIID())));
+            execute(removePlayerReq(getIID(), protoRoleType(roleType), protoThing(player.getIID())));
         }
 
         @Override

--- a/concept/type/AttributeTypeImpl.java
+++ b/concept/type/AttributeTypeImpl.java
@@ -49,25 +49,25 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
     private static final Label ROOT_LABEL = Label.of("attribute");
 
-    AttributeTypeImpl(java.lang.String label, boolean isRoot) {
+    AttributeTypeImpl(Label label, boolean isRoot) {
         super(label, isRoot);
     }
 
     public static AttributeTypeImpl of(ConceptProto.Type type) {
         switch (type.getValueType()) {
             case BOOLEAN:
-                return new AttributeTypeImpl.Boolean(type.getLabel(), type.getRoot());
+                return new AttributeTypeImpl.Boolean(Label.of(type.getLabel()), type.getRoot());
             case LONG:
-                return new AttributeTypeImpl.Long(type.getLabel(), type.getRoot());
+                return new AttributeTypeImpl.Long(Label.of(type.getLabel()), type.getRoot());
             case DOUBLE:
-                return new AttributeTypeImpl.Double(type.getLabel(), type.getRoot());
+                return new AttributeTypeImpl.Double(Label.of(type.getLabel()), type.getRoot());
             case STRING:
-                return new AttributeTypeImpl.String(type.getLabel(), type.getRoot());
+                return new AttributeTypeImpl.String(Label.of(type.getLabel()), type.getRoot());
             case DATETIME:
-                return new AttributeTypeImpl.DateTime(type.getLabel(), type.getRoot());
+                return new AttributeTypeImpl.DateTime(Label.of(type.getLabel()), type.getRoot());
             case OBJECT:
                 assert type.getRoot();
-                return new AttributeTypeImpl(type.getLabel(), type.getRoot());
+                return new AttributeTypeImpl(Label.of(type.getLabel()), type.getRoot());
             case UNRECOGNIZED:
             default:
                 throw new GraknClientException(BAD_VALUE_TYPE, type.getValueType());
@@ -86,31 +86,31 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
     @Override
     public AttributeTypeImpl.Boolean asBoolean() {
-        if (isRoot()) return new Boolean(ROOT_LABEL.name(), true);
+        if (isRoot()) return new Boolean(ROOT_LABEL, true);
         throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(AttributeType.Boolean.class));
     }
 
     @Override
     public AttributeTypeImpl.Long asLong() {
-        if (isRoot()) return new Long(ROOT_LABEL.name(), true);
+        if (isRoot()) return new Long(ROOT_LABEL, true);
         throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(AttributeType.Long.class));
     }
 
     @Override
     public AttributeTypeImpl.Double asDouble() {
-        if (isRoot()) return new Double(ROOT_LABEL.name(), true);
+        if (isRoot()) return new Double(ROOT_LABEL, true);
         throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(AttributeType.Double.class));
     }
 
     @Override
     public AttributeTypeImpl.String asString() {
-        if (isRoot()) return new String(ROOT_LABEL.name(), true);
+        if (isRoot()) return new String(ROOT_LABEL, true);
         throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(AttributeType.String.class));
     }
 
     @Override
     public AttributeTypeImpl.DateTime asDateTime() {
-        if (isRoot()) return new DateTime(ROOT_LABEL.name(), true);
+        if (isRoot()) return new DateTime(ROOT_LABEL, true);
         throw new GraknClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(AttributeType.DateTime.class));
     }
 
@@ -172,8 +172,8 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
                     .map(ThingTypeImpl::of);
         }
 
-        protected final AttributeImpl<?> put(ConceptProto.Attribute.Value value) {
-            ConceptProto.Type.Res res = execute(putReq(getLabel(), value));
+        protected final AttributeImpl<?> put(ConceptProto.Attribute.Value protoValue) {
+            ConceptProto.Type.Res res = execute(putReq(getLabel(), protoValue));
             return AttributeImpl.of(res.getAttributeTypePutRes().getAttribute());
         }
 
@@ -240,12 +240,12 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
     public static class Boolean extends AttributeTypeImpl implements AttributeType.Boolean {
 
-        Boolean(java.lang.String label, boolean isRoot) {
+        Boolean(Label label, boolean isRoot) {
             super(label, isRoot);
         }
 
         public static AttributeTypeImpl.Boolean of(ConceptProto.Type typeProto) {
-            return new AttributeTypeImpl.Boolean(typeProto.getLabel(), typeProto.getRoot());
+            return new AttributeTypeImpl.Boolean(Label.of(typeProto.getLabel()), typeProto.getRoot());
         }
 
         @Override
@@ -305,12 +305,12 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
     public static class Long extends AttributeTypeImpl implements AttributeType.Long {
 
-        Long(java.lang.String label, boolean isRoot) {
+        Long(Label label, boolean isRoot) {
             super(label, isRoot);
         }
 
         public static AttributeTypeImpl.Long of(ConceptProto.Type typeProto) {
-            return new AttributeTypeImpl.Long(typeProto.getLabel(), typeProto.getRoot());
+            return new AttributeTypeImpl.Long(Label.of(typeProto.getLabel()), typeProto.getRoot());
         }
 
         @Override
@@ -370,12 +370,12 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
     public static class Double extends AttributeTypeImpl implements AttributeType.Double {
 
-        Double(java.lang.String label, boolean isRoot) {
+        Double(Label label, boolean isRoot) {
             super(label, isRoot);
         }
 
         public static AttributeTypeImpl.Double of(ConceptProto.Type typeProto) {
-            return new AttributeTypeImpl.Double(typeProto.getLabel(), typeProto.getRoot());
+            return new AttributeTypeImpl.Double(Label.of(typeProto.getLabel()), typeProto.getRoot());
         }
 
         @Override
@@ -435,12 +435,12 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
     public static class String extends AttributeTypeImpl implements AttributeType.String {
 
-        String(java.lang.String label, boolean isRoot) {
+        String(Label label, boolean isRoot) {
             super(label, isRoot);
         }
 
         public static AttributeTypeImpl.String of(ConceptProto.Type typeProto) {
-            return new AttributeTypeImpl.String(typeProto.getLabel(), typeProto.getRoot());
+            return new AttributeTypeImpl.String(Label.of(typeProto.getLabel()), typeProto.getRoot());
         }
 
         @Override
@@ -514,12 +514,12 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
     public static class DateTime extends AttributeTypeImpl implements AttributeType.DateTime {
 
-        DateTime(java.lang.String label, boolean isRoot) {
+        DateTime(Label label, boolean isRoot) {
             super(label, isRoot);
         }
 
         public static AttributeTypeImpl.DateTime of(ConceptProto.Type typeProto) {
-            return new AttributeTypeImpl.DateTime(typeProto.getLabel(), typeProto.getRoot());
+            return new AttributeTypeImpl.DateTime(Label.of(typeProto.getLabel()), typeProto.getRoot());
         }
 
         @Override

--- a/concept/type/AttributeTypeImpl.java
+++ b/concept/type/AttributeTypeImpl.java
@@ -33,11 +33,11 @@ import java.util.stream.Stream;
 
 import static grakn.client.common.exception.ErrorMessage.Concept.BAD_VALUE_TYPE;
 import static grakn.client.common.exception.ErrorMessage.Concept.INVALID_CONCEPT_CASTING;
-import static grakn.client.common.rpc.RequestBuilder.Thing.Attribute.attributeValueBooleanReq;
-import static grakn.client.common.rpc.RequestBuilder.Thing.Attribute.attributeValueDateTimeReq;
-import static grakn.client.common.rpc.RequestBuilder.Thing.Attribute.attributeValueDoubleReq;
-import static grakn.client.common.rpc.RequestBuilder.Thing.Attribute.attributeValueLongReq;
-import static grakn.client.common.rpc.RequestBuilder.Thing.Attribute.attributeValueStringReq;
+import static grakn.client.common.rpc.RequestBuilder.Thing.Attribute.protoBooleanAttributeValue;
+import static grakn.client.common.rpc.RequestBuilder.Thing.Attribute.protoDateTimeAttributeValue;
+import static grakn.client.common.rpc.RequestBuilder.Thing.Attribute.protoDoubleAttributeValue;
+import static grakn.client.common.rpc.RequestBuilder.Thing.Attribute.protoLongAttributeValue;
+import static grakn.client.common.rpc.RequestBuilder.Thing.Attribute.protoStringAttributeValue;
 import static grakn.client.common.rpc.RequestBuilder.Type.AttributeType.getOwnersReq;
 import static grakn.client.common.rpc.RequestBuilder.Type.AttributeType.getRegexReq;
 import static grakn.client.common.rpc.RequestBuilder.Type.AttributeType.getReq;
@@ -296,13 +296,13 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
             @Override
             public final AttributeImpl.Boolean put(boolean value) {
-                return super.put(attributeValueBooleanReq(value)).asBoolean();
+                return super.put(protoBooleanAttributeValue(value)).asBoolean();
             }
 
             @Nullable
             @Override
             public final AttributeImpl.Boolean get(boolean value) {
-                AttributeImpl<?> attr = super.get(attributeValueBooleanReq(value));
+                AttributeImpl<?> attr = super.get(protoBooleanAttributeValue(value));
                 return attr != null ? attr.asBoolean() : null;
             }
 
@@ -361,13 +361,13 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
             @Override
             public final AttributeImpl.Long put(long value) {
-                return super.put(attributeValueLongReq(value)).asLong();
+                return super.put(protoLongAttributeValue(value)).asLong();
             }
 
             @Nullable
             @Override
             public final AttributeImpl.Long get(long value) {
-                AttributeImpl<?> attr = super.get(attributeValueLongReq(value));
+                AttributeImpl<?> attr = super.get(protoLongAttributeValue(value));
                 return attr != null ? attr.asLong() : null;
             }
 
@@ -426,13 +426,13 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
             @Override
             public final AttributeImpl.Double put(double value) {
-                return super.put(attributeValueDoubleReq(value)).asDouble();
+                return super.put(protoDoubleAttributeValue(value)).asDouble();
             }
 
             @Nullable
             @Override
             public final AttributeImpl.Double get(double value) {
-                AttributeImpl<?> attr = super.get(attributeValueDoubleReq(value));
+                AttributeImpl<?> attr = super.get(protoDoubleAttributeValue(value));
                 return attr != null ? attr.asDouble() : null;
             }
 
@@ -491,13 +491,13 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
             @Override
             public final AttributeImpl.String put(java.lang.String value) {
-                return super.put(attributeValueStringReq(value)).asString();
+                return super.put(protoStringAttributeValue(value)).asString();
             }
 
             @Nullable
             @Override
             public final AttributeImpl.String get(java.lang.String value) {
-                AttributeImpl<?> attr = super.get(attributeValueStringReq(value));
+                AttributeImpl<?> attr = super.get(protoStringAttributeValue(value));
                 return attr != null ? attr.asString() : null;
             }
 
@@ -570,13 +570,13 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
             @Override
             public final AttributeImpl.DateTime put(LocalDateTime value) {
-                return super.put(attributeValueDateTimeReq(value)).asDateTime();
+                return super.put(protoDateTimeAttributeValue(value)).asDateTime();
             }
 
             @Nullable
             @Override
             public final AttributeImpl.DateTime get(LocalDateTime value) {
-                AttributeImpl<?> attr = super.get(attributeValueDateTimeReq(value));
+                AttributeImpl<?> attr = super.get(protoDateTimeAttributeValue(value));
                 return attr != null ? attr.asDateTime() : null;
             }
 

--- a/concept/type/AttributeTypeImpl.java
+++ b/concept/type/AttributeTypeImpl.java
@@ -75,11 +75,6 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
     }
 
     @Override
-    public final boolean isKeyable() {
-        return getValueType().isKeyable();
-    }
-
-    @Override
     public AttributeTypeImpl.Remote asRemote(GraknTransaction transaction) {
         return new AttributeTypeImpl.Remote(transaction, getLabel(), isRoot());
     }
@@ -136,11 +131,6 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
         Remote(GraknTransaction transaction, Label label, boolean isRoot) {
             super(transaction, label, isRoot);
-        }
-
-        @Override
-        public final boolean isKeyable() {
-            return getValueType().isKeyable();
         }
 
         @Override

--- a/concept/type/EntityTypeImpl.java
+++ b/concept/type/EntityTypeImpl.java
@@ -32,12 +32,12 @@ import static grakn.client.common.rpc.RequestBuilder.Type.EntityType.createReq;
 
 public class EntityTypeImpl extends ThingTypeImpl implements EntityType {
 
-    EntityTypeImpl(String label, boolean isRoot) {
+    EntityTypeImpl(Label label, boolean isRoot) {
         super(label, isRoot);
     }
 
     public static EntityTypeImpl of(ConceptProto.Type typeProto) {
-        return new EntityTypeImpl(typeProto.getLabel(), typeProto.getRoot());
+        return new EntityTypeImpl(Label.of(typeProto.getLabel()), typeProto.getRoot());
     }
 
     @Override

--- a/concept/type/RelationTypeImpl.java
+++ b/concept/type/RelationTypeImpl.java
@@ -35,12 +35,12 @@ import static grakn.client.common.rpc.RequestBuilder.Type.RelationType.unsetRela
 
 public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
 
-    RelationTypeImpl(String label, boolean isRoot) {
+    RelationTypeImpl(Label label, boolean isRoot) {
         super(label, isRoot);
     }
 
     public static RelationTypeImpl of(ConceptProto.Type typeProto) {
-        return new RelationTypeImpl(typeProto.getLabel(), typeProto.getRoot());
+        return new RelationTypeImpl(Label.of(typeProto.getLabel()), typeProto.getRoot());
     }
 
     @Override

--- a/concept/type/RoleTypeImpl.java
+++ b/concept/type/RoleTypeImpl.java
@@ -34,12 +34,12 @@ import static grakn.client.common.rpc.RequestBuilder.Type.RoleType.getRelationTy
 
 public class RoleTypeImpl extends TypeImpl implements RoleType {
 
-    RoleTypeImpl(String scope, String label, boolean root) {
-        super(Label.of(scope, label), root);
+    RoleTypeImpl(Label label, boolean root) {
+        super(label, root);
     }
 
     public static RoleTypeImpl of(ConceptProto.Type typeProto) {
-        return new RoleTypeImpl(typeProto.getScope(), typeProto.getLabel(), typeProto.getRoot());
+        return new RoleTypeImpl(Label.of(typeProto.getScope(), typeProto.getLabel()), typeProto.getRoot());
     }
 
     public static ConceptProto.Type protoRoleType(RoleType roleType) {

--- a/concept/type/RoleTypeImpl.java
+++ b/concept/type/RoleTypeImpl.java
@@ -42,7 +42,7 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
         return new RoleTypeImpl(typeProto.getScope(), typeProto.getLabel(), typeProto.getRoot());
     }
 
-    public static ConceptProto.Type protoRoleTypes(RoleType roleType) {
+    public static ConceptProto.Type protoRoleType(RoleType roleType) {
         return RequestBuilder.Type.RoleType.protoRoleType(roleType.getLabel(), TypeImpl.encoding(roleType));
     }
 

--- a/concept/type/RoleTypeImpl.java
+++ b/concept/type/RoleTypeImpl.java
@@ -88,7 +88,7 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
         @Override
         public final RelationType getRelationType() {
             assert getLabel().scope().isPresent();
-            return transactionRPC.concepts().getRelationType(getLabel().scope().get());
+            return transactionExt.concepts().getRelationType(getLabel().scope().get());
         }
 
         @Override
@@ -108,7 +108,7 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
         @Override
         public final boolean isDeleted() {
             return getRelationType() == null ||
-                    getRelationType().asRemote(transactionRPC).getRelates(getLabel().name()) == null;
+                    getRelationType().asRemote(transactionExt).getRelates(getLabel().name()) == null;
         }
 
         @Override

--- a/concept/type/ThingTypeImpl.java
+++ b/concept/type/ThingTypeImpl.java
@@ -47,8 +47,8 @@ import static grakn.client.concept.type.RoleTypeImpl.protoRoleType;
 
 public class ThingTypeImpl extends TypeImpl implements ThingType {
 
-    ThingTypeImpl(String label, boolean isRoot) {
-        super(Label.of(label), isRoot);
+    ThingTypeImpl(Label label, boolean isRoot) {
+        super(label, isRoot);
     }
 
     public static ThingTypeImpl of(ConceptProto.Type typeProto) {
@@ -61,7 +61,7 @@ public class ThingTypeImpl extends TypeImpl implements ThingType {
                 return AttributeTypeImpl.of(typeProto);
             case THING_TYPE:
                 assert typeProto.getRoot();
-                return new ThingTypeImpl(typeProto.getLabel(), typeProto.getRoot());
+                return new ThingTypeImpl(Label.of(typeProto.getLabel()), typeProto.getRoot());
             case UNRECOGNIZED:
             default:
                 throw new GraknClientException(BAD_ENCODING, typeProto.getEncoding());

--- a/concept/type/ThingTypeImpl.java
+++ b/concept/type/ThingTypeImpl.java
@@ -209,7 +209,7 @@ public class ThingTypeImpl extends TypeImpl implements ThingType {
 
         @Override
         public final boolean isDeleted() {
-            return transactionRPC.concepts().getThingType(getLabel().name()) == null;
+            return transactionExt.concepts().getThingType(getLabel().name()) == null;
         }
     }
 }

--- a/concept/type/ThingTypeImpl.java
+++ b/concept/type/ThingTypeImpl.java
@@ -43,7 +43,7 @@ import static grakn.client.common.rpc.RequestBuilder.Type.ThingType.setSupertype
 import static grakn.client.common.rpc.RequestBuilder.Type.ThingType.unsetAbstractReq;
 import static grakn.client.common.rpc.RequestBuilder.Type.ThingType.unsetOwnsReq;
 import static grakn.client.common.rpc.RequestBuilder.Type.ThingType.unsetPlaysReq;
-import static grakn.client.concept.type.RoleTypeImpl.protoRoleTypes;
+import static grakn.client.concept.type.RoleTypeImpl.protoRoleType;
 
 public class ThingTypeImpl extends TypeImpl implements ThingType {
 
@@ -128,12 +128,12 @@ public class ThingTypeImpl extends TypeImpl implements ThingType {
 
         @Override
         public final void setPlays(RoleType roleType) {
-            execute(setPlaysReq(getLabel(), protoRoleTypes(roleType)));
+            execute(setPlaysReq(getLabel(), protoRoleType(roleType)));
         }
 
         @Override
         public final void setPlays(RoleType roleType, RoleType overriddenRoleType) {
-            execute(setPlaysReq(getLabel(), protoRoleTypes(roleType), protoRoleTypes(overriddenRoleType)));
+            execute(setPlaysReq(getLabel(), protoRoleType(roleType), protoRoleType(overriddenRoleType)));
         }
 
         @Override
@@ -189,7 +189,7 @@ public class ThingTypeImpl extends TypeImpl implements ThingType {
 
         @Override
         public final void unsetPlays(RoleType roleType) {
-            execute(unsetPlaysReq(getLabel(), protoRoleTypes(roleType)));
+            execute(unsetPlaysReq(getLabel(), protoRoleType(roleType)));
         }
 
         @Override

--- a/concept/type/TypeImpl.java
+++ b/concept/type/TypeImpl.java
@@ -144,7 +144,7 @@ public abstract class TypeImpl extends ConceptImpl implements Type {
 
     public abstract static class Remote extends ConceptImpl.Remote implements Type.Remote {
 
-        final GraknTransaction.Extended transactionRPC;
+        final GraknTransaction.Extended transactionExt;
         private Label label;
         private final boolean isRoot;
         private int hash;
@@ -152,10 +152,10 @@ public abstract class TypeImpl extends ConceptImpl implements Type {
         Remote(GraknTransaction transaction, Label label, boolean isRoot) {
             if (transaction == null) throw new GraknClientException(MISSING_TRANSACTION);
             if (label == null) throw new GraknClientException(MISSING_LABEL);
-            this.transactionRPC = (GraknTransaction.Extended) transaction;
+            this.transactionExt = (GraknTransaction.Extended) transaction;
             this.label = label;
             this.isRoot = isRoot;
-            this.hash = Objects.hash(this.transactionRPC, label);
+            this.hash = Objects.hash(this.transactionExt, label);
         }
 
         @Override
@@ -172,7 +172,7 @@ public abstract class TypeImpl extends ConceptImpl implements Type {
         public final void setLabel(String newLabel) {
             execute(setLabelReq(getLabel(), newLabel));
             this.label = Label.of(label.scope().orElse(null), newLabel);
-            this.hash = Objects.hash(transactionRPC, this.label);
+            this.hash = Objects.hash(transactionExt, this.label);
         }
 
         @Override
@@ -263,15 +263,15 @@ public abstract class TypeImpl extends ConceptImpl implements Type {
         }
 
         final GraknTransaction tx() {
-            return transactionRPC;
+            return transactionExt;
         }
 
         protected ConceptProto.Type.Res execute(TransactionProto.Transaction.Req.Builder request) {
-            return transactionRPC.execute(request).getTypeRes();
+            return transactionExt.execute(request).getTypeRes();
         }
 
         protected Stream<ConceptProto.Type.ResPart> stream(TransactionProto.Transaction.Req.Builder request) {
-            return transactionRPC.stream(request).map(TransactionProto.Transaction.ResPart::getTypeResPart);
+            return transactionExt.stream(request).map(TransactionProto.Transaction.ResPart::getTypeResPart);
         }
 
         @Override
@@ -285,7 +285,7 @@ public abstract class TypeImpl extends ConceptImpl implements Type {
             if (o == null || getClass() != o.getClass()) return false;
 
             TypeImpl.Remote that = (TypeImpl.Remote) o;
-            return this.transactionRPC.equals(that.transactionRPC) &&
+            return this.transactionExt.equals(that.transactionExt) &&
                     this.getLabel().equals(that.getLabel());
         }
 

--- a/concept/type/TypeImpl.java
+++ b/concept/type/TypeImpl.java
@@ -56,7 +56,7 @@ import static grakn.client.common.rpc.RequestBuilder.Type.getSupertypeReq;
 import static grakn.client.common.rpc.RequestBuilder.Type.getSupertypesReq;
 import static grakn.client.common.rpc.RequestBuilder.Type.isAbstractReq;
 import static grakn.client.common.rpc.RequestBuilder.Type.setLabelReq;
-import static grakn.client.concept.type.RoleTypeImpl.protoRoleTypes;
+import static grakn.client.concept.type.RoleTypeImpl.protoRoleType;
 import static grakn.client.concept.type.ThingTypeImpl.protoThingType;
 import static grakn.common.util.Objects.className;
 import static java.util.stream.Collectors.toList;
@@ -104,7 +104,7 @@ public abstract class TypeImpl extends ConceptImpl implements Type {
     public static List<ConceptProto.Type> protoTypes(Collection<? extends Type> types) {
         return types.stream().map(type -> {
             if (type.isThingType()) return protoThingType(type.asThingType());
-            else return protoRoleTypes(type.asRoleType());
+            else return protoRoleType(type.asRoleType());
         }).collect(toList());
     }
 

--- a/logic/RuleImpl.java
+++ b/logic/RuleImpl.java
@@ -105,7 +105,7 @@ public class RuleImpl implements Rule {
 
     public static class Remote implements Rule.Remote {
 
-        final GraknTransaction.Extended transactionRPC;
+        final GraknTransaction.Extended transactionExt;
         private String label;
         private final Conjunction<? extends Pattern> when;
         private final ThingVariable<?> then;
@@ -114,7 +114,7 @@ public class RuleImpl implements Rule {
         public Remote(GraknTransaction transaction, String label, Conjunction<? extends Pattern> when, ThingVariable<?> then) {
             if (transaction == null) throw new GraknClientException(MISSING_TRANSACTION);
             if (label == null || label.isEmpty()) throw new GraknClientException(MISSING_LABEL);
-            this.transactionRPC = (GraknTransaction.Extended) transaction;
+            this.transactionExt = (GraknTransaction.Extended) transaction;
             this.label = label;
             this.when = when;
             this.then = then;
@@ -138,18 +138,18 @@ public class RuleImpl implements Rule {
 
         @Override
         public void setLabel(String newLabel) {
-            transactionRPC.execute(setLabelReq(label, newLabel));
+            transactionExt.execute(setLabelReq(label, newLabel));
             this.label = newLabel;
         }
 
         @Override
         public void delete() {
-            transactionRPC.execute(deleteReq(label));
+            transactionExt.execute(deleteReq(label));
         }
 
         @Override
         public final boolean isDeleted() {
-            return transactionRPC.logic().getRule(label) != null;
+            return transactionExt.logic().getRule(label) != null;
         }
 
         @Override
@@ -173,7 +173,7 @@ public class RuleImpl implements Rule {
             if (o == null || getClass() != o.getClass()) return false;
 
             RuleImpl.Remote that = (RuleImpl.Remote) o;
-            return this.transactionRPC.equals(that.transactionRPC) && this.label.equals(that.label);
+            return this.transactionExt.equals(that.transactionExt) && this.label.equals(that.label);
         }
 
         @Override

--- a/query/QueryManagerImpl.java
+++ b/query/QueryManagerImpl.java
@@ -54,10 +54,10 @@ import static grakn.client.common.rpc.RequestBuilder.QueryManager.updateReq;
 
 public final class QueryManagerImpl implements QueryManager {
 
-    private final GraknTransaction.Extended transactionRPC;
+    private final GraknTransaction.Extended transactionExt;
 
-    public QueryManagerImpl(GraknTransaction.Extended transactionRPC) {
-        this.transactionRPC = transactionRPC;
+    public QueryManagerImpl(GraknTransaction.Extended transactionExt) {
+        this.transactionExt = transactionExt;
     }
 
     @Override
@@ -163,14 +163,14 @@ public final class QueryManagerImpl implements QueryManager {
     }
 
     private QueryFuture<Void> queryVoid(TransactionProto.Transaction.Req.Builder req) {
-        return transactionRPC.query(req).map(res -> null);
+        return transactionExt.query(req).map(res -> null);
     }
 
     private QueryFuture<QueryProto.QueryManager.Res> query(TransactionProto.Transaction.Req.Builder req) {
-        return transactionRPC.query(req).map(TransactionProto.Transaction.Res::getQueryManagerRes);
+        return transactionExt.query(req).map(TransactionProto.Transaction.Res::getQueryManagerRes);
     }
 
     private Stream<QueryProto.QueryManager.ResPart> stream(TransactionProto.Transaction.Req.Builder req) {
-        return transactionRPC.stream(req).map(TransactionProto.Transaction.ResPart::getQueryManagerResPart);
+        return transactionExt.stream(req).map(TransactionProto.Transaction.ResPart::getQueryManagerResPart);
     }
 }

--- a/query/QueryManagerImpl.java
+++ b/query/QueryManagerImpl.java
@@ -138,7 +138,7 @@ public final class QueryManagerImpl implements QueryManager {
     @Override
     public Stream<ConceptMap> update(GraqlUpdate query, GraknOptions options) {
         return stream(updateReq(query.toString(), options.proto()))
-                .flatMap(rp -> rp.getInsertResPart().getAnswersList().stream())
+                .flatMap(rp -> rp.getUpdateResPart().getAnswersList().stream())
                 .map(ConceptMapImpl::of);
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

We fixed a possible error when getting the results of a Graql Update query, and cleaned up various unnecessary or confusing methods in the Concept package.

## What are the changes implemented in this PR?

- Fix possible error getting results of an Update query
- Fix inaccurate RequestBuilder method names
- Rename protoRoleTypes, transactionRPC
- Delete AttributeType.isKeyable
