### PR TITLE
Merge library targets referring to the same crate

### DIFF
--- a/c/BUILD
+++ b/c/BUILD
@@ -48,6 +48,7 @@ rust_static_library(
         "@crates//:env_logger",
         "@crates//:log",
     ],
+    tags = ["crate-name=typedb_driver_clib"],
 )
 
 rust_cbindgen(
@@ -73,6 +74,7 @@ rust_shared_library(
         "@crates//:env_logger",
         "@crates//:log",
     ],
+    tags = ["crate-name=typedb_driver_clib"],
 )
 
 filegroup(

--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -21,7 +21,7 @@ features = {}
 
 	[dependencies.log]
 		features = ["kv", "kv_unstable", "std", "value-bag"]
-		version = "0.4.22"
+		version = "0.4.26"
 		default-features = false
 
 	[dependencies.typedb-driver]
@@ -30,8 +30,8 @@ features = {}
 		default-features = false
 
 	[dependencies.chrono]
-		features = ["alloc", "android-tzdata", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-targets"]
-		version = "0.4.39"
+		features = ["alloc", "android-tzdata", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-link"]
+		version = "0.4.40"
 		default-features = false
 
 	[dependencies.itertools]

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def typedb_dependencies():
     git_repository(
         name = "typedb_dependencies",
-        remote = "https://github.com/dmitrii-ubskii/vaticle-dependencies",
-        commit = "b54170a621058a8dff82e7a80d26e08002609ec2",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
+        remote = "https://github.com/typedb/typedb-dependencies",
+        commit = "cf9c1707c7896d61ff97bbf60b1880852ad42353",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
     )
 
 def typedb_protocol():

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def typedb_dependencies():
     git_repository(
         name = "typedb_dependencies",
-        remote = "https://github.com/typedb/typedb-dependencies",
-        commit = "5c2d4dcc25493be9d35356075372229a6d2ba2a9",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
+        remote = "https://github.com/dmitrii-ubskii/vaticle-dependencies",
+        commit = "b54170a621058a8dff82e7a80d26e08002609ec2",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
     )
 
 def typedb_protocol():

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -48,14 +48,14 @@
 
 	[dev-dependencies.serde_json]
 		features = ["alloc", "default", "indexmap", "preserve_order", "raw_value", "std"]
-		version = "1.0.135"
+		version = "1.0.140"
 		default-features = false
 
 [dependencies]
 
 	[dependencies.tokio]
 		features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "mio", "net", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"]
-		version = "1.42.0"
+		version = "1.43.0"
 		default-features = false
 
 	[dependencies.typedb-protocol]
@@ -66,7 +66,7 @@
 
 	[dependencies.log]
 		features = ["kv", "kv_unstable", "std", "value-bag"]
-		version = "0.4.22"
+		version = "0.4.26"
 		default-features = false
 
 	[dependencies.tokio-stream]
@@ -81,7 +81,7 @@
 
 	[dependencies.uuid]
 		features = ["default", "fast-rng", "rng", "serde", "std", "v4"]
-		version = "1.11.0"
+		version = "1.15.1"
 		default-features = false
 
 	[dependencies.itertools]
@@ -91,7 +91,7 @@
 
 	[dependencies.prost]
 		features = ["default", "derive", "prost-derive", "std"]
-		version = "0.13.4"
+		version = "0.13.5"
 		default-features = false
 
 	[dependencies.chrono-tz]
@@ -120,8 +120,8 @@
 		default-features = false
 
 	[dependencies.chrono]
-		features = ["alloc", "android-tzdata", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-targets"]
-		version = "0.4.39"
+		features = ["alloc", "android-tzdata", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-link"]
+		version = "0.4.40"
 		default-features = false
 
 	[dependencies.crossbeam]

--- a/rust/tests/behaviour/steps/Cargo.toml
+++ b/rust/tests/behaviour/steps/Cargo.toml
@@ -16,7 +16,7 @@ features = {}
 
 	[dependencies.tokio]
 		features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "mio", "net", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"]
-		version = "1.42.0"
+		version = "1.43.0"
 		default-features = false
 
 	[dependencies.smol]
@@ -55,13 +55,13 @@ features = {}
 		default-features = false
 
 	[dependencies.chrono]
-		features = ["alloc", "android-tzdata", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-targets"]
-		version = "0.4.39"
+		features = ["alloc", "android-tzdata", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-link"]
+		version = "0.4.40"
 		default-features = false
 
 	[dependencies.uuid]
 		features = ["default", "fast-rng", "rng", "serde", "std", "v4"]
-		version = "1.11.0"
+		version = "1.15.1"
 		default-features = false
 
 	[dependencies.itertools]
@@ -71,6 +71,6 @@ features = {}
 
 	[dependencies.serde_json]
 		features = ["alloc", "default", "indexmap", "preserve_order", "raw_value", "std"]
-		version = "1.0.135"
+		version = "1.0.140"
 		default-features = false
 


### PR DESCRIPTION
## Usage and product changes

When two library targets with the same crate name and path appear among the bazel rust targets, we assume them to refer to the same crate, but with different configuration (e.g., different set of enabled features).

We update the C library targets with a crate name tag to allow the sync tool to merge them correctly.

## Implementation
