### PR TITLE
Add cluster failover for http-ts

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -277,6 +277,24 @@ build:
         tool/test/stop-cluster-servers.sh
         exit $TEST_SUCCESS
 
+    test-http-ts-integration:
+      image: typedb-ubuntu-22.04
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+        bazel run --config=ci @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
+
+        tool/http-ts/install-deps.sh
+
+        source tool/test/start-cluster-servers.sh 3 &&
+          bazel test --config=ci //http-ts/tests/integration:cluster-failover --test_env=CLUSTER_SERVER_SCRIPT=$CLUSTER_SERVER_SCRIPT --test_env=ROOT_CA=$ROOT_CA --test_env=CLUSTER_DIR=$CLUSTER_DIR --test_output=streamed --jobs=1 &&
+          export CLUSTER_FAILED= || export CLUSTER_FAILED=1
+        tool/test/stop-cluster-servers.sh
+        if [[ -n "$CLUSTER_FAILED" ]]; then exit 1; fi
+
     test-http-ts-behaviour-core:
       image: typedb-ubuntu-22.04
       type: foreground
@@ -318,24 +336,6 @@ build:
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-cluster-servers.sh
         exit $TEST_SUCCESS
-
-    test-http-ts-integration:
-      image: typedb-ubuntu-22.04
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-        bazel run --config=ci @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
-
-        tool/http-ts/install-deps.sh
-
-        source tool/test/start-cluster-servers.sh 3 &&
-          bazel test --config=ci //http-ts/tests/integration:cluster-failover --test_env=CLUSTER_SERVER_SCRIPT=$CLUSTER_SERVER_SCRIPT --test_env=ROOT_CA=$ROOT_CA --test_env=CLUSTER_DIR=$CLUSTER_DIR --test_output=streamed --jobs=1 &&
-          export CLUSTER_FAILED= || export CLUSTER_FAILED=1
-        tool/test/stop-cluster-servers.sh
-        if [[ -n "$CLUSTER_FAILED" ]]; then exit 1; fi
 
     test-csharp-integration:
       image: typedb-ubuntu-22.04

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -319,6 +319,24 @@ build:
         tool/test/stop-cluster-servers.sh
         exit $TEST_SUCCESS
 
+    test-http-ts-integration:
+      image: typedb-ubuntu-22.04
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+        bazel run --config=ci @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
+
+        tool/http-ts/install-deps.sh
+
+        source tool/test/start-cluster-servers.sh 3 &&
+          bazel test --config=ci //http-ts/tests/integration:cluster-failover --test_env=CLUSTER_SERVER_SCRIPT=$CLUSTER_SERVER_SCRIPT --test_env=ROOT_CA=$ROOT_CA --test_env=CLUSTER_DIR=$CLUSTER_DIR --test_output=streamed --jobs=1 &&
+          export CLUSTER_FAILED= || export CLUSTER_FAILED=1
+        tool/test/stop-cluster-servers.sh
+        if [[ -n "$CLUSTER_FAILED" ]]; then exit 1; fi
+
     test-csharp-integration:
       image: typedb-ubuntu-22.04
       type: foreground

--- a/dependencies/typedb/artifacts.bzl
+++ b/dependencies/typedb/artifacts.bzl
@@ -25,7 +25,7 @@ def typedb_artifact():
         artifact_name = "typedb-all-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        commit = "911fff808ad25214ec89b036001f5e210b0a32f0"
+        commit = "1eddf41e279e65fb96b71884b91f2bab5051b258"
     )
 
 def typedb_cluster_artifact():
@@ -35,5 +35,5 @@ def typedb_cluster_artifact():
         artifact_name = "typedb-cluster-all-{platform}-{version}.tar.gz", # TODO: Make {ext} instead of tar.gz
         tag_source = deployment_private["artifact"]["release"]["download"],
         commit_source = deployment_private["artifact"]["snapshot"]["download"],
-        commit = "22f07211ce34dacfed310d0892ba7f244e598cb1",
+        commit = "2ab679a207276a865b6ebb97d1d4f7b3e60b35a2",
     )

--- a/dependencies/typedb/artifacts.bzl
+++ b/dependencies/typedb/artifacts.bzl
@@ -25,7 +25,7 @@ def typedb_artifact():
         artifact_name = "typedb-all-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        commit = "53156d7aed0193163f29587bcc4b47f28665e216"
+        commit = "911fff808ad25214ec89b036001f5e210b0a32f0"
     )
 
 def typedb_cluster_artifact():
@@ -35,5 +35,5 @@ def typedb_cluster_artifact():
         artifact_name = "typedb-cluster-all-{platform}-{version}.tar.gz", # TODO: Make {ext} instead of tar.gz
         tag_source = deployment_private["artifact"]["release"]["download"],
         commit_source = deployment_private["artifact"]["snapshot"]["download"],
-        commit = "d5e64113bc33c0c1e06a651e6f83ce7c46c9253a",
+        commit = "22f07211ce34dacfed310d0892ba7f244e598cb1",
     )

--- a/http-ts/src/index.ts
+++ b/http-ts/src/index.ts
@@ -23,6 +23,7 @@ import {
     ApiErrorResponse,
     ApiResponse,
     DatabasesListResponse,
+    driverError,
     isApiError,
     isMisdirectedError,
     QueryResponse,
@@ -196,7 +197,7 @@ export class TypeDBHttpDriver {
                 result = fallback;
             }
         }
-        return result ?? { err: { code: "HDR1", message: "Cannot connect to any server" }, status: 503 };
+        return result ?? driverError("HDR1", "Cannot connect to any server");
     }
 
     private async tryApiReq<BODY>(method: string, path: string, body?: BODY, options?: { headers?: Record<string, string> }): Promise<Response | null> {
@@ -287,7 +288,7 @@ export class TypeDBHttpDriver {
         try {
             resp = await fetch(url, { method: "POST", body: JSON.stringify(body), headers: { "Content-Type": "application/json" } });
         } catch {
-            return { err: { code: "HDR2", message: `Cannot connect to server at ${this.currentOrigin}` }, status: 503 };
+            return driverError("HDR2", `Cannot connect to server at ${this.currentOrigin}`);
         }
         const json = await this.jsonOrNull(resp);
         if (resp.ok) {

--- a/http-ts/src/index.ts
+++ b/http-ts/src/index.ts
@@ -17,13 +17,14 @@
  * under the License.
  */
 
-import { DriverParams, remoteOrigin } from "./params";
+import { DriverParams, remoteOrigin, resolveOrigin, allOrigins } from "./params";
 import {
     AnalyzeResponse,
     ApiErrorResponse,
     ApiResponse,
     DatabasesListResponse,
     isApiError,
+    isMisdirectedError,
     QueryResponse,
     ServersListResponse,
     SignInResponse,
@@ -33,6 +34,7 @@ import {
 } from "./response";
 
 const HTTP_UNAUTHORIZED = 401;
+const HTTP_MISDIRECTED = 421;
 
 export * from "./analyze";
 export * from "./concept";
@@ -45,8 +47,11 @@ export * from "./legacy";
 export class TypeDBHttpDriver {
 
     private token?: string;
+    private currentOrigin: string;
 
-    constructor(private params: DriverParams) {}
+    constructor(private params: DriverParams) {
+        this.currentOrigin = remoteOrigin(params);
+    }
 
     getDatabases(): Promise<ApiResponse<DatabasesListResponse>> {
         return this.apiGet<DatabasesListResponse>(`/v1/databases`);
@@ -181,33 +186,133 @@ export class TypeDBHttpDriver {
     }
 
     private async apiReq<BODY>(method: string, path: string, body?: BODY, options?: { headers?: Record<string, string> }): Promise<ApiErrorResponse | Response> {
-        const url = `${remoteOrigin(this.params)}${path}`;
+        // 1. Try current origin
+        let result = await this.tryApiReq(method, path, body, options);
+
+        // 2. Connection error → try fallback origins
+        if (result === null) {
+            result = await this.tryFallbackOrigins(method, path, body, options);
+            if (result === null) {
+                return { err: { code: "HDR1", message: `Cannot connect to any server` }, status: 503 };
+            }
+        }
+
+        // 3. 421 Misdirected → switch origin and retry once
+        if (result instanceof Response && result.status === HTTP_MISDIRECTED) {
+            const switched = await this.handleMisdirected(result);
+            if (switched) {
+                const retry = await this.tryApiReq(method, path, body, options);
+                if (retry !== null) return retry;
+            }
+            // If misdirected handling or retry failed, try all other origins
+            const fallback = await this.tryFallbackOrigins(method, path, body, options);
+            if (fallback !== null) return fallback;
+            return { err: { code: "HDR1", message: `Cannot connect to any server` }, status: 503 };
+        }
+
+        // 4. Non-ok response in a multi-address cluster → try other origins
+        //    Handles cases like CSV8/CSV9 errors wrapped in 400 by transaction handlers,
+        //    where the server can't provide a 421 redirect.
+        if (result instanceof Response && !result.ok && allOrigins(this.params).length > 1) {
+            const fallback = await this.tryFallbackOrigins(method, path, body, options);
+            if (fallback !== null && fallback instanceof Response && fallback.ok) {
+                return fallback;
+            }
+            // No origin returned a success — return the original error.
+            // Note: tryFallbackOrigins may have updated currentOrigin, which helps
+            // subsequent calls cycle through addresses.
+        }
+
+        return result;
+    }
+
+    /** Single request attempt on currentOrigin. Returns null on connection error. */
+    private async tryApiReq<BODY>(method: string, path: string, body?: BODY, options?: { headers?: Record<string, string> }): Promise<ApiErrorResponse | Response | null> {
+        const url = `${this.currentOrigin}${path}`;
         let tokenResp = await this.getToken();
-        if ("err" in tokenResp) return tokenResp;
+        if ("err" in tokenResp) {
+            // Connection error during token refresh → signal as connection error for fallback
+            if (tokenResp.status === 503) return null;
+            return tokenResp;
+        }
         let bodyString = undefined;
-        if (body !== undefined) bodyString = JSON.stringify(body)
+        if (body !== undefined) bodyString = JSON.stringify(body);
         let headers = Object.assign({ "Authorization": `Bearer ${tokenResp.ok.token}`, "Content-Type": "application/json" }, options?.headers || {});
-        let resp = await fetch(url, { method, body: bodyString, headers });
+        let resp: Response;
+        try {
+            resp = await fetch(url, { method, body: bodyString, headers });
+        } catch {
+            return null;
+        }
         if (resp.status === HTTP_UNAUTHORIZED) {
             tokenResp = await this.refreshToken();
             if ("err" in tokenResp) return tokenResp;
             headers = Object.assign({ "Authorization": `Bearer ${tokenResp.ok.token}`, "Content-Type": "application/json" }, options?.headers || {});
-            resp = await fetch(url, { method, body: bodyString, headers });
+            try {
+                resp = await fetch(url, { method, body: bodyString, headers });
+            } catch {
+                return null;
+            }
         }
         return resp;
     }
 
+    /** Parse a 421 response body and switch currentOrigin to the indicated primary. Returns true if switch succeeded. */
+    private async handleMisdirected(resp: Response): Promise<boolean> {
+        let json: any;
+        try {
+            json = await resp.json();
+        } catch {
+            return false;
+        }
+        if (!isMisdirectedError(json)) return false;
+        const newOrigin = resolveOrigin(this.params, json.primaryHttpAddress);
+        if (newOrigin === this.currentOrigin) return false;
+        this.currentOrigin = newOrigin;
+        this.token = undefined;
+        return true;
+    }
+
+    /** Try all configured origins except the one already attempted. */
+    private async tryFallbackOrigins<BODY>(method: string, path: string, body?: BODY, options?: { headers?: Record<string, string> }): Promise<ApiErrorResponse | Response | null> {
+        const origins = allOrigins(this.params);
+        const alreadyTried = this.currentOrigin;
+        for (const origin of origins) {
+            if (origin === alreadyTried) continue;
+            this.currentOrigin = origin;
+            this.token = undefined;
+            const result = await this.tryApiReq(method, path, body, options);
+            if (result === null) continue;
+            // Got a response — if it's a 421, follow the redirect
+            if (result instanceof Response && result.status === HTTP_MISDIRECTED) {
+                const switched = await this.handleMisdirected(result);
+                if (switched) {
+                    const retry = await this.tryApiReq(method, path, body, options);
+                    if (retry !== null) return retry;
+                }
+                continue;
+            }
+            return result;
+        }
+        return null;
+    }
+
     private getToken(): Promise<ApiResponse<SignInResponse>> {
         if (this.token) {
-            const resp: ApiResponse<SignInResponse> ={ ok: { token: this.token } };
+            const resp: ApiResponse<SignInResponse> = { ok: { token: this.token } };
             return Promise.resolve(resp);
         } else return this.refreshToken();
     }
 
     private async refreshToken(): Promise<ApiResponse<SignInResponse>> {
-        const url = `${remoteOrigin(this.params)}/v1/signin`;
+        const url = `${this.currentOrigin}/v1/signin`;
         const body = { username: this.params.username, password: this.params.password };
-        const resp = await fetch(url, { method: "POST", body: JSON.stringify(body), headers: { "Content-Type": "application/json" } });
+        let resp: Response;
+        try {
+            resp = await fetch(url, { method: "POST", body: JSON.stringify(body), headers: { "Content-Type": "application/json" } });
+        } catch {
+            return { err: { code: "HDR2", message: `Cannot connect to server at ${this.currentOrigin}` }, status: 503 };
+        }
         const json = await this.jsonOrNull(resp);
         if (resp.ok) {
             this.token = (json as SignInResponse).token;

--- a/http-ts/src/index.ts
+++ b/http-ts/src/index.ts
@@ -231,9 +231,10 @@ export class TypeDBHttpDriver {
         const url = `${this.currentOrigin}${path}`;
         let tokenResp = await this.getToken();
         if ("err" in tokenResp) {
-            // Connection error during token refresh → signal as connection error for fallback
-            if (tokenResp.status === 503) return null;
-            return tokenResp;
+            // Signin failed on this origin. Treat as a connection-like error so the caller
+            // can try fallback origins. This covers both connection errors (503) and server
+            // state errors (e.g. SRV14 "Not yet initialised" on a recovering cluster node).
+            return null;
         }
         let bodyString = undefined;
         if (body !== undefined) bodyString = JSON.stringify(body);
@@ -246,7 +247,7 @@ export class TypeDBHttpDriver {
         }
         if (resp.status === HTTP_UNAUTHORIZED) {
             tokenResp = await this.refreshToken();
-            if ("err" in tokenResp) return tokenResp;
+            if ("err" in tokenResp) return null;
             headers = Object.assign({ "Authorization": `Bearer ${tokenResp.ok.token}`, "Content-Type": "application/json" }, options?.headers || {});
             try {
                 resp = await fetch(url, { method, body: bodyString, headers });
@@ -277,6 +278,7 @@ export class TypeDBHttpDriver {
     private async tryFallbackOrigins<BODY>(method: string, path: string, body?: BODY, options?: { headers?: Record<string, string> }): Promise<ApiErrorResponse | Response | null> {
         const origins = allOrigins(this.params);
         const alreadyTried = this.currentOrigin;
+        let lastResult: Response | null = null;
         for (const origin of origins) {
             if (origin === alreadyTried) continue;
             this.currentOrigin = origin;
@@ -292,9 +294,18 @@ export class TypeDBHttpDriver {
                 }
                 continue;
             }
+            // Got a successful response — return immediately
+            if (result instanceof Response && result.ok) return result;
+            // Got a non-ok HTTP response — save it and try next origin.
+            // This allows us to find an origin that can handle the request, while
+            // still returning the last error if no origin succeeds.
+            if (result instanceof Response) {
+                lastResult = result;
+                continue;
+            }
             return result;
         }
-        return null;
+        return lastResult;
     }
 
     private getToken(): Promise<ApiResponse<SignInResponse>> {

--- a/http-ts/src/index.ts
+++ b/http-ts/src/index.ts
@@ -186,59 +186,25 @@ export class TypeDBHttpDriver {
     }
 
     private async apiReq<BODY>(method: string, path: string, body?: BODY, options?: { headers?: Record<string, string> }): Promise<ApiErrorResponse | Response> {
-        // 1. Try current origin
         let result = await this.tryApiReq(method, path, body, options);
-
-        // 2. Connection error → try fallback origins
-        if (result === null) {
-            result = await this.tryFallbackOrigins(method, path, body, options);
-            if (result === null) {
-                return { err: { code: "HDR1", message: `Cannot connect to any server` }, status: 503 };
-            }
+        if (result !== null && result.status === HTTP_MISDIRECTED) {
+            result = await this.followMisdirected(result, method, path, body, options);
         }
-
-        // 3. 421 Misdirected → switch origin and retry once
-        if (result instanceof Response && result.status === HTTP_MISDIRECTED) {
-            const switched = await this.handleMisdirected(result);
-            if (switched) {
-                const retry = await this.tryApiReq(method, path, body, options);
-                if (retry !== null) return retry;
-            }
-            // If misdirected handling or retry failed, try all other origins
+        if (result === null || !result.ok) {
             const fallback = await this.tryFallbackOrigins(method, path, body, options);
-            if (fallback !== null) return fallback;
-            return { err: { code: "HDR1", message: `Cannot connect to any server` }, status: 503 };
-        }
-
-        // 4. Non-ok response in a multi-address cluster → try other origins
-        //    Handles cases like CSV8/CSV9 errors wrapped in 400 by transaction handlers,
-        //    where the server can't provide a 421 redirect.
-        if (result instanceof Response && !result.ok && allOrigins(this.params).length > 1) {
-            const fallback = await this.tryFallbackOrigins(method, path, body, options);
-            if (fallback !== null && fallback instanceof Response && fallback.ok) {
-                return fallback;
+            if (fallback !== null && (result === null || fallback.ok)) {
+                result = fallback;
             }
-            // No origin returned a success — return the original error.
-            // Note: tryFallbackOrigins may have updated currentOrigin, which helps
-            // subsequent calls cycle through addresses.
         }
-
-        return result;
+        return result ?? { err: { code: "HDR1", message: "Cannot connect to any server" }, status: 503 };
     }
 
-    /** Single request attempt on currentOrigin. Returns null on connection error. */
-    private async tryApiReq<BODY>(method: string, path: string, body?: BODY, options?: { headers?: Record<string, string> }): Promise<ApiErrorResponse | Response | null> {
+    private async tryApiReq<BODY>(method: string, path: string, body?: BODY, options?: { headers?: Record<string, string> }): Promise<Response | null> {
         const url = `${this.currentOrigin}${path}`;
         let tokenResp = await this.getToken();
-        if ("err" in tokenResp) {
-            // Signin failed on this origin. Treat as a connection-like error so the caller
-            // can try fallback origins. This covers both connection errors (503) and server
-            // state errors (e.g. SRV14 "Not yet initialised" on a recovering cluster node).
-            return null;
-        }
-        let bodyString = undefined;
-        if (body !== undefined) bodyString = JSON.stringify(body);
-        let headers = Object.assign({ "Authorization": `Bearer ${tokenResp.ok.token}`, "Content-Type": "application/json" }, options?.headers || {});
+        if ("err" in tokenResp) return null;
+        const bodyString = body !== undefined ? JSON.stringify(body) : undefined;
+        let headers = this.authHeaders(tokenResp.ok.token, options);
         let resp: Response;
         try {
             resp = await fetch(url, { method, body: bodyString, headers });
@@ -248,7 +214,7 @@ export class TypeDBHttpDriver {
         if (resp.status === HTTP_UNAUTHORIZED) {
             tokenResp = await this.refreshToken();
             if ("err" in tokenResp) return null;
-            headers = Object.assign({ "Authorization": `Bearer ${tokenResp.ok.token}`, "Content-Type": "application/json" }, options?.headers || {});
+            headers = this.authHeaders(tokenResp.ok.token, options);
             try {
                 resp = await fetch(url, { method, body: bodyString, headers });
             } catch {
@@ -258,8 +224,14 @@ export class TypeDBHttpDriver {
         return resp;
     }
 
-    /** Parse a 421 response body and switch currentOrigin to the indicated primary. Returns true if switch succeeded. */
-    private async handleMisdirected(resp: Response): Promise<boolean> {
+    private async followMisdirected<BODY>(resp: Response, method: string, path: string, body?: BODY, options?: { headers?: Record<string, string> }): Promise<Response | null> {
+        if (await this.switchToRedirectTarget(resp)) {
+            return await this.tryApiReq(method, path, body, options);
+        }
+        return null;
+    }
+
+    private async switchToRedirectTarget(resp: Response): Promise<boolean> {
         let json: any;
         try {
             json = await resp.json();
@@ -267,45 +239,38 @@ export class TypeDBHttpDriver {
             return false;
         }
         if (!isMisdirectedError(json)) return false;
-        const newOrigin = resolveOrigin(this.params, json.primaryHttpAddress);
+        const newOrigin = resolveOrigin(this.params, json.primaryAddress);
         if (newOrigin === this.currentOrigin) return false;
-        this.currentOrigin = newOrigin;
-        this.token = undefined;
+        this.switchOrigin(newOrigin);
         return true;
     }
 
-    /** Try all configured origins except the one already attempted. */
-    private async tryFallbackOrigins<BODY>(method: string, path: string, body?: BODY, options?: { headers?: Record<string, string> }): Promise<ApiErrorResponse | Response | null> {
+    private async tryFallbackOrigins<BODY>(method: string, path: string, body?: BODY, options?: { headers?: Record<string, string> }): Promise<Response | null> {
         const origins = allOrigins(this.params);
-        const alreadyTried = this.currentOrigin;
-        let lastResult: Response | null = null;
+        const failedOrigin = this.currentOrigin;
+        let lastError: Response | null = null;
         for (const origin of origins) {
-            if (origin === alreadyTried) continue;
-            this.currentOrigin = origin;
-            this.token = undefined;
-            const result = await this.tryApiReq(method, path, body, options);
+            if (origin === failedOrigin) continue;
+            this.switchOrigin(origin);
+            let result = await this.tryApiReq(method, path, body, options);
             if (result === null) continue;
-            // Got a response — if it's a 421, follow the redirect
-            if (result instanceof Response && result.status === HTTP_MISDIRECTED) {
-                const switched = await this.handleMisdirected(result);
-                if (switched) {
-                    const retry = await this.tryApiReq(method, path, body, options);
-                    if (retry !== null) return retry;
-                }
-                continue;
+            if (result.status === HTTP_MISDIRECTED) {
+                result = await this.followMisdirected(result, method, path, body, options);
+                if (result === null) continue;
             }
-            // Got a successful response — return immediately
-            if (result instanceof Response && result.ok) return result;
-            // Got a non-ok HTTP response — save it and try next origin.
-            // This allows us to find an origin that can handle the request, while
-            // still returning the last error if no origin succeeds.
-            if (result instanceof Response) {
-                lastResult = result;
-                continue;
-            }
-            return result;
+            if (result.ok) return result;
+            lastError = result;
         }
-        return lastResult;
+        return lastError;
+    }
+
+    private switchOrigin(origin: string): void {
+        this.currentOrigin = origin;
+        this.token = undefined;
+    }
+
+    private authHeaders(token: string, options?: { headers?: Record<string, string> }): Record<string, string> {
+        return { "Authorization": `Bearer ${token}`, "Content-Type": "application/json", ...options?.headers };
     }
 
     private getToken(): Promise<ApiResponse<SignInResponse>> {

--- a/http-ts/src/params.ts
+++ b/http-ts/src/params.ts
@@ -48,3 +48,46 @@ export function remoteOrigin(params: DriverParams) {
     if (isBasicParams(params)) return `${params.addresses[0]}`;
     else return `${params.translatedAddresses[0].external}`;
 }
+
+/** Extract host:port from a URL string. "https://127.0.0.1:18000" → "127.0.0.1:18000" */
+export function hostPortFromOrigin(origin: string): string {
+    try {
+        const url = new URL(origin);
+        return url.host;
+    } catch {
+        return origin;
+    }
+}
+
+/** Resolve a bare primaryAddress (host:port) to a full URL using configured params. */
+export function resolveOrigin(params: DriverParams, primaryAddress: string): string {
+    if (isBasicParams(params)) {
+        for (const addr of params.addresses) {
+            if (hostPortFromOrigin(addr) === primaryAddress) return addr;
+        }
+        return deriveOriginWithScheme(params.addresses[0], primaryAddress);
+    } else {
+        for (const ta of params.translatedAddresses) {
+            if (hostPortFromOrigin(ta.internal) === primaryAddress
+                || hostPortFromOrigin(ta.external) === primaryAddress) {
+                return ta.external;
+            }
+        }
+        return deriveOriginWithScheme(params.translatedAddresses[0].external, primaryAddress);
+    }
+}
+
+function deriveOriginWithScheme(referenceUrl: string, hostPort: string): string {
+    try {
+        const url = new URL(referenceUrl);
+        return `${url.protocol}//${hostPort}`;
+    } catch {
+        return `https://${hostPort}`;
+    }
+}
+
+/** Return all configured origins for connection error fallback. */
+export function allOrigins(params: DriverParams): string[] {
+    if (isBasicParams(params)) return params.addresses;
+    else return params.translatedAddresses.map(ta => ta.external);
+}

--- a/http-ts/src/response.ts
+++ b/http-ts/src/response.ts
@@ -133,14 +133,14 @@ export function isApiError(err: any): err is ApiError {
 export interface MisdirectedError {
     code: string;
     message: string;
-    primaryHttpAddress: string;
+    primaryAddress: string;
 }
 
 export function isMisdirectedError(err: any): err is MisdirectedError {
     return err != null
         && typeof err.code === "string"
         && typeof err.message === "string"
-        && typeof err.primaryHttpAddress === "string";
+        && typeof err.primaryAddress === "string";
 }
 
 export type ApiResponse<OK_RES = {} | null> = ApiOkResponse<OK_RES> | ApiErrorResponse;

--- a/http-ts/src/response.ts
+++ b/http-ts/src/response.ts
@@ -143,6 +143,10 @@ export function isMisdirectedError(err: any): err is MisdirectedError {
         && typeof err.primaryAddress === "string";
 }
 
+export function driverError(code: string, message: string): ApiErrorResponse {
+    return { err: { code, message }, status: 503 };
+}
+
 export type ApiResponse<OK_RES = {} | null> = ApiOkResponse<OK_RES> | ApiErrorResponse;
 
 export function isOkResponse<OK_RES>(res: ApiResponse<OK_RES>): res is ApiOkResponse<OK_RES> {

--- a/http-ts/src/response.ts
+++ b/http-ts/src/response.ts
@@ -130,6 +130,19 @@ export function isApiError(err: any): err is ApiError {
     return err != null && typeof err.code === "string" && typeof err.message === "string";
 }
 
+export interface MisdirectedError {
+    code: string;
+    message: string;
+    primaryHttpAddress: string;
+}
+
+export function isMisdirectedError(err: any): err is MisdirectedError {
+    return err != null
+        && typeof err.code === "string"
+        && typeof err.message === "string"
+        && typeof err.primaryHttpAddress === "string";
+}
+
 export type ApiResponse<OK_RES = {} | null> = ApiOkResponse<OK_RES> | ApiErrorResponse;
 
 export function isOkResponse<OK_RES>(res: ApiResponse<OK_RES>): res is ApiOkResponse<OK_RES> {

--- a/http-ts/tests/behaviour/steps/connection.ts
+++ b/http-ts/tests/behaviour/steps/connection.ts
@@ -65,12 +65,10 @@ Then("connection has {int} user(s)", async (expectedUserCount: number) => {
 When("connection closes", closeConnection);
 
 // Cluster/Replica steps
-let cachedServers: Server[] = [];
 
 async function getServers(): Promise<Server[]> {
     const res = await driver.getServers().then(assertNotError);
-    cachedServers = res.ok.servers;
-    return cachedServers;
+    return res.ok.servers;
 }
 
 Then("connection has {int} server(s)", async (expectedCount: number) => {

--- a/http-ts/tests/behaviour/steps/context.ts
+++ b/http-ts/tests/behaviour/steps/context.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { After, Before, BeforeAll } from "@cucumber/cucumber";
+import { After, Before } from "@cucumber/cucumber";
 import { AnalyzeResponse, isOkResponse, QueryOptions, QueryResponse, TransactionOptions, TransactionType, TypeDBHttpDriver } from "../../../dist/index.cjs";
 import { assertNotError } from "./params";
 import * as https from "https";
@@ -105,67 +105,56 @@ export const CLUSTER_ADDRESSES = [
 
 // For cluster mode tests, replace global fetch with one that handles mTLS
 if (isClusterMode) {
-    // Load TLS certificates for mTLS - ROOT_CA env var points to the CA certificate
     const rootCaPath = process.env.ROOT_CA;
-    if (!rootCaPath) {
-        throw new Error("ROOT_CA environment variable must be set for cluster mode tests");
-    }
+    if (!rootCaPath) throw new Error("ROOT_CA environment variable must be set for cluster mode tests");
     const certDir = path.dirname(rootCaPath);
     const ca = fs.readFileSync(rootCaPath);
     const cert = fs.readFileSync(path.join(certDir, "ext-grpc-certificate.pem"));
     const key = fs.readFileSync(path.join(certDir, "ext-grpc-private-key.pem"));
 
-    console.log("Cluster mode: Using custom fetch with mTLS");
-
-    // Create a custom fetch that uses https module with client certificates
     const customFetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-        const url = typeof input === 'string' ? new URL(input) : input instanceof URL ? input : new URL(input.url);
-        const isHttps = url.protocol === 'https:';
+        const url = typeof input === "string" ? new URL(input) : input instanceof URL ? input : new URL(input.url);
+        const isHttps = url.protocol === "https:";
 
         return new Promise((resolve, reject) => {
             const options: https.RequestOptions = {
                 hostname: url.hostname,
                 port: url.port || (isHttps ? 443 : 80),
                 path: url.pathname + url.search,
-                method: init?.method || 'GET',
+                method: init?.method || "GET",
                 headers: init?.headers as Record<string, string>,
-                ca: ca,
-                cert: cert,
-                key: key,
+                ca,
+                cert,
+                key,
                 rejectUnauthorized: true,
             };
 
             const client = isHttps ? https : http;
             const req = client.request(options, (res) => {
                 const chunks: Buffer[] = [];
-                res.on('data', (chunk) => chunks.push(chunk));
-                res.on('end', () => {
+                res.on("data", (chunk) => chunks.push(chunk));
+                res.on("end", () => {
                     const body = Buffer.concat(chunks).toString();
                     const headers = new Headers();
-                    Object.entries(res.headers).forEach(([key, value]) => {
-                        if (value) headers.set(key, Array.isArray(value) ? value.join(', ') : value);
+                    Object.entries(res.headers).forEach(([k, value]) => {
+                        if (value) headers.set(k, Array.isArray(value) ? value.join(", ") : value);
                     });
                     const status = res.statusCode || 200;
-                    // Status codes 204 and 304 are "null body" statuses - Response constructor rejects body for these
                     const isNullBodyStatus = status === 204 || status === 304;
                     resolve(new Response(isNullBodyStatus ? null : body, {
                         status,
-                        statusText: res.statusMessage || '',
+                        statusText: res.statusMessage || "",
                         headers,
                     }));
                 });
             });
 
-            req.on('error', reject);
-
-            if (init?.body) {
-                req.write(init.body);
-            }
+            req.on("error", reject);
+            if (init?.body) req.write(init.body);
             req.end();
         });
     };
 
-    // Replace global fetch
     (globalThis as any).fetch = customFetch;
 }
 

--- a/http-ts/tests/integration/BUILD
+++ b/http-ts/tests/integration/BUILD
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@aspect_rules_js//js:defs.bzl", "js_test")
+load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+load("//http-ts/tests/behaviour:rules.bzl", "behaviour_test_ts_config")
+
+ts_project(
+    name = "cluster-failover-lib",
+    srcs = ["cluster-failover.ts"],
+    tsconfig = behaviour_test_ts_config(),
+    deps = [
+        "//http-ts:driver-lib",
+        "//http-ts:node_modules/@types/node",
+    ],
+    transpiler = "tsc",
+    declaration = True,
+)
+
+js_test(
+    name = "cluster-failover",
+    entry_point = ":cluster-failover.js",
+    data = [
+        ":cluster-failover-lib",
+        "//tool/test:cluster-server.sh",
+        "//tool/test/resources:certificates",
+    ],
+    env = {
+        "CLUSTER_SERVER_SCRIPT": "$(rootpath //tool/test:cluster-server.sh)",
+        "ROOT_CA": "$(rootpath //tool/test/resources:encryption/ext-grpc-root-ca.pem)",
+    },
+    size = "large",
+)
+
+checkstyle_test(
+    name = "checkstyle",
+    include = glob(["*"]),
+    license_type = "apache-header",
+)

--- a/http-ts/tests/integration/BUILD
+++ b/http-ts/tests/integration/BUILD
@@ -22,10 +22,9 @@ load("//http-ts/tests/behaviour:rules.bzl", "behaviour_test_ts_config")
 
 ts_project(
     name = "cluster-failover-lib",
-    srcs = ["cluster-failover.ts"],
+    srcs = ["cluster-failover.ts"] + ["//http-ts:driver-lib"],
     tsconfig = behaviour_test_ts_config(),
     deps = [
-        "//http-ts:driver-lib",
         "//http-ts:node_modules/@types/node",
     ],
     transpiler = "tsc",
@@ -37,13 +36,7 @@ js_test(
     entry_point = ":cluster-failover.js",
     data = [
         ":cluster-failover-lib",
-        "//tool/test:cluster-server.sh",
-        "//tool/test/resources:certificates",
     ],
-    env = {
-        "CLUSTER_SERVER_SCRIPT": "$(rootpath //tool/test:cluster-server.sh)",
-        "ROOT_CA": "$(rootpath //tool/test/resources:encryption/ext-grpc-root-ca.pem)",
-    },
     size = "large",
 )
 

--- a/http-ts/tests/integration/BUILD
+++ b/http-ts/tests/integration/BUILD
@@ -36,8 +36,21 @@ js_test(
     entry_point = ":cluster-failover.js",
     data = [
         ":cluster-failover-lib",
+        "//tool/test:cluster-server.sh",
+        "//tool/test/resources:certificates",
+        "//tool/test/resources:encryption/ext-grpc-root-ca.pem",
     ],
+    no_copy_to_bin = [
+        "//tool/test:cluster-server.sh",
+        "//tool/test/resources:certificates",
+        "//tool/test/resources:encryption/ext-grpc-root-ca.pem",
+    ],
+    env = {
+        "CLUSTER_SERVER_SCRIPT": "$(rootpath //tool/test:cluster-server.sh)",
+        "ROOT_CA": "$(rootpath //tool/test/resources:encryption/ext-grpc-root-ca.pem)",
+    },
     size = "large",
+    local = True,  # Test manages external server processes via CLUSTER_DIR
 )
 
 checkstyle_test(

--- a/http-ts/tests/integration/cluster-failover.ts
+++ b/http-ts/tests/integration/cluster-failover.ts
@@ -1,0 +1,310 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { execSync } from "child_process";
+import * as https from "https";
+import * as http from "http";
+import * as fs from "fs";
+import * as path from "path";
+import { TypeDBHttpDriver, isOkResponse, isApiErrorResponse, Server } from "../../dist/index.cjs";
+
+const ADDRESSES = [
+    "https://127.0.0.1:18000",
+    "https://127.0.0.1:28000",
+    "https://127.0.0.1:38000",
+];
+const USERNAME = "admin";
+const PASSWORD = "password";
+const DATABASE_NAME = "test-failover";
+const FAILOVER_ITERATIONS = 10;
+const PRIMARY_POLL_RETRIES = 60;
+const PRIMARY_POLL_INTERVAL_MS = 2000;
+const POST_KILL_STABILIZATION_MS = 5000;
+
+function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function setupMtlsFetch(): void {
+    const rootCaPath = process.env.ROOT_CA;
+    if (!rootCaPath) throw new Error("ROOT_CA environment variable must be set");
+    const certDir = path.dirname(rootCaPath);
+    const ca = fs.readFileSync(rootCaPath);
+    const cert = fs.readFileSync(path.join(certDir, "ext-grpc-certificate.pem"));
+    const key = fs.readFileSync(path.join(certDir, "ext-grpc-private-key.pem"));
+
+    const customFetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url = typeof input === "string" ? new URL(input) : input instanceof URL ? input : new URL(input.url);
+        const isHttps = url.protocol === "https:";
+
+        return new Promise((resolve, reject) => {
+            const options: https.RequestOptions = {
+                hostname: url.hostname,
+                port: url.port || (isHttps ? 443 : 80),
+                path: url.pathname + url.search,
+                method: init?.method || "GET",
+                headers: init?.headers as Record<string, string>,
+                ca,
+                cert,
+                key,
+                rejectUnauthorized: true,
+            };
+
+            const client = isHttps ? https : http;
+            const req = client.request(options, (res) => {
+                const chunks: Buffer[] = [];
+                res.on("data", (chunk) => chunks.push(chunk));
+                res.on("end", () => {
+                    const body = Buffer.concat(chunks).toString();
+                    const headers = new Headers();
+                    Object.entries(res.headers).forEach(([k, value]) => {
+                        if (value) headers.set(k, Array.isArray(value) ? value.join(", ") : value);
+                    });
+                    const status = res.statusCode || 200;
+                    const isNullBodyStatus = status === 204 || status === 304;
+                    resolve(new Response(isNullBodyStatus ? null : body, {
+                        status,
+                        statusText: res.statusMessage || "",
+                        headers,
+                    }));
+                });
+            });
+
+            req.on("error", reject);
+            if (init?.body) req.write(init.body);
+            req.end();
+        });
+    };
+
+    (globalThis as any).fetch = customFetch;
+}
+
+function clusterServer(command: string, nodeId: string): void {
+    const script = process.env.CLUSTER_SERVER_SCRIPT;
+    if (!script) throw new Error("CLUSTER_SERVER_SCRIPT environment variable must be set");
+    const env: Record<string, string> = { ...process.env as Record<string, string> };
+    if (!env.CLUSTER_DIR && env.BUILD_WORKSPACE_DIRECTORY) {
+        env.CLUSTER_DIR = env.BUILD_WORKSPACE_DIRECTORY;
+    }
+    execSync(`${script} ${command} ${nodeId}`, { env, stdio: "inherit" });
+}
+
+function ensureAllNodesUp(): void {
+    for (let i = 1; i <= ADDRESSES.length; i++) {
+        const id = i.toString();
+        clusterServer("start", id);
+        clusterServer("await", id);
+    }
+}
+
+function nodeIdFromAddress(address: string): string {
+    // HTTP port pattern: <node_id>8000 → node_id is first digit of port
+    const match = address.match(/:(\d)8000/);
+    if (match) return match[1];
+    // Fallback: extract from host:port
+    const port = address.split(":").pop() || "";
+    return port[0];
+}
+
+function createDriver(): TypeDBHttpDriver {
+    return new TypeDBHttpDriver({ username: USERNAME, password: PASSWORD, addresses: ADDRESSES });
+}
+
+async function getPrimaryServer(driver: TypeDBHttpDriver): Promise<Server> {
+    for (let attempt = 0; attempt < PRIMARY_POLL_RETRIES; attempt++) {
+        const resp = await driver.getServers();
+        if (isOkResponse(resp)) {
+            const primary = resp.ok.servers.find(
+                s => s.replicaStatus?.replicaRole === "primary" && s.address != null
+            );
+            if (primary) return primary;
+        }
+        if (attempt < PRIMARY_POLL_RETRIES - 1) {
+            console.log(
+                `  No primary server found (attempt ${attempt + 1}/${PRIMARY_POLL_RETRIES}). Retrying in ${PRIMARY_POLL_INTERVAL_MS}ms...`
+            );
+            await sleep(PRIMARY_POLL_INTERVAL_MS);
+        }
+    }
+    throw new Error("Retry limit exceeded while seeking a primary server.");
+}
+
+async function setupDatabase(driver: TypeDBHttpDriver): Promise<void> {
+    for (let attempt = 0; attempt < PRIMARY_POLL_RETRIES; attempt++) {
+        try {
+            await trySetupDatabase(driver);
+            return;
+        } catch (e) {
+            if (attempt < PRIMARY_POLL_RETRIES - 1) {
+                console.log(
+                    `  Database setup failed (attempt ${attempt + 1}/${PRIMARY_POLL_RETRIES}): ${e}. Retrying in ${PRIMARY_POLL_INTERVAL_MS}ms...`
+                );
+                await sleep(PRIMARY_POLL_INTERVAL_MS);
+            } else {
+                throw new Error(`Database setup failed after ${PRIMARY_POLL_RETRIES} attempts: ${e}`);
+            }
+        }
+    }
+}
+
+async function trySetupDatabase(driver: TypeDBHttpDriver): Promise<void> {
+    const dbsResp = await driver.getDatabases();
+    if (!isOkResponse(dbsResp)) throw new Error(`Failed to list databases: ${JSON.stringify(dbsResp)}`);
+    if (dbsResp.ok.databases.some(db => db.name === DATABASE_NAME)) {
+        const delResp = await driver.deleteDatabase(DATABASE_NAME);
+        if (isApiErrorResponse(delResp)) throw new Error(`Failed to delete database: ${JSON.stringify(delResp)}`);
+    }
+
+    const createResp = await driver.createDatabase(DATABASE_NAME);
+    if (isApiErrorResponse(createResp)) throw new Error(`Failed to create database: ${JSON.stringify(createResp)}`);
+
+    const txResp = await driver.openTransaction(DATABASE_NAME, "schema");
+    if (!isOkResponse(txResp)) throw new Error(`Failed to open schema transaction: ${JSON.stringify(txResp)}`);
+
+    const qResp = await driver.query(txResp.ok.transactionId, "define entity person;");
+    if (isApiErrorResponse(qResp)) throw new Error(`Failed to define schema: ${JSON.stringify(qResp)}`);
+
+    const commitResp = await driver.commitTransaction(txResp.ok.transactionId);
+    if (isApiErrorResponse(commitResp)) throw new Error(`Failed to commit: ${JSON.stringify(commitResp)}`);
+}
+
+async function verifyReadQuery(driver: TypeDBHttpDriver): Promise<void> {
+    for (let attempt = 0; attempt < PRIMARY_POLL_RETRIES; attempt++) {
+        const txResp = await driver.openTransaction(DATABASE_NAME, "read");
+        if (!isOkResponse(txResp)) {
+            if (attempt < PRIMARY_POLL_RETRIES - 1) {
+                console.log(`    Read query attempt ${attempt + 1}/${PRIMARY_POLL_RETRIES} failed (transaction open). Retrying...`);
+                await sleep(PRIMARY_POLL_INTERVAL_MS);
+                continue;
+            }
+            throw new Error(`Failed to open read transaction after ${PRIMARY_POLL_RETRIES} attempts: ${JSON.stringify(txResp)}`);
+        }
+
+        const qResp = await driver.query(txResp.ok.transactionId, "match entity $t;");
+        await driver.closeTransaction(txResp.ok.transactionId);
+
+        if (!isOkResponse(qResp)) {
+            if (attempt < PRIMARY_POLL_RETRIES - 1) {
+                console.log(`    Read query attempt ${attempt + 1}/${PRIMARY_POLL_RETRIES} failed (query). Retrying...`);
+                await sleep(PRIMARY_POLL_INTERVAL_MS);
+                continue;
+            }
+            throw new Error(`Read query failed after ${PRIMARY_POLL_RETRIES} attempts: ${JSON.stringify(qResp)}`);
+        }
+        if (qResp.ok.answerType === "conceptRows" && qResp.ok.answers.length === 0) {
+            throw new Error("Expected at least one entity type in read query results");
+        }
+        return;
+    }
+}
+
+async function waitForClusterHealthy(driver: TypeDBHttpDriver): Promise<void> {
+    for (let attempt = 0; attempt < PRIMARY_POLL_RETRIES; attempt++) {
+        const resp = await driver.getServers();
+        if (isOkResponse(resp)) {
+            const activeNodes = resp.ok.servers.filter(
+                (s: Server) => s.address != null && s.replicaStatus != null && s.replicaStatus.replicaRole != null
+            );
+            if (activeNodes.length >= ADDRESSES.length) return;
+            if (attempt % 10 === 0 && attempt > 0) {
+                console.log(`    Waiting for cluster health: ${activeNodes.length}/${ADDRESSES.length} nodes active`);
+            }
+        }
+        await sleep(PRIMARY_POLL_INTERVAL_MS);
+    }
+    throw new Error(`Cluster did not reach ${ADDRESSES.length} healthy nodes within ${PRIMARY_POLL_RETRIES * PRIMARY_POLL_INTERVAL_MS / 1000}s timeout`);
+}
+
+async function cleanupDatabase(): Promise<void> {
+    try {
+        const driver = createDriver();
+        const dbsResp = await driver.getDatabases();
+        if (isOkResponse(dbsResp) && dbsResp.ok.databases.some(db => db.name === DATABASE_NAME)) {
+            await driver.deleteDatabase(DATABASE_NAME);
+        }
+    } catch {
+        // Best-effort cleanup
+    }
+}
+
+async function main(): Promise<void> {
+    setupMtlsFetch();
+    ensureAllNodesUp();
+
+    console.log("=== Cluster Failover Test (HTTP-TS) ===");
+
+    console.log("Connecting driver...");
+    const driver = createDriver();
+
+    console.log("Setting up database and schema...");
+    await setupDatabase(driver);
+    await verifyReadQuery(driver);
+    console.log("Initial setup verified.");
+
+    for (let iteration = 1; iteration <= FAILOVER_ITERATIONS; iteration++) {
+        console.log(`\n--- Failover iteration ${iteration}/${FAILOVER_ITERATIONS} ---`);
+
+        const primary = await getPrimaryServer(driver);
+        const primaryAddress = primary.address!;
+        const nodeId = nodeIdFromAddress(primaryAddress);
+        console.log(`  Primary server: ${primaryAddress} (node ${nodeId})`);
+
+        console.log("  Read query before kill...");
+        await verifyReadQuery(driver);
+
+        console.log(`  Killing node ${nodeId}...`);
+        clusterServer("kill", nodeId);
+
+        // Allow cluster time to detect failure and begin election before polling
+        console.log(`  Waiting ${POST_KILL_STABILIZATION_MS / 1000}s for cluster to stabilize...`);
+        await sleep(POST_KILL_STABILIZATION_MS);
+
+        console.log("  Read query after kill (driver auto-failover)...");
+        await verifyReadQuery(driver);
+        console.log("  Auto-failover read succeeded.");
+
+        console.log("  Confirming new primary...");
+        const newPrimary = await getPrimaryServer(driver);
+        const newNodeId = nodeIdFromAddress(newPrimary.address!);
+        console.log(`  New primary: ${newPrimary.address} (node ${newNodeId})`);
+
+        console.log("  Read query on confirmed primary...");
+        await verifyReadQuery(driver);
+        console.log("  Confirmed primary read succeeded.");
+
+        console.log(`  Restarting node ${nodeId}...`);
+        clusterServer("start", nodeId);
+        clusterServer("await", nodeId);
+        // Wait for the restarted node to fully rejoin the cluster
+        await waitForClusterHealthy(driver);
+        console.log(`  Node ${nodeId} restarted, cluster fully healthy.`);
+    }
+
+    console.log(`\n=== All ${FAILOVER_ITERATIONS} failover iterations passed! ===`);
+
+    await cleanupDatabase();
+}
+
+main().then(
+    () => process.exit(0),
+    (err) => {
+        console.error("FAILOVER TEST FAILED:", err);
+        process.exit(1);
+    }
+);

--- a/tool/test/cluster-server.sh
+++ b/tool/test/cluster-server.sh
@@ -133,6 +133,7 @@ server_start() {
     --server.connection-address="127.0.0.1:${server_port}" \
     --server.http.enabled=true \
     --server.http.address="0.0.0.0:${http_port}" \
+    --server.http.connection-address="127.0.0.1:${http_port}" \
     --server.admin.enabled=true \
     --server.admin.port="${admin_port}" \
     --server.encryption.enabled="${ENCRYPTION_ENABLED}" \

--- a/tool/test/cluster-server.sh
+++ b/tool/test/cluster-server.sh
@@ -127,7 +127,13 @@ server_start() {
   local log_file="${node_dir}/server.log"
   rm -f "${log_file}"
 
-  nohup "${node_dir}/typedb" server \
+  # Use setsid on Linux to start in a new session (prevents process group cleanup).
+  # On macOS, nohup + disown is sufficient.
+  local setsid_cmd=""
+  if command -v setsid >/dev/null 2>&1; then
+    setsid_cmd="setsid"
+  fi
+  $setsid_cmd nohup "${node_dir}/typedb" server \
     ${config_args} \
     --diagnostics.deployment-id "${DEPLOYMENT_ID}" \
     --server.listen-address="0.0.0.0:${server_port}" \

--- a/tool/test/cluster-server.sh
+++ b/tool/test/cluster-server.sh
@@ -125,15 +125,16 @@ server_start() {
   fi
 
   local log_file="${node_dir}/server.log"
+  rm -f "${log_file}"
 
   nohup "${node_dir}/typedb" server \
     ${config_args} \
     --diagnostics.deployment-id "${DEPLOYMENT_ID}" \
-    --server.address="0.0.0.0:${server_port}" \
-    --server.connection-address="127.0.0.1:${server_port}" \
+    --server.listen-address="0.0.0.0:${server_port}" \
+    --server.advertise-address="127.0.0.1:${server_port}" \
     --server.http.enabled=true \
-    --server.http.address="0.0.0.0:${http_port}" \
-    --server.http.connection-address="127.0.0.1:${http_port}" \
+    --server.http.listen-address="0.0.0.0:${http_port}" \
+    --server.http.advertise-address="127.0.0.1:${http_port}" \
     --server.admin.enabled=true \
     --server.admin.port="${admin_port}" \
     --server.encryption.enabled="${ENCRYPTION_ENABLED}" \


### PR DESCRIPTION
## Usage and product changes
Add cluster failover logic for the HTTP-TS driver.                                                                         
                                                                       
## Implementation
### Initial connection 

The driver uses addresses[0] as its starting server (currentOrigin). This is the same as master — no behavior change for single-address users.       
                                                    
### Per-request flow (`apiReq`)
                                                                                                                               
1. Try current server — Send the request to currentOrigin. If the server is unreachable or signin fails, treat it as a connection error (null).
2. Follow 421 redirect — If the server responds with 421 Misdirected (meaning "I'm not the primary, go talk to X"), the driver parses the primaryAddress from the response body, switches currentOrigin to that server, re-authenticates, and retries once.
3. Fallback to other addresses — If the result is still null (connection error) or non-ok (server error, e.g. during leader election), iterate through all other configured addresses. For each: try the request, follow any 421 redirect, return the first successful response. If none succeed, return the last error.
4. All failed — Return a synthetic HDR1: Cannot connect to any server error.

Sticky routing: Once the driver discovers a working server (especially the primary via 421 redirect), currentOrigin stays pointed there. Subsequent requests go directly — no redundant 421 round-trips until that server becomes unavailable.

Authentication: One token cached per origin. Cleared on origin switch. On 401, the driver refreshes the token once and retries. If signin itself fails on a server (e.g. SRV14 "Not yet initialised" during raft recovery), that server is skipped and fallback continues.

What's NOT configurable:
- No retry count setting — each address is tried once per request
- No timeout settings for failover (the application-level retry loop controls that)
- No explicit primary preference — the driver just follows what the cluster tells it
- The address list is fixed at construction time