### PR TITLE
Mark query answer accessors as allocating for SWIG

### DIFF
--- a/c/swig/typedb_driver_java.swg
+++ b/c/swig/typedb_driver_java.swg
@@ -194,7 +194,8 @@
 %nojavaexception concept_row_to_string;
 
 %nojavaexception query_answer_get_query_type;
-%nojavaexception query_answer_get_rows;
+%nojavaexception query_answer_into_rows;
+%nojavaexception query_answer_into_documents;
 %nojavaexception query_answer_is_ok;
 %nojavaexception query_answer_is_concept_row_stream;
 %nojavaexception query_answer_is_concept_document_stream;
@@ -413,20 +414,12 @@
 
     public ConceptRowIterator intoRows() {
         swigCMemOwn = false;
-        try {
-            return typedb_driver.query_answer_into_rows(this);
-        } catch (Error e) {
-            throw new Error.Unchecked(e);
-        }
+        return typedb_driver.query_answer_into_rows(this);
     }
 
     public StringIterator intoDocuments() {
         swigCMemOwn = false;
-        try {
-            return typedb_driver.query_answer_into_documents(this);
-        } catch (Error e) {
-            throw new Error.Unchecked(e);
-        }
+        return typedb_driver.query_answer_into_documents(this);
     }
 %}
 

--- a/c/typedb_driver.i
+++ b/c/typedb_driver.i
@@ -157,6 +157,8 @@ void transaction_on_close_register(const Transaction* transaction, TransactionCa
 
 %newobject query_answer_into_rows;
 %newobject query_answer_into_documents;
+%delobject query_answer_into_rows;
+%delobject query_answer_into_documents;
 
 %newobject concept_to_string;
 

--- a/c/typedb_driver.i
+++ b/c/typedb_driver.i
@@ -155,7 +155,8 @@ void transaction_on_close_register(const Transaction* transaction, TransactionCa
 %newobject value_get_string;
 %newobject value_get_datetime_tz;
 
-%newobject query_answer_get_rows;
+%newobject query_answer_into_rows;
+%newobject query_answer_into_documents;
 
 %newobject concept_to_string;
 


### PR DESCRIPTION
## Usage and product changes

We mark `query_answer_into_rows` and `query_answer_into_documents` as creating a new allocation that needs to be freed by SWIG. Previously, the iterators extracted from the `QueryAnswer` would have been ignored by SWIG and not deallocated when the wrapper is freed.

## Implementation

Mark `query_answer_into_rows` and `query_answer_into_documents` as `%newobject` and `%delobject`.