### PR TITLE
Fix database importer decoding error

### DIFF
--- a/rust/src/database/migration.rs
+++ b/rust/src/database/migration.rs
@@ -48,6 +48,7 @@ pub struct ProtoMessageIterator<M: Message + Default, R: BufRead> {
 
 impl<M: Message + Default, R: BufRead> ProtoMessageIterator<M, R> {
     const BUF_CAPACITY: usize = 8 * 1024;
+    // prost's length delimiters take up to 10 bytes
     const MAX_LENGTH_DELIMITER_LEN: usize = 10;
 
     pub fn new(reader: R) -> Self {


### PR DESCRIPTION
## Usage and product changes
Stabilize the database import function by eliminating rare decoding errors that could occur during the import of large datasets. All the exported files that the import function could not process are still valid and should be correctly imported after the proposed changes.

## Implementation
* For better control of the manual bytes processing, replace `VecDeque` with `prost::bytes::*` and isolate the file reader's moving in a single function (`Iterator::next`).
* Since `read` functions can read fewer bytes than requested even without meeting EOF, replace single `if` calls with `loop`s <- this was probably the main issue before.

I was not able to reduce the bug to a single test case, even with thousands of records (however, we had a report of a failure after processing 200 entries), so no new behavior tests were introduced. I decided not to spend more time searching for such cases.
