### PR TITLE
Encode request IDs as bytes and make isInferred a Local Thing method

### DIFF
--- a/api/concept/thing/Thing.java
+++ b/api/concept/thing/Thing.java
@@ -36,6 +36,9 @@ public interface Thing extends Concept {
     @CheckReturnValue
     ThingType getType();
 
+    @CheckReturnValue
+    boolean isInferred();
+
     @Override
     @CheckReturnValue
     default boolean isThing() {
@@ -51,9 +54,6 @@ public interface Thing extends Concept {
         void setHas(Attribute<?> attribute);
 
         void unsetHas(Attribute<?> attribute);
-
-        @CheckReturnValue
-        boolean isInferred();
 
         @CheckReturnValue
         Stream<? extends Attribute<?>> getHas(boolean onlyKey);

--- a/common/collection/Bytes.java
+++ b/common/collection/Bytes.java
@@ -1,0 +1,21 @@
+package grakn.client.common.collection;
+
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+public class Bytes {
+
+    public static byte[] uuidToBytes(UUID uuid) {
+        ByteBuffer buffer = ByteBuffer.wrap(new byte[16]);
+        buffer.putLong(uuid.getMostSignificantBits());
+        buffer.putLong(uuid.getLeastSignificantBits());
+        return buffer.array();
+    }
+
+    public static UUID bytesToUUID(byte[] bytes) {
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        long firstLong = buffer.getLong();
+        long secondLong = buffer.getLong();
+        return new UUID(firstLong, secondLong);
+    }
+}

--- a/common/collection/Bytes.java
+++ b/common/collection/Bytes.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package grakn.client.common.collection;
 
 import java.nio.ByteBuffer;

--- a/common/rpc/RequestBuilder.java
+++ b/common/rpc/RequestBuilder.java
@@ -577,12 +577,6 @@ public class RequestBuilder {
             return TransactionProto.Transaction.Req.newBuilder().setThingReq(req);
         }
 
-        public static TransactionProto.Transaction.Req.Builder isInferredReq(String iid) {
-            return thingReq(ConceptProto.Thing.Req.newBuilder().setIid(byteString(iid)).setThingIsInferredReq(
-                    ConceptProto.Thing.IsInferred.Req.getDefaultInstance())
-            );
-        }
-
         public static TransactionProto.Transaction.Req.Builder getHasReq(
                 String iid, List<ConceptProto.Type> attributeTypes) {
             return thingReq(ConceptProto.Thing.Req.newBuilder().setIid(byteString(iid)).setThingGetHasReq(

--- a/common/rpc/RequestBuilder.java
+++ b/common/rpc/RequestBuilder.java
@@ -44,8 +44,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static com.google.protobuf.ByteString.copyFrom;
 import static grabl.tracing.client.GrablTracingThreadStatic.currentThreadTrace;
 import static grabl.tracing.client.GrablTracingThreadStatic.isTracingEnabled;
+import static grakn.client.common.collection.Bytes.uuidToBytes;
 import static grakn.client.common.rpc.RequestBuilder.Thing.byteString;
 import static grakn.common.collection.Bytes.hexStringToBytes;
 import static java.util.Collections.emptyMap;
@@ -65,6 +67,10 @@ public class RequestBuilder {
         } else {
             return emptyMap();
         }
+    }
+
+    public static ByteString UUIDAsByteString(UUID uuid) {
+        return copyFrom(uuidToBytes(uuid));
     }
 
     public static class Core {
@@ -145,7 +151,7 @@ public class RequestBuilder {
         }
 
         public static TransactionProto.Transaction.Req streamReq(UUID reqID) {
-            return TransactionProto.Transaction.Req.newBuilder().setReqId(reqID.toString()).setStreamReq(
+            return TransactionProto.Transaction.Req.newBuilder().setReqId(UUIDAsByteString(reqID)).setStreamReq(
                     TransactionProto.Transaction.Stream.Req.getDefaultInstance()
             ).build();
         }

--- a/concept/thing/AttributeImpl.java
+++ b/concept/thing/AttributeImpl.java
@@ -40,8 +40,8 @@ import static grakn.common.util.Objects.className;
 
 public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribute<VALUE> {
 
-    AttributeImpl(java.lang.String iid) {
-        super(iid);
+    AttributeImpl(java.lang.String iid, boolean isInferred) {
+        super(iid, isInferred);
     }
 
     public static AttributeImpl<?> of(ConceptProto.Thing thingProto) {
@@ -99,8 +99,8 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
     public abstract static class Remote<VALUE> extends ThingImpl.Remote implements Attribute.Remote<VALUE> {
 
-        Remote(GraknTransaction transaction, java.lang.String iid) {
-            super(transaction, iid);
+        Remote(GraknTransaction transaction, java.lang.String iid, boolean isInferred) {
+            super(transaction, iid, isInferred);
         }
 
         @Override
@@ -158,8 +158,8 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
         private final AttributeTypeImpl.Boolean type;
         private final java.lang.Boolean value;
 
-        Boolean(java.lang.String iid, AttributeTypeImpl.Boolean type, boolean value) {
-            super(iid);
+        Boolean(java.lang.String iid, boolean isInferred, AttributeTypeImpl.Boolean type, boolean value) {
+            super(iid, isInferred);
             this.type = type;
             this.value = value;
         }
@@ -167,6 +167,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
         public static AttributeImpl.Boolean of(ConceptProto.Thing thingProto) {
             return new AttributeImpl.Boolean(
                     bytesToHexString(thingProto.getIid().toByteArray()),
+                    thingProto.getInferred(),
                     AttributeTypeImpl.Boolean.of(thingProto.getType()),
                     thingProto.getValue().getBoolean()
             );
@@ -189,7 +190,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
         @Override
         public AttributeImpl.Boolean.Remote asRemote(GraknTransaction transaction) {
-            return new AttributeImpl.Boolean.Remote(transaction, getIID(), type, value);
+            return new AttributeImpl.Boolean.Remote(transaction, getIID(), isInferred(), type, value);
         }
 
         public static class Remote extends AttributeImpl.Remote<java.lang.Boolean> implements Attribute.Boolean.Remote {
@@ -197,15 +198,15 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
             private final AttributeTypeImpl.Boolean type;
             private final java.lang.Boolean value;
 
-            Remote(GraknTransaction transaction, java.lang.String iid, AttributeTypeImpl.Boolean type, java.lang.Boolean value) {
-                super(transaction, iid);
+            Remote(GraknTransaction transaction, java.lang.String iid, boolean isInferred, AttributeTypeImpl.Boolean type, java.lang.Boolean value) {
+                super(transaction, iid, isInferred);
                 this.type = type;
                 this.value = value;
             }
 
             @Override
             public Attribute.Boolean.Remote asRemote(GraknTransaction transaction) {
-                return new AttributeImpl.Boolean.Remote(transaction, getIID(), type, value);
+                return new AttributeImpl.Boolean.Remote(transaction, getIID(), isInferred(), type, value);
             }
 
             @Override
@@ -230,8 +231,8 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
         private final AttributeTypeImpl.Long type;
         private final long value;
 
-        Long(java.lang.String iid, AttributeTypeImpl.Long type, long value) {
-            super(iid);
+        Long(java.lang.String iid, boolean isInferred, AttributeTypeImpl.Long type, long value) {
+            super(iid, isInferred);
             this.type = type;
             this.value = value;
         }
@@ -239,6 +240,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
         public static AttributeImpl.Long of(ConceptProto.Thing thingProto) {
             return new AttributeImpl.Long(
                     bytesToHexString(thingProto.getIid().toByteArray()),
+                    thingProto.getInferred(),
                     AttributeTypeImpl.Long.of(thingProto.getType()),
                     thingProto.getValue().getLong()
             );
@@ -261,7 +263,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
         @Override
         public AttributeImpl.Long.Remote asRemote(GraknTransaction transaction) {
-            return new AttributeImpl.Long.Remote(transaction, getIID(), type, value);
+            return new AttributeImpl.Long.Remote(transaction, getIID(), isInferred(), type, value);
         }
 
         public static class Remote extends AttributeImpl.Remote<java.lang.Long> implements Attribute.Long.Remote {
@@ -269,15 +271,15 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
             private final AttributeTypeImpl.Long type;
             private final long value;
 
-            Remote(GraknTransaction transaction, java.lang.String iid, AttributeTypeImpl.Long type, long value) {
-                super(transaction, iid);
+            Remote(GraknTransaction transaction, java.lang.String iid, boolean isInferred, AttributeTypeImpl.Long type, long value) {
+                super(transaction, iid, isInferred);
                 this.type = type;
                 this.value = value;
             }
 
             @Override
             public Attribute.Long.Remote asRemote(GraknTransaction transaction) {
-                return new AttributeImpl.Long.Remote(transaction, getIID(), type, value);
+                return new AttributeImpl.Long.Remote(transaction, getIID(), isInferred(), type, value);
             }
 
             @Override
@@ -302,8 +304,8 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
         private final AttributeTypeImpl.Double type;
         private final double value;
 
-        Double(java.lang.String iid, AttributeTypeImpl.Double type, double value) {
-            super(iid);
+        Double(java.lang.String iid, boolean isInferred, AttributeTypeImpl.Double type, double value) {
+            super(iid, isInferred);
             this.type = type;
             this.value = value;
         }
@@ -311,6 +313,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
         public static AttributeImpl.Double of(ConceptProto.Thing thingProto) {
             return new AttributeImpl.Double(
                     bytesToHexString(thingProto.getIid().toByteArray()),
+                    thingProto.getInferred(),
                     AttributeTypeImpl.Double.of(thingProto.getType()),
                     thingProto.getValue().getDouble()
             );
@@ -333,7 +336,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
         @Override
         public AttributeImpl.Double.Remote asRemote(GraknTransaction transaction) {
-            return new AttributeImpl.Double.Remote(transaction, getIID(), type, value);
+            return new AttributeImpl.Double.Remote(transaction, getIID(), isInferred(), type, value);
         }
 
         public static class Remote extends AttributeImpl.Remote<java.lang.Double> implements Attribute.Double.Remote {
@@ -341,15 +344,15 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
             private final AttributeTypeImpl.Double type;
             private final double value;
 
-            Remote(GraknTransaction transaction, java.lang.String iid, AttributeTypeImpl.Double type, double value) {
-                super(transaction, iid);
+            Remote(GraknTransaction transaction, java.lang.String iid, boolean isInferred, AttributeTypeImpl.Double type, double value) {
+                super(transaction, iid, isInferred);
                 this.type = type;
                 this.value = value;
             }
 
             @Override
             public Attribute.Double.Remote asRemote(GraknTransaction transaction) {
-                return new AttributeImpl.Double.Remote(transaction, getIID(), type, value);
+                return new AttributeImpl.Double.Remote(transaction, getIID(), isInferred(), type, value);
             }
 
             @Override
@@ -374,8 +377,8 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
         private final AttributeTypeImpl.String type;
         private final java.lang.String value;
 
-        String(java.lang.String iid, AttributeTypeImpl.String type, java.lang.String value) {
-            super(iid);
+        String(java.lang.String iid, boolean isInferred, AttributeTypeImpl.String type, java.lang.String value) {
+            super(iid, isInferred);
             this.type = type;
             this.value = value;
         }
@@ -383,6 +386,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
         public static AttributeImpl.String of(ConceptProto.Thing thingProto) {
             return new AttributeImpl.String(
                     bytesToHexString(thingProto.getIid().toByteArray()),
+                    thingProto.getInferred(),
                     AttributeTypeImpl.String.of(thingProto.getType()),
                     thingProto.getValue().getString()
             );
@@ -405,7 +409,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
         @Override
         public AttributeImpl.String.Remote asRemote(GraknTransaction transaction) {
-            return new AttributeImpl.String.Remote(transaction, getIID(), type, value);
+            return new AttributeImpl.String.Remote(transaction, getIID(), isInferred(), type, value);
         }
 
         public static class Remote extends AttributeImpl.Remote<java.lang.String> implements Attribute.String.Remote {
@@ -413,15 +417,15 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
             private final AttributeTypeImpl.String type;
             private final java.lang.String value;
 
-            Remote(GraknTransaction transaction, java.lang.String iid, AttributeTypeImpl.String type, java.lang.String value) {
-                super(transaction, iid);
+            Remote(GraknTransaction transaction, java.lang.String iid, boolean isInferred, AttributeTypeImpl.String type, java.lang.String value) {
+                super(transaction, iid, isInferred);
                 this.type = type;
                 this.value = value;
             }
 
             @Override
             public Attribute.String.Remote asRemote(GraknTransaction transaction) {
-                return new AttributeImpl.String.Remote(transaction, getIID(), type, value);
+                return new AttributeImpl.String.Remote(transaction, getIID(), isInferred(), type, value);
             }
 
             @Override
@@ -446,8 +450,8 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
         private final AttributeTypeImpl.DateTime type;
         private final LocalDateTime value;
 
-        DateTime(java.lang.String iid, AttributeTypeImpl.DateTime type, LocalDateTime value) {
-            super(iid);
+        DateTime(java.lang.String iid, boolean isInferred, AttributeTypeImpl.DateTime type, LocalDateTime value) {
+            super(iid, isInferred);
             this.type = type;
             this.value = value;
         }
@@ -455,6 +459,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
         public static AttributeImpl.DateTime of(ConceptProto.Thing thingProto) {
             return new AttributeImpl.DateTime(
                     bytesToHexString(thingProto.getIid().toByteArray()),
+                    thingProto.getInferred(),
                     AttributeTypeImpl.DateTime.of(thingProto.getType()),
                     toLocalDateTime(thingProto.getValue().getDateTime())
             );
@@ -477,7 +482,7 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
         @Override
         public AttributeImpl.DateTime.Remote asRemote(GraknTransaction transaction) {
-            return new AttributeImpl.DateTime.Remote(transaction, getIID(), type, value);
+            return new AttributeImpl.DateTime.Remote(transaction, getIID(), isInferred(), type, value);
         }
 
         private static LocalDateTime toLocalDateTime(long rpcDatetime) {
@@ -489,15 +494,15 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
             private final AttributeTypeImpl.DateTime type;
             private final LocalDateTime value;
 
-            Remote(GraknTransaction transaction, java.lang.String iid, AttributeTypeImpl.DateTime type, LocalDateTime value) {
-                super(transaction, iid);
+            Remote(GraknTransaction transaction, java.lang.String iid, boolean isInferred, AttributeTypeImpl.DateTime type, LocalDateTime value) {
+                super(transaction, iid, isInferred);
                 this.type = type;
                 this.value = value;
             }
 
             @Override
             public Attribute.DateTime.Remote asRemote(GraknTransaction transaction) {
-                return new AttributeImpl.DateTime.Remote(transaction, getIID(), type, value);
+                return new AttributeImpl.DateTime.Remote(transaction, getIID(), isInferred(), type, value);
             }
 
             @Override

--- a/concept/thing/EntityImpl.java
+++ b/concept/thing/EntityImpl.java
@@ -29,13 +29,13 @@ public class EntityImpl extends ThingImpl implements Entity {
 
     private final EntityTypeImpl type;
 
-    EntityImpl(String iid, EntityTypeImpl type) {
-        super(iid);
+    EntityImpl(String iid, boolean isInferred, EntityTypeImpl type) {
+        super(iid, isInferred);
         this.type = type;
     }
 
     public static EntityImpl of(ConceptProto.Thing protoThing) {
-        return new EntityImpl(Bytes.bytesToHexString(protoThing.getIid().toByteArray()), EntityTypeImpl.of(protoThing.getType()));
+        return new EntityImpl(Bytes.bytesToHexString(protoThing.getIid().toByteArray()), protoThing.getInferred(), EntityTypeImpl.of(protoThing.getType()));
     }
 
     @Override
@@ -45,7 +45,7 @@ public class EntityImpl extends ThingImpl implements Entity {
 
     @Override
     public EntityImpl.Remote asRemote(GraknTransaction transaction) {
-        return new EntityImpl.Remote(transaction, getIID(), type);
+        return new EntityImpl.Remote(transaction, getIID(), isInferred(), type);
     }
 
     @Override
@@ -57,14 +57,14 @@ public class EntityImpl extends ThingImpl implements Entity {
 
         private final EntityTypeImpl type;
 
-        public Remote(GraknTransaction transaction, String iid, EntityTypeImpl type) {
-            super(transaction, iid);
+        public Remote(GraknTransaction transaction, String iid, boolean isInferred, EntityTypeImpl type) {
+            super(transaction, iid, isInferred);
             this.type = type;
         }
 
         @Override
         public EntityImpl.Remote asRemote(GraknTransaction transaction) {
-            return new EntityImpl.Remote(transaction, getIID(), type);
+            return new EntityImpl.Remote(transaction, getIID(), isInferred(), type);
         }
 
         @Override

--- a/concept/thing/RelationImpl.java
+++ b/concept/thing/RelationImpl.java
@@ -50,19 +50,20 @@ public class RelationImpl extends ThingImpl implements Relation {
 
     private final RelationTypeImpl type;
 
-    RelationImpl(String iid, RelationTypeImpl type) {
-        super(iid);
+    RelationImpl(String iid, boolean isInferred, RelationTypeImpl type) {
+        super(iid, isInferred);
         this.type = type;
     }
 
     public static RelationImpl of(ConceptProto.Thing protoThing) {
         return new RelationImpl(Bytes.bytesToHexString(protoThing.getIid().toByteArray()),
-                                RelationTypeImpl.of(protoThing.getType()));
+                protoThing.getInferred(),
+                RelationTypeImpl.of(protoThing.getType()));
     }
 
     @Override
     public RelationImpl.Remote asRemote(GraknTransaction transaction) {
-        return new RelationImpl.Remote(transaction, getIID(), type);
+        return new RelationImpl.Remote(transaction, getIID(), isInferred(), type);
     }
 
     @Override
@@ -79,14 +80,14 @@ public class RelationImpl extends ThingImpl implements Relation {
 
         private final RelationTypeImpl type;
 
-        public Remote(GraknTransaction transaction, String iid, RelationTypeImpl type) {
-            super(transaction, iid);
+        public Remote(GraknTransaction transaction, String iid, boolean isInferred, RelationTypeImpl type) {
+            super(transaction, iid, isInferred);
             this.type = type;
         }
 
         @Override
         public RelationImpl.Remote asRemote(GraknTransaction transaction) {
-            return new RelationImpl.Remote(transaction, getIID(), type);
+            return new RelationImpl.Remote(transaction, getIID(), isInferred(), type);
         }
 
         @Override

--- a/concept/thing/ThingImpl.java
+++ b/concept/thing/ThingImpl.java
@@ -41,7 +41,6 @@ import static grakn.client.common.rpc.RequestBuilder.Thing.deleteReq;
 import static grakn.client.common.rpc.RequestBuilder.Thing.getHasReq;
 import static grakn.client.common.rpc.RequestBuilder.Thing.getPlayingReq;
 import static grakn.client.common.rpc.RequestBuilder.Thing.getRelationsReq;
-import static grakn.client.common.rpc.RequestBuilder.Thing.isInferredReq;
 import static grakn.client.common.rpc.RequestBuilder.Thing.protoThing;
 import static grakn.client.common.rpc.RequestBuilder.Thing.setHasReq;
 import static grakn.client.common.rpc.RequestBuilder.Thing.unsetHasReq;
@@ -52,10 +51,12 @@ import static java.util.Arrays.asList;
 public abstract class ThingImpl extends ConceptImpl implements Thing {
 
     private final String iid;
+    private final boolean isInferred;
 
-    ThingImpl(String iid) {
+    ThingImpl(String iid, boolean isInferred) {
         if (iid == null || iid.isEmpty()) throw new GraknClientException(MISSING_IID);
         this.iid = iid;
+        this.isInferred = isInferred;
     }
 
     public static ThingImpl of(ConceptProto.Thing thingProto) {
@@ -79,6 +80,11 @@ public abstract class ThingImpl extends ConceptImpl implements Thing {
 
     @Override
     public abstract ThingTypeImpl getType();
+
+    @Override
+    public boolean isInferred() {
+        return isInferred;
+    }
 
     @Override
     public ThingImpl asThing() {
@@ -108,13 +114,15 @@ public abstract class ThingImpl extends ConceptImpl implements Thing {
 
         final GraknTransaction.Extended transactionRPC;
         private final String iid;
+        private final boolean isInferred;
         private final int hash;
 
-        Remote(GraknTransaction transaction, String iid) {
+        Remote(GraknTransaction transaction, String iid, boolean isInferred) {
             if (transaction == null) throw new GraknClientException(MISSING_TRANSACTION);
             this.transactionRPC = (GraknTransaction.Extended) transaction;
             if (iid == null || iid.isEmpty()) throw new GraknClientException(MISSING_IID);
             this.iid = iid;
+            this.isInferred = isInferred;
             this.hash = Objects.hash(this.transactionRPC, this.getIID());
         }
 
@@ -127,8 +135,8 @@ public abstract class ThingImpl extends ConceptImpl implements Thing {
         public abstract ThingTypeImpl getType();
 
         @Override
-        public final boolean isInferred() {
-            return execute(isInferredReq(getIID())).getThingIsInferredRes().getInferred();
+        public boolean isInferred() {
+            return isInferred;
         }
 
         @Override

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,7 +27,7 @@ def graknlabs_grakn_core_artifact():
         artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "d9c34353ca57d5e916c71077c257cde9a0f2fed7"
+        commit = "922f9e50d05fd24187c5f020a8fc720722d49a60"
     )
 
 def graknlabs_grakn_cluster_artifact():
@@ -37,5 +37,5 @@ def graknlabs_grakn_cluster_artifact():
         artifact_name = "grakn-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "f08e4d9e194ee7e1806995377c8b0a7bd56903ec",
+        commit = "ff24c81c3ce821d25df802192db05d6084365161",
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -43,8 +43,8 @@ def graknlabs_dependencies():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/graknlabs/protocol",
-        tag = "2.0.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/alexjpwalker/protocol",
+        commit = "d8ec1776bbd799e1e969138c458d670785d05c69", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -44,7 +44,7 @@ def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/alexjpwalker/protocol",
-        commit = "d8ec1776bbd799e1e969138c458d670785d05c69", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "39122114004684f270d78fa7da0e500f4c575e10", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_behaviour():

--- a/stream/BUILD
+++ b/stream/BUILD
@@ -34,6 +34,7 @@ java_library(
 
         # External dependencies from Maven
         "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:io_grpc_grpc_stub",
         "@maven//:io_grpc_grpc_api",
         "@maven//:org_slf4j_slf4j_api"

--- a/test/behaviour/connection/transaction/TransactionSteps.java
+++ b/test/behaviour/connection/transaction/TransactionSteps.java
@@ -19,6 +19,7 @@
 
 package grakn.client.test.behaviour.connection.transaction;
 
+import grakn.client.api.GraknOptions;
 import grakn.client.api.GraknSession;
 import grakn.client.api.GraknTransaction;
 import graql.lang.Graql;
@@ -65,7 +66,7 @@ public class TransactionSteps {
         for (GraknSession session : sessions) {
             List<GraknTransaction> transactions = new ArrayList<>();
             for (GraknTransaction.Type type : types) {
-                GraknTransaction transaction = session.transaction(type);
+                GraknTransaction transaction = session.transaction(type, GraknOptions.core().infer(true));
                 transactions.add(transaction);
             }
             sessionsToTransactions.put(session, transactions);

--- a/test/integration/ClientQueryTest.java
+++ b/test/integration/ClientQueryTest.java
@@ -514,7 +514,7 @@ public class ClientQueryTest {
             assertEquals(3, explanations.size());
             List<Explanation> explanations2 = tx.query().explain(answers.get(1).explainables().relations().values().iterator().next()).collect(Collectors.toList());
             assertEquals(3, explanations2.size());
-        }, READ, GraknOptions.core().explain(true));
+        }, READ, GraknOptions.core().infer(true).explain(true));
     }
 
     private String[] lionNames() {


### PR DESCRIPTION
## What is the goal of this PR?

Previously the ID of a transaction request was stored as a string, which is an inefficient representation of a UUID. We've changed it to bytes.

Also, `isInferred` is now a Local method on `Thing`.

## What are the changes implemented in this PR?

Store request IDs as bytes, not strings
Make isInferred a Local Thing method