### PR TITLE
Fix HTTP/TS driver trying to deploy as a private package

### DIFF
--- a/http-ts/package.json
+++ b/http-ts/package.json
@@ -34,6 +34,9 @@
     "docs": "typedoc"
   },
   "packageManager" : "pnpm@8.15.9",
+  "packageConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@cucumber/cucumber": "9.0.0",
     "@types/node": "24.0.12",


### PR DESCRIPTION
## Usage and product changes

Fix a bug where the HTTP/TS driver was trying to deploy as a private package

## Implementation

Add packageConfig field to package.json of HTTP/TS driver with access set to public as per https://stackoverflow.com/questions/41981686/getting-error-402-while-publishing-package-using-npm