### PR TITLE
Install PNPM deps in CI release pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -482,6 +482,7 @@ commands:
       - run: |
           export DEPLOY_NPM_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_NPM_PASSWORD=$REPO_TYPEDB_PASSWORD
+          tool/http-ts/install-deps.sh
           bazel run --define version=$(git rev-parse HEAD) //http-ts:deploy-npm -- snapshot
 
   test-npm-snapshot-unix:
@@ -510,6 +511,7 @@ commands:
           wget -q -O - https://cli-assets.heroku.com/apt/release.key | apt-key add -
           wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
           export DEPLOY_NPM_TOKEN=$REPO_NPM_TOKEN
+          tool/http-ts/install-deps.sh
           bazel run --define version=$(cat VERSION) //http-ts:deploy-npm --compilation_mode=opt -- release
 
 jobs:


### PR DESCRIPTION
## Usage and product changes

The release pipeline in CI now correctly installs PNPM dependencies for the HTTP TS driver.

## Implementation

Add install deps script to circleci config.