### PR TITLE
Upgrade assemble_maven to use rewritten rule

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -25,7 +25,8 @@ load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 load("@graknlabs_dependencies//distribution/maven:version.bzl", "version")
 load("@graknlabs_dependencies//library/maven:artifacts.bzl", artifacts_org = "artifacts")
 load("//dependencies/maven:artifacts.bzl", artifacts_repo = "overrides")
-load("@graknlabs_bazel_distribution//maven:rules.bzl", "deploy_maven", "assemble_maven")
+load("@graknlabs_bazel_distribution//maven:rules.bzl", "deploy_maven")
+load("@graknlabs_bazel_distribution//maven:new_rules.bzl", "assemble_maven")
 load("@graknlabs_bazel_distribution//github:rules.bzl", "deploy_github")
 load("@graknlabs_dependencies//distribution:deployment.bzl", "deployment")
 load("//:deployment.bzl", github_deployment = "deployment")
@@ -56,14 +57,13 @@ checkstyle_test(
 assemble_maven(
     name = "assemble-maven",
     target = ":client-java",
-    package = "client-java",
     workspace_refs = "@graknlabs_client_java_workspace_refs//:refs.json",
     version_overrides = version(artifacts_org, artifacts_repo),
     project_name = "Grakn Client Java",
     project_description = "Grakn Client API for Java",
     project_url = "https://github.com/graknlabs/client-java",
     scm_url = "https://github.com/graknlabs/client-java",
-    source_jar_prefix = "grakn/client",
+    source_jar_prefix = "grakn/client/",
 )
 
 deploy_maven(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -90,6 +90,8 @@ rules_pkg()
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 rules_pkg_dependencies()
 
+load("@graknlabs_bazel_distribution//maven:deps.bzl", graknlabs_bazel_distribution_maven_artifacts = "maven_artifacts")
+
 # Load //github
 load("@graknlabs_bazel_distribution//github:deps.bzl", github_deps = "deps")
 github_deps()
@@ -125,7 +127,8 @@ maven(
     graknlabs_grabl_tracing_artifacts +
     graknlabs_graql_artifacts +
     graknlabs_dependencies_tool_maven_artifacts +
-    graknlabs_client_java_artifacts,
+    graknlabs_client_java_artifacts +
+    graknlabs_bazel_distribution_maven_artifacts,
 
     graknlabs_client_java_overrides
 )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -37,7 +37,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "afb7192e104dd36776953cbd041bfc6c5802650d", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "5cff3a6cf388fe799b6e27af4772384fbbfc317b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_protocol():

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -30,6 +30,8 @@
 @maven//:commons_io_commons_io_2_3
 @maven//:commons_logging_commons_logging
 @maven//:commons_logging_commons_logging_1_2
+@maven//:info_picocli_picocli
+@maven//:info_picocli_picocli_4_3_2
 @maven//:io_cucumber_cucumber_core
 @maven//:io_cucumber_cucumber_core_5_1_3
 @maven//:io_cucumber_cucumber_expressions


### PR DESCRIPTION
## What is the goal of this PR?

Use the modernized `assemble_maven` written in Kotlin

## What are the changes implemented in this PR?

Use `assemble_maven` from `@graknlabs_bazel_distribution//maven:new_rules.bzl` and update the attributes