### PR TITLE
Prepare release 3.7.0-rc1

### DIFF
--- a/.circleci/windows/clib/test_assembly.bat
+++ b/.circleci/windows/clib/test_assembly.bat
@@ -22,9 +22,9 @@ choco install cmake.install --version 3.27.0 --installargs '"ADD_CMAKE_TO_PATH=U
 CALL refreshenv
 
 bazel --output_user_root=C:\b build @typedb_artifact_windows-x86_64//file
-powershell -Command "Move-Item -Path bazel-typedb-driver\external\typedb_artifact_windows-x86_64\file\typedb-server-windows* -Destination typedb-server-windows.zip"
-7z x typedb-server-windows.zip
-powershell -Command "Move-Item -Path typedb-server-windows-* -Destination typedb-server-windows"
+powershell -Command "Move-Item -Path bazel-typedb-driver\external\typedb_artifact_windows-x86_64\file\typedb-all-windows* -Destination typedb-all-windows.zip"
+7z x typedb-all-windows.zip
+powershell -Command "Move-Item -Path typedb-all-windows-* -Destination typedb-all-windows"
 
 bazel --output_user_root=C:\b build //c:assemble-windows-x86_64-zip
 mkdir test_assembly_clib
@@ -35,7 +35,7 @@ cmake --build . --config release
 popd
 set PATH=%cd%\test_assembly_clib\typedb-driver-clib-windows-x86_64\lib;%PATH%;
 
-START /B "" typedb-server-windows\typedb server --development-mode.enable=true
+START /B "" typedb-all-windows\typedb server --development-mode.enable=true
 powershell -Command "Start-Sleep -Seconds 10"
 
 test_assembly_clib\Release\test_assembly.exe


### PR DESCRIPTION
## Usage and product changes

We update the release notes and bump the version to 3.7.0-rc1.

## Implementation

- fix windows C lib assembly test,
- includes potential npm upload fix.