### PR TITLE
Fix possible NullPointer errors when connecting to Cluster

### DIFF
--- a/cluster/ClusterClient.java
+++ b/cluster/ClusterClient.java
@@ -77,7 +77,7 @@ public class ClusterClient implements GraknClient.Cluster {
                 LOG.debug("The cluster servers are {}", members);
                 return members;
             } catch (GraknClientException e) {
-                if (e.getErrorMessage().equals(UNABLE_TO_CONNECT)) {
+                if (UNABLE_TO_CONNECT.equals(e.getErrorMessage())) {
                     LOG.error("Fetching cluster servers from {} failed.", address);
                 } else {
                     throw e;

--- a/cluster/FailsafeTask.java
+++ b/cluster/FailsafeTask.java
@@ -21,7 +21,6 @@ package grakn.client.cluster;
 
 import grakn.client.common.exception.GraknClientException;
 import grakn.protocol.ClusterDatabaseProto;
-import io.grpc.StatusRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -128,7 +127,7 @@ abstract class FailsafeTask<RESULT> {
                 client.databaseByName().put(database, clusterDatabase);
                 return clusterDatabase;
             } catch (GraknClientException e) {
-                if (e.getErrorMessage().equals(UNABLE_TO_CONNECT)) {
+                if (UNABLE_TO_CONNECT.equals(e.getErrorMessage())) {
                     LOG.debug("Failed to fetch replica info for database '" + database + "' from " +
                             serverAddress + ". Attempting next server.", e);
                 } else {

--- a/common/exception/GraknClientException.java
+++ b/common/exception/GraknClientException.java
@@ -63,6 +63,8 @@ public class GraknClientException extends RuntimeException {
 
     // TODO: propagate exception from the server side in a less-brittle way
     private static boolean isReplicaNotPrimaryException(StatusRuntimeException statusRuntimeException) {
-        return statusRuntimeException.getStatus().getCode() == Status.Code.INTERNAL && statusRuntimeException.getStatus().getDescription().contains("[RPL01]");
+        return statusRuntimeException.getStatus().getCode() == Status.Code.INTERNAL
+                && statusRuntimeException.getStatus().getDescription() != null
+                && statusRuntimeException.getStatus().getDescription().contains("[RPL01]");
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

We fixed a few possible sources of `NullPointerException` which would be thrown while trying to print other errors when constructing a Cluster client or during Cluster operations.

## What are the changes implemented in this PR?

Fix Null errors when trying to print other errors
