### PR TITLE
Invert address translation table: map public addresses to private

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -26,7 +26,7 @@ config:
 build:
   quality:
     filter:
-      owner: vaticle
+      owner: typedb
       branch: [master, development]
     dependency-analysis:
       image: vaticle-ubuntu-22.04
@@ -125,7 +125,7 @@ build:
       machine: 8-core-32-gb
       image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
       filter:
-        owner: vaticle
+        owner: typedb
         branch: [master, development]
       dependencies:
         - build
@@ -149,7 +149,7 @@ build:
       machine: 8-core-32-gb
       image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
       filter:
-        owner: vaticle
+        owner: typedb
         branch: [master, development]
       dependencies:
         - build
@@ -509,7 +509,7 @@ build:
     sync-dependencies:
       image: vaticle-ubuntu-22.04
       filter:
-        owner: vaticle
+        owner: typedb
         branch: [master, development]
       dependencies:
         - build
@@ -546,7 +546,7 @@ build:
 
 release:
   filter:
-    owner: vaticle
+    owner: typedb
     branch: [master]
   validation:
     validate-dependencies:

--- a/c/src/concept/concept.rs
+++ b/c/src/concept/concept.rs
@@ -19,7 +19,7 @@
 
 use std::ffi::c_char;
 
-use chrono::NaiveDateTime;
+use chrono::DateTime;
 use typedb_driver::{
     concept::{
         Annotation, Attribute, AttributeType, Concept, Entity, EntityType, Relation, RelationType, RoleType, Value,
@@ -56,7 +56,7 @@ pub extern "C" fn value_new_string(string: *const c_char) -> *mut Concept {
 /// Creates a new ``Value`` object of the specified datetime value.
 #[no_mangle]
 pub extern "C" fn value_new_date_time_from_millis(millis: i64) -> *mut Concept {
-    release(Concept::Value(Value::DateTime(NaiveDateTime::from_timestamp_millis(millis).unwrap())))
+    release(Concept::Value(Value::DateTime(DateTime::from_timestamp_millis(millis).unwrap().naive_utc())))
 }
 
 /// Returns <code>true</code> if the value which this ``Value`` concept holds is of type <code>boolean</code>.
@@ -143,7 +143,7 @@ pub extern "C" fn value_get_string(value: *const Concept) -> *mut c_char {
 #[no_mangle]
 pub extern "C" fn value_get_date_time_as_millis(value: *const Concept) -> i64 {
     if let Value::DateTime(date_time) = borrow_as_value(value) {
-        date_time.timestamp_millis()
+        date_time.and_utc().timestamp_millis()
     } else {
         unreachable!("Attempting to unwrap a non-datetime {:?} as datetime", borrow_as_value(value))
     }

--- a/c/src/connection.rs
+++ b/c/src/connection.rs
@@ -59,11 +59,11 @@ pub extern "C" fn connection_open_cloud(
 /// @param credential The <code>Credential</code> to connect with
 #[no_mangle]
 pub extern "C" fn connection_open_cloud_translated(
-    advertised_addresses: *const *const c_char,
-    translated_addresses: *const *const c_char,
+    public_addresses: *const *const c_char,
+    private_addresses: *const *const c_char,
     credential: *const Credential,
 ) -> *mut Connection {
-    let addresses = string_array_view(advertised_addresses).zip_eq(string_array_view(translated_addresses)).collect();
+    let addresses = string_array_view(public_addresses).zip_eq(string_array_view(private_addresses)).collect();
     try_release(Connection::new_cloud_with_translation(addresses, borrow(credential).clone()))
 }
 

--- a/c/src/connection.rs
+++ b/c/src/connection.rs
@@ -52,10 +52,10 @@ pub extern "C" fn connection_open_cloud(
 /// Open a TypeDB Driver to TypeDB Cloud server(s), using provided address translation, with
 /// the provided credential.
 ///
-/// @param advertised_addresses A null-terminated array holding the address(es) the TypeDB server(s)
-/// are configured to advertise
-/// @param translated_addresses A null-terminated array holding the address(es) of the TypeDB server(s)
+/// @param public_addresses A null-terminated array holding the address(es) of the TypeDB server(s)
 /// the driver will connect to. This array <i>must</i> have the same length as <code>advertised_addresses</code>
+/// @param private_addresses A null-terminated array holding the address(es) the TypeDB server(s)
+/// are configured to advertise
 /// @param credential The <code>Credential</code> to connect with
 #[no_mangle]
 pub extern "C" fn connection_open_cloud_translated(

--- a/cpp/include/typedb/connection/driver.hpp
+++ b/cpp/include/typedb/connection/driver.hpp
@@ -85,8 +85,8 @@ public:
      * Driver::cloudDriver(addresses, credential);
      * </pre>
      *
-     * @param addresses The address(es) of the TypeDB server(s) or translation map from addresses
-     * received from the TypeDB server(s) to addresses to be used by the driver for connection
+     * @param addresses The address(es) of the TypeDB server(s) or translation map from addresses to be used
+     * by the driver for connection to addresses received from the TypeDB server(s) 
      * @param credential The Credential to connect with
      */
     static Driver cloudDriver(const std::vector<std::string>& addresses, const Credential& credential);

--- a/cpp/lib/connection/driver.cpp
+++ b/cpp/lib/connection/driver.cpp
@@ -47,17 +47,17 @@ Driver Driver::cloudDriver(const std::vector<std::string>& addresses, const Cred
 }
 
 Driver Driver::cloudDriver(const std::unordered_map<std::string, std::string>& addressTranslation, const Credential& credential) {
-    std::vector<const char*> advertisedAddressesNative;
-    std::vector<const char*> translatedAddressesNative;
-    for (auto& [advertised, translated] : addressTranslation) {
-        advertisedAddressesNative.push_back(advertised.c_str());
-        translatedAddressesNative.push_back(translated.c_str());
+    std::vector<const char*> publicAddressesNative;
+    std::vector<const char*> privateAddressesNative;
+    for (auto& [publicAddress, privateAddress] : addressTranslation) {
+        publicAddressesNative.push_back(publicAddress.c_str());
+        privateAddressesNative.push_back(privateAddress.c_str());
     }
-    advertisedAddressesNative.push_back(nullptr);
-    translatedAddressesNative.push_back(nullptr);
+    publicAddressesNative.push_back(nullptr);
+    privateAddressesNative.push_back(nullptr);
     auto p = _native::connection_open_cloud_translated(
-        advertisedAddressesNative.data(),
-        translatedAddressesNative.data(),
+        publicAddressesNative.data(),
+        privateAddressesNative.data(),
         credential.getNative()
     );
     DriverException::check_and_throw();

--- a/cpp/test/behaviour/steps/main.cpp
+++ b/cpp/test/behaviour/steps/main.cpp
@@ -56,5 +56,4 @@ int main(int argc, char** argv) {
         &TypeDB::BDD::testHooks);
     driver.loadFeature(argv[1]);
     return driver.runAllTests();
-    return 0;
 }

--- a/cpp/test/cucumber/include/cucumber_bdd/runner.hpp
+++ b/cpp/test/cucumber/include/cucumber_bdd/runner.hpp
@@ -71,6 +71,7 @@ class TestRunner : public TestRunnerBase {
     void afterAllTests() override {
         if (hooks != nullptr) hooks->afterAll();
     }
+
     bool skipScenario(const cucumber::messages::pickle& scenario) override {
         return (hooks != nullptr) ? hooks->skipScenario(scenario) : false;
     }

--- a/cpp/test/cucumber/lib/runner.cpp
+++ b/cpp/test/cucumber/lib/runner.cpp
@@ -51,7 +51,7 @@ void TestRunnerBase::loadFeature(const std::string& path) {
 
     if (doc.feature.has_value()) {
         for (cucumber::messages::pickle scenario : compiler.compile(doc, path)) {
-            if (skipScenario(scenario)) {
+            if (skipScenario(scenario) || scenario.steps.empty()) {
                 DEBUGONLY(std::cout << "Skipping scenario: " << scenario.name << std::endl)
             } else {
                 DEBUGONLY(std::cout << "Registering scenario: " << scenario.name << std::endl)

--- a/cpp/test/cucumber/lib/runner.cpp
+++ b/cpp/test/cucumber/lib/runner.cpp
@@ -64,8 +64,9 @@ void TestRunnerBase::loadFeature(const std::string& path) {
 
 int TestRunnerBase::runAllTests() {
     beforeAllTests();
-    return RUN_ALL_TESTS();
+    int ret = RUN_ALL_TESTS();
     afterAllTests();
+    return ret;
 }
 
 }  // namespace cucumber_bdd

--- a/csharp/Connection/TypeDBDriver.cs
+++ b/csharp/Connection/TypeDBDriver.cs
@@ -80,16 +80,16 @@ namespace TypeDB.Driver.Connection
         {
             try
             {
-                string[] advertisedAddresses = new string[addressTranslation.Count];
-                string[] translatedAddresses = new string[addressTranslation.Count];
+                string[] publicAddresses = new string[addressTranslation.Count];
+                string[] privateAddresses = new string[addressTranslation.Count];
                 int index = 0;
                 foreach (KeyValuePair<string, string> translation in addressTranslation)
                 {
-                    advertisedAddresses[index] = translation.Key;
-                    translatedAddresses[index] = translation.Value;
+                    publicAddresses[index] = translation.Key;
+                    privateAddresses[index] = translation.Value;
                     index++;
                 }
-                return Pinvoke.typedb_driver.connection_open_cloud_translated(advertisedAddresses, translatedAddresses, credential.NativeObject);
+                return Pinvoke.typedb_driver.connection_open_cloud_translated(publicAddresses, privateAddresses, credential.NativeObject);
             }
             catch (Pinvoke.Error e)
             {

--- a/csharp/Drivers.cs
+++ b/csharp/Drivers.cs
@@ -71,7 +71,7 @@ namespace TypeDB.Driver
          * </pre>
          *
          * @param addresses The address(es) of the TypeDB server(s) or translation map from addresses
-         * received from the TypeDB server(s) to addresses to be used by the driver for connection
+         * to be used by the driver for connection to addresses received from the TypeDB server(s)
          * @param credential The credential to connect with
          */
         public static ITypeDBDriver CloudDriver(ICollection<string> addresses, TypeDBCredential credential)

--- a/docs/modules/ROOT/partials/c/connection/connection.adoc
+++ b/docs/modules/ROOT/partials/c/connection/connection.adoc
@@ -88,7 +88,7 @@ a| `credential` a| The ``Credential`` to connect with a| `const struct Credentia
 
 [source,cpp]
 ----
-struct Connection* connection_open_cloud_translated(const char*const* advertised_addresses, const char*const* translated_addresses, const struct Credential* credential)
+struct Connection* connection_open_cloud_translated(const char*const* public_addresses, const char*const* private_addresses, const struct Credential* credential)
 ----
 
 
@@ -102,8 +102,8 @@ Open a TypeDB Driver to TypeDB Cloud server(s), using provided address translati
 [options="header"]
 |===
 |Name |Description |Type
-a| `advertised_addresses` a| A null-terminated array holding the address(es) the TypeDB server(s) are configured to advertise a| `const char*const*`
-a| `translated_addresses` a| A null-terminated array holding the address(es) of the TypeDB server(s) the driver will connect to. This array _must_ have the same length as ``advertised_addresses`` a| `const char*const*`
+a| `public_addresses` a| A null-terminated array holding the address(es) of the TypeDB server(s) the driver will connect to. This array _must_ have the same length as ``advertised_addresses`` a| `const char*const*`
+a| `private_addresses` a| A null-terminated array holding the address(es) the TypeDB server(s) are configured to advertise a| `const char*const*`
 a| `credential` a| The ``Credential`` to connect with a| `const struct Credential*`
 |===
 

--- a/docs/modules/ROOT/partials/cpp/connection/Driver.adoc
+++ b/docs/modules/ROOT/partials/cpp/connection/Driver.adoc
@@ -63,7 +63,7 @@ Open a TypeDB Driver to TypeDB Cloud server(s) available at the provided address
 [options="header"]
 |===
 |Name |Description |Type
-a| `addresses` a| The address(es) of the TypeDB server(s) or translation map from addresses received from the TypeDB server(s) to addresses to be used by the driver for connection a| `const std::vector< std::string >&`
+a| `addresses` a| The address(es) of the TypeDB server(s) or translation map from addresses to be used by the driver for connection to addresses received from the TypeDB server(s) a| `const std::vector< std::string >&`
 a| `credential` a| The Credential to connect with a| `const Credential&`
 |===
 

--- a/docs/modules/ROOT/partials/csharp/connection/Drivers.adoc
+++ b/docs/modules/ROOT/partials/csharp/connection/Drivers.adoc
@@ -57,7 +57,7 @@ Open a TypeDB Driver to TypeDB Cloud server(s) available at the provided address
 [options="header"]
 |===
 |Name |Description |Type
-a| `addresses` a| The address(es) of the TypeDB server(s) or translation map from addresses received from the TypeDB server(s) to addresses to be used by the driver for connection a| `ICollection< string >`
+a| `addresses` a| The address(es) of the TypeDB server(s) or translation map from addresses to be used by the driver for connection to addresses received from the TypeDB server(s) a| `ICollection< string >`
 a| `credential` a| The credential to connect with a| `TypeDBCredential`
 |===
 

--- a/docs/modules/ROOT/partials/java/connection/TypeDB.adoc
+++ b/docs/modules/ROOT/partials/java/connection/TypeDB.adoc
@@ -113,7 +113,7 @@ Open a TypeDB Driver to TypeDB Cloud server(s), using provided address translati
 [options="header"]
 |===
 |Name |Description |Type
-a| `addressTranslation` a| Translation map from addresses received from the TypeDB server(s) to addresses to be used by the driver for connection a| `java.util.Map<java.lang.String,​java.lang.String>`
+a| `addressTranslation` a| Translation map from addresses to be used by the driver for connection to addresses received from the TypeDB server(s) a| `java.util.Map<java.lang.String,​java.lang.String>`
 a| `credential` a| The credential to connect with a| `TypeDBCredential`
 |===
 

--- a/docs/modules/ROOT/partials/nodejs/connection/TypeDB.adoc
+++ b/docs/modules/ROOT/partials/nodejs/connection/TypeDB.adoc
@@ -29,7 +29,7 @@ Creates a connection to TypeDB Cloud, authenticating with the provided credentia
 [options="header"]
 |===
 |Name |Description |Type
-a| `addresses` a| List of addresses of the individual TypeDB Cloud servers. As long one specified address is provided, the driver will discover the other addresses from that server. a| `string \| string[] \| Record<string, string>`
+a| `addresses` a| List of addresses of the individual TypeDB Cloud servers. As long one specified address is provided, the driver will discover the other addresses from that server. Alternatively, a translation map from addresses to be used by the driver for connection to addresses received from the TypeDB server(s) may be provided. a| `string \| string[] \| Record<string, string>`
 a| `credential` a| The credentials to log in, and encryption settings. See ``TypeDBCredential``
 Examples
 ``const driver = TypeDB.cloudDriver(["127.0.0.1:11729"], new TypeDBCredential(username, password));

--- a/docs/modules/ROOT/partials/rust/connection/Connection.adoc
+++ b/docs/modules/ROOT/partials/rust/connection/Connection.adoc
@@ -149,7 +149,7 @@ Creates a new TypeDB Cloud connection.
 [options="header"]
 |===
 |Name |Description |Type
-a| `address_translation` a| Translation map from addresses received from the TypeDB server(s) to addresses to be used by the driver for connection a| `HashMap<T`
+a| `address_translation` a| Translation map from addresses to be used by the driver for connection to addresses received from the TypeDB server(s) a| `HashMap<T`
 a| `credential` a| User credential and TLS encryption setting a| `Credential`
 |===
 

--- a/docs/modules/ROOT/partials/rust/connection/ReplicaInfo.adoc
+++ b/docs/modules/ROOT/partials/rust/connection/ReplicaInfo.adoc
@@ -16,7 +16,7 @@ The metadata and state of an individual raft replica of a database.
 |Name |Type |Description
 a| `is_preferred` a| `bool` a| Whether this is the preferred replica of the raft cluster. If true, Operations which can be run on any replica will prefer to use this replica.
 a| `is_primary` a| `bool` a| Whether this is the primary replica of the raft cluster.
-a| `server` a| `String` a| The server hosting this replica
+a| `server` a| `Address` a| The server hosting this replica
 a| `term` a| `i64` a| The raft protocol ‘term’ of this replica.
 |===
 // end::properties[]

--- a/java/TypeDB.java
+++ b/java/TypeDB.java
@@ -86,8 +86,8 @@ public class TypeDB {
      * TypeDB.cloudDriver(addressTranslation, credential);
      * </pre>
      *
-     * @param addressTranslation Translation map from addresses received from the TypeDB server(s)
-     * to addresses to be used by the driver for connection
+     * @param addressTranslation Translation map from addresses to be used by the driver for connection
+     * to addresses received from the TypeDB server(s)
      * @param credential The credential to connect with
      */
     public static TypeDBDriver cloudDriver(Map<String, String> addressTranslation, TypeDBCredential credential) {

--- a/java/connection/TypeDBDriverImpl.java
+++ b/java/connection/TypeDBDriverImpl.java
@@ -81,15 +81,15 @@ public class TypeDBDriverImpl extends NativeObject<com.vaticle.typedb.driver.jni
 
     private static com.vaticle.typedb.driver.jni.Connection openCloud(Map<String, String> addressTranslation, TypeDBCredential credential) {
         try {
-            List<String> advertised = new ArrayList();
-            List<String> translated = new ArrayList();
+            List<String> publicAddresses = new ArrayList();
+            List<String> privateAddresses = new ArrayList();
             for (Map.Entry<String, String> entry: addressTranslation.entrySet()) {
-                advertised.add(entry.getKey());
-                translated.add(entry.getValue());
+                publicAddresses.add(entry.getKey());
+                privateAddresses.add(entry.getValue());
             }
             return connection_open_cloud_translated(
-                advertised.toArray(new String[0]),
-                translated.toArray(new String[0]),
+                publicAddresses.toArray(new String[0]),
+                privateAddresses.toArray(new String[0]),
                 credential.nativeObject
             );
         } catch (com.vaticle.typedb.driver.jni.Error e) {

--- a/nodejs/TypeDB.ts
+++ b/nodejs/TypeDB.ts
@@ -42,6 +42,8 @@ export namespace TypeDB {
      * Creates a connection to TypeDB Cloud, authenticating with the provided credentials.
      * @param addresses - List of addresses of the individual TypeDB Cloud servers.
      * As long one specified address is provided, the driver will discover the other addresses from that server.
+     * Alternatively, a translation map from addresses to be used by the driver for connection
+     * to addresses received from the TypeDB server(s) may be provided.
      * @param credential - The credentials to log in, and encryption settings. See <code>{@link TypeDBCredential}</code>
      *
      * ### Examples

--- a/nodejs/connection/TypeDBDriverImpl.ts
+++ b/nodejs/connection/TypeDBDriverImpl.ts
@@ -107,7 +107,7 @@ export class TypeDBDriverImpl implements TypeDBDriver {
             }
             const unmapped = [];
             for (const privateAddress of serverAddresses) {
-                let publicAddress = Object.keys(addressTranslation).find((key) => addressTranslation[key] == privateAddress);
+                const publicAddress = Object.keys(addressTranslation).find((key) => addressTranslation[key] == privateAddress);
                 if (!publicAddress) {
                     unmapped.push(privateAddress);
                 }

--- a/python/typedb/connection/driver.py
+++ b/python/typedb/connection/driver.py
@@ -44,10 +44,10 @@ class _Driver(TypeDBDriver, NativeWrapper[NativeConnection]):
                 if isinstance(addresses, list):
                     native_connection = connection_open_cloud(addresses, credential.native_object)
                 else:
-                    advertised_addresses = list(addresses.keys())
-                    translated_addresses = [addresses[advertised] for advertised in advertised_addresses]
+                    public_addresses = list(addresses.keys())
+                    private_addresses = [addresses[public] for public in public_addresses]
                     native_connection = connection_open_cloud_translated(
-                            advertised_addresses, translated_addresses, credential.native_object)
+                            public_addresses, private_addresses, credential.native_object)
             except TypeDBDriverExceptionNative as e:
                 raise TypeDBDriverException.of(e)
         else:

--- a/rust/src/common/address.rs
+++ b/rust/src/common/address.rs
@@ -26,7 +26,7 @@ use crate::{
     error::ConnectionError,
 };
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Hash, PartialEq, Eq)]
 pub struct Address {
     uri: Uri,
 }
@@ -56,5 +56,11 @@ impl FromStr for Address {
 impl fmt::Display for Address {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.uri.authority().unwrap())
+    }
+}
+
+impl fmt::Debug for Address {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
     }
 }

--- a/rust/src/common/error.rs
+++ b/rust/src/common/error.rs
@@ -21,6 +21,7 @@ use std::{collections::HashSet, error::Error as StdError, fmt};
 
 use tonic::{Code, Status};
 use typeql::error_messages;
+use crate::common::address::Address;
 
 use super::RequestID;
 
@@ -72,7 +73,7 @@ error_messages! { ConnectionError
         22: "Connection failed. Please check the server is running and the address is accessible. Encrypted Cloud endpoints may also have misconfigured SSL certificates.",
     MissingPort { address: String } =
         23: "Invalid URL '{address}': missing port.",
-    AddressTranslationMismatch { unknown: HashSet<String>, unmapped: HashSet<String> } =
+    AddressTranslationMismatch { unknown: HashSet<Address>, unmapped: HashSet<Address> } =
         24: "Address translation map does not match the server's advertised address list. User-provided servers not in the advertised list: {unknown:?}. Advertised servers not mapped by user: {unmapped:?}.",
 }
 
@@ -86,7 +87,7 @@ error_messages! { InternalError
         3: "Unexpected request type for remote procedure call: {request_type}.",
     UnexpectedResponseType { response_type: String } =
         4: "Unexpected response type for remote procedure call: {response_type}.",
-    UnknownServer { server: String } =
+    UnknownServer { server: Address } =
         5: "Received replica at unrecognized server: {server}.",
     EnumOutOfBounds { value: i32, enum_name: &'static str } =
         6: "Value '{value}' is out of bounds for enum '{enum_name}'.",

--- a/rust/src/common/error.rs
+++ b/rust/src/common/error.rs
@@ -21,9 +21,8 @@ use std::{collections::HashSet, error::Error as StdError, fmt};
 
 use tonic::{Code, Status};
 use typeql::error_messages;
-use crate::common::address::Address;
 
-use super::RequestID;
+use super::{address::Address, RequestID};
 
 error_messages! { ConnectionError
     code: "CXN", type: "Connection Error",

--- a/rust/src/common/error.rs
+++ b/rust/src/common/error.rs
@@ -47,8 +47,8 @@ error_messages! { ConnectionError
         9: "Invalid field in message received from server: '{name}'.",
     UnexpectedResponse { response: String } =
         10: "Received unexpected response from server: '{response}'.",
-    ServerConnectionFailed { addresses: String } =
-        11: "Unable to connect to TypeDB server(s) at: \n{addresses}",
+    ServerConnectionFailed { addresses: Vec<Address> } =
+        11: "Unable to connect to TypeDB server(s) at: \n{addresses:?}",
     ServerConnectionFailedWithError { error: String } =
         12: "Unable to connect to TypeDB server(s), received errors: \n{error}",
     ServerConnectionFailedStatusError { error: String } =

--- a/rust/src/common/info.rs
+++ b/rust/src/common/info.rs
@@ -20,6 +20,7 @@
 use std::time::Duration;
 
 use tokio::sync::mpsc::UnboundedSender;
+use crate::common::address::Address;
 
 use super::{Callback, SessionID};
 
@@ -40,7 +41,7 @@ pub(crate) struct DatabaseInfo {
 #[derive(Debug)]
 pub struct ReplicaInfo {
     /// The server hosting this replica
-    pub server: String,
+    pub server: Address,
     /// Whether this is the primary replica of the raft cluster.
     pub is_primary: bool,
     /// Whether this is the preferred replica of the raft cluster.

--- a/rust/src/common/info.rs
+++ b/rust/src/common/info.rs
@@ -20,9 +20,8 @@
 use std::time::Duration;
 
 use tokio::sync::mpsc::UnboundedSender;
-use crate::common::address::Address;
 
-use super::{Callback, SessionID};
+use super::{address::Address, Callback, SessionID};
 
 #[derive(Clone, Debug)]
 pub(crate) struct SessionInfo {

--- a/rust/src/connection/connection.rs
+++ b/rust/src/connection/connection.rs
@@ -131,8 +131,8 @@ impl Connection {
     ///
     /// # Arguments
     ///
-    /// * `address_translation` -- Translation map from addresses received from the TypeDB server(s)
-    /// to addresses to be used by the driver for connection
+    /// * `address_translation` -- Translation map from addresses to be used by the driver for connection
+    ///    to addresses received from the TypeDB server(s)
     /// * `credential` -- User credential and TLS encryption setting
     ///
     /// # Examples
@@ -162,7 +162,7 @@ impl Connection {
             .map(|(public, private)| -> Result<_> { Ok((public.as_ref().parse()?, private.as_ref().parse()?)) })
             .try_collect()?;
 
-        let provided: HashSet<Address> = address_to_server.keys().cloned().collect();
+        let provided: HashSet<Address> = address_to_server.values().cloned().collect();
         let unknown = &provided - &fetched;
         let unmapped = &fetched - &provided;
         if !unknown.is_empty() || !unmapped.is_empty() {
@@ -190,7 +190,7 @@ impl Connection {
         let errors = server_connections.values().map(|conn| conn.validate()).filter_map(Result::err).collect_vec();
         if errors.len() == server_connections.len() {
             Err(ConnectionError::CloudAllNodesFailed {
-                errors: errors.into_iter().map(|err| err.to_string()).collect::<Vec<_>>().join("\n"),
+                errors: errors.into_iter().map(|err| err.to_string()).join("\n"),
             })?
         } else {
             Ok(Connection {

--- a/rust/src/connection/message.rs
+++ b/rust/src/connection/message.rs
@@ -26,7 +26,7 @@ use typeql::pattern::{Conjunction, Statement};
 
 use crate::{
     answer::{readable_concept, ConceptMap, ConceptMapGroup, ValueGroup},
-    common::{info::DatabaseInfo, RequestID, SessionID, IID},
+    common::{address::Address, info::DatabaseInfo, RequestID, SessionID, IID},
     concept::{
         Annotation, Attribute, AttributeType, Entity, EntityType, Relation, RelationType, RoleType, SchemaException,
         Thing, ThingType, Transitivity, Value, ValueType,
@@ -73,7 +73,7 @@ pub(super) enum Response {
     ConnectionOpen,
 
     ServersAll {
-        servers: Vec<String>,
+        servers: Vec<Address>,
     },
 
     DatabasesContains {

--- a/rust/src/connection/network/channel.rs
+++ b/rust/src/connection/network/channel.rs
@@ -43,20 +43,11 @@ pub(super) type CallCredChannel = InterceptedService<Channel, CredentialInjector
 pub(super) trait GRPCChannel:
     GrpcService<BoxBody, Error = TonicError, ResponseBody = BoxBody, Future = ResponseFuture> + Clone + Send + 'static
 {
-    fn is_plaintext(&self) -> bool;
 }
 
-impl GRPCChannel for PlainTextChannel {
-    fn is_plaintext(&self) -> bool {
-        true
-    }
-}
+impl GRPCChannel for PlainTextChannel {}
 
-impl GRPCChannel for CallCredChannel {
-    fn is_plaintext(&self) -> bool {
-        false
-    }
-}
+impl GRPCChannel for CallCredChannel {}
 
 pub(super) fn open_plaintext_channel(address: Address) -> PlainTextChannel {
     PlainTextChannel::new(Channel::builder(address.into_uri()).connect_lazy(), PlainTextFacade)

--- a/rust/src/connection/network/proto/concept.rs
+++ b/rust/src/connection/network/proto/concept.rs
@@ -19,7 +19,7 @@
 
 use std::collections::HashMap;
 
-use chrono::NaiveDateTime;
+use chrono::DateTime;
 use itertools::Itertools;
 use typedb_protocol::{
     concept,
@@ -408,7 +408,7 @@ impl TryFromProto<ValueProto> for Value {
             Some(ValueProtoInner::Double(double)) => Ok(Self::Double(double)),
             Some(ValueProtoInner::String(string)) => Ok(Self::String(string)),
             Some(ValueProtoInner::DateTime(millis)) => {
-                Ok(Self::DateTime(NaiveDateTime::from_timestamp_millis(millis).unwrap()))
+                Ok(Self::DateTime(DateTime::from_timestamp_millis(millis).unwrap().naive_utc()))
             }
             None => Err(ConnectionError::MissingResponseField { field: "value" }.into()),
         }
@@ -423,7 +423,7 @@ impl IntoProto<ValueProto> for Value {
                 Self::Long(long) => ValueProtoInner::Long(long),
                 Self::Double(double) => ValueProtoInner::Double(double),
                 Self::String(string) => ValueProtoInner::String(string),
-                Self::DateTime(date_time) => ValueProtoInner::DateTime(date_time.timestamp_millis()),
+                Self::DateTime(date_time) => ValueProtoInner::DateTime(date_time.and_utc().timestamp_millis()),
             }),
         }
     }

--- a/rust/src/connection/network/proto/database.rs
+++ b/rust/src/connection/network/proto/database.rs
@@ -17,24 +17,31 @@
  * under the License.
  */
 
+use itertools::Itertools;
 use typedb_protocol::{database_replicas::Replica as ReplicaProto, DatabaseReplicas as DatabaseProto};
 
-use super::FromProto;
-use crate::common::info::{DatabaseInfo, ReplicaInfo};
+use super::TryFromProto;
+use crate::common::{
+    info::{DatabaseInfo, ReplicaInfo},
+    Result,
+};
 
-impl FromProto<DatabaseProto> for DatabaseInfo {
-    fn from_proto(proto: DatabaseProto) -> Self {
-        Self { name: proto.name, replicas: proto.replicas.into_iter().map(ReplicaInfo::from_proto).collect() }
+impl TryFromProto<DatabaseProto> for DatabaseInfo {
+    fn try_from_proto(proto: DatabaseProto) -> Result<Self> {
+        Ok(Self {
+            name: proto.name,
+            replicas: proto.replicas.into_iter().map(ReplicaInfo::try_from_proto).try_collect()?,
+        })
     }
 }
 
-impl FromProto<ReplicaProto> for ReplicaInfo {
-    fn from_proto(proto: ReplicaProto) -> Self {
-        Self {
-            server: proto.address, // TODO should be eventually replaced by "server_id" or "server_name" in protocol
+impl TryFromProto<ReplicaProto> for ReplicaInfo {
+    fn try_from_proto(proto: ReplicaProto) -> Result<Self> {
+        Ok(Self {
+            server: proto.address.parse()?,
             is_primary: proto.primary,
             is_preferred: proto.preferred,
             term: proto.term,
-        }
+        })
     }
 }

--- a/rust/src/connection/network/proto/message.rs
+++ b/rust/src/connection/network/proto/message.rs
@@ -245,10 +245,11 @@ impl FromProto<connection::open::Res> for Response {
     }
 }
 
-impl FromProto<server_manager::all::Res> for Response {
-    fn from_proto(proto: server_manager::all::Res) -> Self {
-        let servers = proto.servers.into_iter().map(|server| server.address).collect();
-        Self::ServersAll { servers }
+impl TryFromProto<server_manager::all::Res> for Response {
+    fn try_from_proto(proto: server_manager::all::Res) -> Result<Self> {
+        let server_manager::all::Res { servers } = proto;
+        let servers = servers.into_iter().map(|server| server.address.parse()).try_collect()?;
+        Ok(Self::ServersAll { servers })
     }
 }
 
@@ -267,16 +268,17 @@ impl FromProto<database_manager::create::Res> for Response {
 impl TryFromProto<database_manager::get::Res> for Response {
     fn try_from_proto(proto: database_manager::get::Res) -> Result<Self> {
         Ok(Self::DatabaseGet {
-            database: DatabaseInfo::from_proto(
+            database: DatabaseInfo::try_from_proto(
                 proto.database.ok_or(ConnectionError::MissingResponseField { field: "database" })?,
-            ),
+            )?,
         })
     }
 }
 
-impl FromProto<database_manager::all::Res> for Response {
-    fn from_proto(proto: database_manager::all::Res) -> Self {
-        Self::DatabasesAll { databases: proto.databases.into_iter().map(DatabaseInfo::from_proto).collect() }
+impl TryFromProto<database_manager::all::Res> for Response {
+    fn try_from_proto(proto: database_manager::all::Res) -> Result<Self> {
+        let database_manager::all::Res { databases } = proto;
+        Ok(Self::DatabasesAll { databases: databases.into_iter().map(DatabaseInfo::try_from_proto).try_collect()? })
     }
 }
 

--- a/rust/src/connection/network/transmitter/rpc.rs
+++ b/rust/src/connection/network/transmitter/rpc.rs
@@ -121,7 +121,7 @@ impl RPCTransmitter {
         match request {
             Request::ConnectionOpen => rpc.connection_open(request.try_into_proto()?).await.map(Response::from_proto),
 
-            Request::ServersAll => rpc.servers_all(request.try_into_proto()?).await.map(Response::from_proto),
+            Request::ServersAll => rpc.servers_all(request.try_into_proto()?).await.and_then(Response::try_from_proto),
 
             Request::DatabasesContains { .. } => {
                 rpc.databases_contains(request.try_into_proto()?).await.map(Response::from_proto)
@@ -132,7 +132,9 @@ impl RPCTransmitter {
             Request::DatabaseGet { .. } => {
                 rpc.databases_get(request.try_into_proto()?).await.and_then(Response::try_from_proto)
             }
-            Request::DatabasesAll => rpc.databases_all(request.try_into_proto()?).await.map(Response::from_proto),
+            Request::DatabasesAll => {
+                rpc.databases_all(request.try_into_proto()?).await.and_then(Response::try_from_proto)
+            }
 
             Request::DatabaseDelete { .. } => {
                 rpc.database_delete(request.try_into_proto()?).await.map(Response::from_proto)

--- a/rust/src/database/database.rs
+++ b/rust/src/database/database.rs
@@ -33,6 +33,7 @@ use crate::{
     error::InternalError,
     Connection,
 };
+use crate::common::address::Address;
 
 /// A TypeDB database
 pub struct Database {
@@ -254,7 +255,7 @@ impl fmt::Debug for Database {
 #[derive(Clone)]
 pub(super) struct Replica {
     /// The server hosting this replica
-    server: String,
+    server: Address,
     /// Retrieves the database name for which this is a replica
     database_name: String,
     /// Checks whether this is the primary replica of the raft cluster.

--- a/rust/src/database/database.rs
+++ b/rust/src/database/database.rs
@@ -25,6 +25,7 @@ use log::{debug, error};
 
 use crate::{
     common::{
+        address::Address,
         error::ConnectionError,
         info::{DatabaseInfo, ReplicaInfo},
         Error, Result,
@@ -33,7 +34,6 @@ use crate::{
     error::InternalError,
     Connection,
 };
-use crate::common::address::Address;
 
 /// A TypeDB database
 pub struct Database {

--- a/rust/tests/BUILD
+++ b/rust/tests/BUILD
@@ -31,6 +31,7 @@ rust_test(
         "@crates//:chrono",
         "@crates//:cucumber",
         "@crates//:futures",
+        "@crates//:itertools",
         "@crates//:regex",
         "@crates//:serde_json",
         "@crates//:serial_test",


### PR DESCRIPTION
## Usage and product changes

NOTE: The address translation table now represents mapping _from_ the desired connection addresses to the addresses the cloud servers are configured with. This change does not impact users of TypeDB Core or TypeDB Cloud through the TypeDB Cloud Platform (https://cloud.typedb.com/)

## Implementation
