### PR TITLE
Raise gRPC message size limits to 1 GB

### DIFF
--- a/rust/src/connection/network/stub.rs
+++ b/rust/src/connection/network/stub.rs
@@ -37,6 +37,8 @@ use crate::{
 
 type TonicResult<T> = StdResult<Response<T>, Status>;
 
+const GRPC_MAX_MESSAGE_SIZE: usize = 1024 * 1024 * 1024;
+
 #[derive(Clone, Debug)]
 pub(super) struct RPCStub<Channel: GRPCChannel> {
     grpc: GRPC<Channel>,
@@ -45,7 +47,12 @@ pub(super) struct RPCStub<Channel: GRPCChannel> {
 
 impl<Channel: GRPCChannel> RPCStub<Channel> {
     pub(super) async fn new(channel: Channel, call_credentials: Option<Arc<CallCredentials>>) -> Self {
-        Self { grpc: GRPC::new(channel), call_credentials }
+        Self {
+            grpc: GRPC::new(channel)
+                .max_decoding_message_size(GRPC_MAX_MESSAGE_SIZE)
+                .max_encoding_message_size(GRPC_MAX_MESSAGE_SIZE),
+            call_credentials,
+        }
     }
 
     async fn call_with_auto_renew_token<F, R>(&mut self, call: F) -> Result<R>


### PR DESCRIPTION

## Usage and product changes

The default tonic limit of 4 MB is too restrictive for database workloads. Large fetch documents, query result batches, and export streams can legitimately exceed 4 MB, causing decode failures on the client side with: "decoded message length too large: found N bytes, the limit is: 4194304 bytes"

Set both encoding and decoding limits to 1 GB on the TypeDbClient stub, matching the corresponding server-side change in https://github.com/typedb/typedb/pull/7745


## Implementation

Increase message size limits to 1gb.