### PR TITLE
Fix deploying client-java to Maven

### DIFF
--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -37,7 +37,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "5cff3a6cf388fe799b6e27af4772384fbbfc317b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "34b2d3329431ef3370f396263fe3a706fc0b538c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_protocol():


### PR DESCRIPTION
## What is the goal of this PR?

Fix deployment of Client Java to Maven

## What are the changes implemented in this PR?

Upgrade `@graknlabs_dependencies` to include fixes from graknlabs/bazel-distribution#294