### PR TITLE
Fix CircleCI release configuration for HTTP driver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -793,7 +793,7 @@ jobs:
           bazel-arch: amd64
       - deploy-crate-release-unix
       - deploy-maven-release-unix
-      - deploy=http-ts-npm-release-unix
+      - deploy-http-ts-npm-release-unix
 #      - deploy-npm-release-unix
 
   deploy-release-dotnet-any:


### PR DESCRIPTION
## Usage and product changes

We fix a typo that made the CircleCI release configuration invalid.

## Implementation

Correct the typo.