### PR TITLE
Add timeout to channel builder

### DIFF
--- a/docs/modules/ROOT/partials/rust/errors/ConnectionError.adoc
+++ b/docs/modules/ROOT/partials/rust/errors/ConnectionError.adoc
@@ -17,6 +17,7 @@ a| `CloudSSLCertificateNotValidated`
 a| `CloudTokenCredentialInvalid`
 a| `ConnectionFailed`
 a| `ConnectionIsClosed`
+a| `ConnectionTimedOut`
 a| `DatabaseDoesNotExist`
 a| `InvalidResponseField`
 a| `MissingPort`

--- a/rust/src/common/error.rs
+++ b/rust/src/common/error.rs
@@ -74,6 +74,8 @@ error_messages! { ConnectionError
         23: "Invalid URL '{address}': missing port.",
     AddressTranslationMismatch { unknown: HashSet<Address>, unmapped: HashSet<Address> } =
         24: "Address translation map does not match the server's advertised address list. User-provided servers not in the advertised list: {unknown:?}. Advertised servers not mapped by user: {unmapped:?}.",
+    ConnectionTimedOut =
+        25: "Connection to the server timed out."
 }
 
 error_messages! { InternalError
@@ -196,6 +198,8 @@ impl From<Status> for Error {
             Self::Connection(ConnectionError::ServerConnectionFailedStatusError { error: status.message().to_owned() })
         } else if status.code() == Code::Unimplemented {
             Self::Connection(ConnectionError::RPCMethodUnavailable { message: status.message().to_owned() })
+        } else if status.code() == Code::Cancelled && status.message() == "Timeout expired" {
+            Self::Connection(ConnectionError::ConnectionTimedOut)
         } else {
             Self::from_message(status.message())
         }

--- a/rust/src/connection/network/channel.rs
+++ b/rust/src/connection/network/channel.rs
@@ -55,10 +55,7 @@ impl GRPCChannel for CallCredChannel {}
 const TIMEOUT: Duration = Duration::from_secs(60);
 
 pub(super) fn open_plaintext_channel(address: Address) -> PlainTextChannel {
-    PlainTextChannel::new(
-        Channel::builder(address.into_uri()).timeout(TIMEOUT).connect_lazy(),
-        PlainTextFacade,
-    )
+    PlainTextChannel::new(Channel::builder(address.into_uri()).timeout(TIMEOUT).connect_lazy(), PlainTextFacade)
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Usage and product changes

We introduce a timeout in the gRPC channel so that the driver correctly fails when the server is available but unresponsive.

Resolves #672.

## Implementation
