### PR TITLE
fix(c): add crate-type = ["cdylib"] to c/Cargo.toml

### DIFF
--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -11,6 +11,7 @@ features = {}
 
 [lib]
 	path = "src/lib.rs"
+	crate-type = ["cdylib"]
 
 [dependencies]
 


### PR DESCRIPTION
## Problem

\`c/Cargo.toml\` is generated by TypeDB's Bazel sync tool and does not declare \`crate-type = ["cdylib"]\` under \`[lib]\`. Without it, a plain \`cargo build -p typedb_driver_clib\` produces a Rust \`rlib\` instead of a C-compatible shared library (\`.dylib\` / \`.so\` / \`.dll\`).

## Impact

This affects any toolchain that builds the C FFI layer via Cargo rather than Bazel:

- **Julia BinaryBuilder (Yggdrasil)** — the recipe for [\`TypeDBDriverClib_jll\`](https://github.com/JuliaPackaging/Yggdrasil/pull/13229) builds pre-compiled binaries for all platforms, including \`aarch64-apple-darwin\` (Apple Silicon M1/M2/M3). Without this fix the build script needs a \`sed\` workaround to inject \`crate-type\` at build time.
- **Any downstream author** who tries to build the C library locally via \`cargo build\` will get an \`rlib\` and be puzzled by a missing \`.dylib\`/\`.so\`.

## Fix

Add \`crate-type = ["cdylib"]\` to the \`[lib]\` section of \`c/Cargo.toml\`.

This is the standard Cargo declaration for a C-compatible shared library. Bazel ignores this field during its own build, so it is safe to keep permanently.

## Change

\`\`\`toml
 [lib]
 	path = "src/lib.rs"
+	crate-type = ["cdylib"]
\`\`\`

One line, no behaviour change for Bazel-based builds.