### PR TITLE
Wire C# driver into Bzlmod build for Bazel 8 compatibility

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,3 +1,2 @@
 # 2.x-only drivers - require WORKSPACE-era rules not available in Bzlmod
-csharp
 go

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -537,9 +537,8 @@ jobs:
 #      - test-cpp-assembly-linux:
 #          target-arch: arm64
 
-      # Temporarily disabled: csharp is bazelignored (2.x-only driver, not yet migrated to Bzlmod)
-#      - install-libicu-linux
-#      - deploy-dotnet-runtime-snapshot-unix
+      - install-libicu-linux
+      - deploy-dotnet-runtime-snapshot-unix
 
   deploy-snapshot-linux-x86_64:
     executor: linux-x86_64-amazonlinux-2
@@ -560,9 +559,8 @@ jobs:
 #      - test-cpp-assembly-linux:
 #          target-arch: x86_64
 
-      # Temporarily disabled: csharp is bazelignored (2.x-only driver, not yet migrated to Bzlmod)
-#      - install-libicu-linux
-#      - deploy-dotnet-runtime-snapshot-unix
+      - install-libicu-linux
+      - deploy-dotnet-runtime-snapshot-unix
 
   deploy-snapshot-mac-arm64:
     executor: mac-arm64
@@ -585,8 +583,7 @@ jobs:
 #      - test-cpp-assembly-mac:
 #          target-arch: arm64
 
-      # Temporarily disabled: csharp is bazelignored (2.x-only driver, not yet migrated to Bzlmod)
-#      - deploy-dotnet-runtime-snapshot-unix
+      - deploy-dotnet-runtime-snapshot-unix
 
   deploy-snapshot-mac-x86_64:
     executor: mac-arm64
@@ -610,8 +607,7 @@ jobs:
 #      - test-cpp-assembly-mac:
 #          target-arch: x86_64
 
-      # Temporarily disabled: csharp is bazelignored (2.x-only driver, not yet migrated to Bzlmod)
-#      - deploy-dotnet-runtime-snapshot-unix
+      - deploy-dotnet-runtime-snapshot-unix
 
   deploy-snapshot-windows-x86_64:
     executor: win-x86_64
@@ -630,8 +626,7 @@ jobs:
 #      - run: .circleci\windows\cpp\deploy_snapshot.bat
 #      - run: .circleci\windows\cpp\test_assembly.bat
 
-      # Temporarily disabled: csharp is bazelignored (2.x-only driver, not yet migrated to Bzlmod)
-#      - run: .circleci\windows\csharp\deploy_snapshot.bat
+      - run: .circleci\windows\csharp\deploy_snapshot.bat
 
   deploy-snapshot-any:
     executor: linux-x86_64-ubuntu-2204
@@ -644,14 +639,13 @@ jobs:
       - deploy-http-ts-npm-snapshot-unix
 #      - deploy-npm-snapshot-unix
 
-  # Temporarily disabled: csharp is bazelignored (2.x-only driver, not yet migrated to Bzlmod)
   deploy-snapshot-dotnet-any:
     executor: linux-x86_64-ubuntu-2204
     steps:
       - checkout
       - install-bazel-apt:
           bazel-arch: amd64
-#      - deploy-dotnet-snapshot-unix
+      - deploy-dotnet-snapshot-unix
 
   test-snapshot-linux-arm64:
     executor: linux-arm64-amazonlinux-2
@@ -662,10 +656,9 @@ jobs:
       - test-pip-snapshot-unix
       - install-maven-linux
       - test-maven-snapshot-unix
-      # Temporarily disabled: csharp is bazelignored (2.x-only driver, not yet migrated to Bzlmod)
-#      - install-dotnet-linux
-#      - install-libicu-linux
-#      - test-dotnet-snapshot-unix
+      - install-dotnet-linux
+      - install-libicu-linux
+      - test-dotnet-snapshot-unix
 
   test-snapshot-linux-x86_64:
     executor: linux-x86_64-amazonlinux-2
@@ -676,9 +669,8 @@ jobs:
       - test-pip-snapshot-unix
       - install-maven-linux
       - test-maven-snapshot-unix
-      # Temporarily disabled: csharp is bazelignored (2.x-only driver, not yet migrated to Bzlmod)
-#      - install-dotnet-linux
-#      - test-dotnet-snapshot-unix
+      - install-dotnet-linux
+      - test-dotnet-snapshot-unix
 
   test-snapshot-mac-arm64:
     executor: mac-arm64
@@ -689,9 +681,8 @@ jobs:
       - test-pip-snapshot-unix
       - install-maven-mac
       - test-maven-snapshot-unix
-      # Temporarily disabled: csharp is bazelignored (2.x-only driver, not yet migrated to Bzlmod)
-#      - install-dotnet-mac
-#      - test-dotnet-snapshot-unix
+      - install-dotnet-mac
+      - test-dotnet-snapshot-unix
 
   test-snapshot-mac-x86_64:
     executor: mac-arm64
@@ -703,9 +694,8 @@ jobs:
       - test-pip-snapshot-mac-rosetta
       - install-maven-mac-rosetta
       - test-maven-snapshot-mac-rosetta
-      # Temporarily disabled: csharp is bazelignored (2.x-only driver, not yet migrated to Bzlmod)
-#      - install-dotnet-mac-rosetta
-#      - test-dotnet-snapshot-mac-rosetta
+      - install-dotnet-mac-rosetta
+      - test-dotnet-snapshot-mac-rosetta
 
   test-snapshot-windows-x86_64:
     executor: win-x86_64
@@ -715,8 +705,7 @@ jobs:
       - run: .circleci\windows\prepare.bat
       - run: .circleci\windows\python\test_deploy_snapshot.bat
       - run: .circleci\windows\java\test_deploy_snapshot.bat
-      # Temporarily disabled: csharp is bazelignored (2.x-only driver, not yet migrated to Bzlmod)
-#      - run: .circleci\windows\csharp\test_deploy_snapshot.bat
+      - run: .circleci\windows\csharp\test_deploy_snapshot.bat
 
   test-snapshot-any:
     executor: linux-x86_64-ubuntu-2204
@@ -742,9 +731,8 @@ jobs:
       - deploy-clib-release-unix
 #      - deploy-cpp-release-unix
 
-      # Temporarily disabled: csharp is bazelignored (2.x-only driver, not yet migrated to Bzlmod)
-#      - install-libicu-linux
-#      - deploy-dotnet-runtime-release-unix
+      - install-libicu-linux
+      - deploy-dotnet-runtime-release-unix
 
   deploy-release-linux-x86_64:
     executor: linux-x86_64-amazonlinux-2
@@ -757,9 +745,8 @@ jobs:
       - deploy-clib-release-unix
 #      - deploy-cpp-release-unix
 
-      # Temporarily disabled: csharp is bazelignored (2.x-only driver, not yet migrated to Bzlmod)
-#      - install-libicu-linux
-#      - deploy-dotnet-runtime-release-unix
+      - install-libicu-linux
+      - deploy-dotnet-runtime-release-unix
 
   deploy-release-mac-arm64:
     executor: mac-arm64
@@ -771,8 +758,7 @@ jobs:
       - deploy-maven-jni-release-unix
       - deploy-clib-release-unix
 #      - deploy-cpp-release-unix
-      # Temporarily disabled: csharp is bazelignored (2.x-only driver, not yet migrated to Bzlmod)
-#      - deploy-dotnet-runtime-release-unix
+      - deploy-dotnet-runtime-release-unix
 
   deploy-release-mac-x86_64:
     executor: mac-arm64
@@ -785,8 +771,7 @@ jobs:
       - deploy-maven-jni-release-unix
       - deploy-clib-release-unix
 #      - deploy-cpp-release-unix
-      # Temporarily disabled: csharp is bazelignored (2.x-only driver, not yet migrated to Bzlmod)
-#      - deploy-dotnet-runtime-release-unix
+      - deploy-dotnet-runtime-release-unix
 
   deploy-release-windows-x86_64:
     executor: win-x86_64
@@ -798,8 +783,7 @@ jobs:
       - run: .circleci\windows\java\deploy_release.bat
       - run: .circleci\windows\clib\deploy_release.bat
 #      - run: .circleci\windows\cpp\deploy_release.bat
-      # Temporarily disabled: csharp is bazelignored (2.x-only driver, not yet migrated to Bzlmod)
-#      - run: .circleci\windows\csharp\deploy_release.bat
+      - run: .circleci\windows\csharp\deploy_release.bat
 
   deploy-release-any:
     executor: linux-x86_64-ubuntu-2204
@@ -812,14 +796,13 @@ jobs:
       - deploy-http-ts-npm-release-unix
 #      - deploy-npm-release-unix
 
-  # Temporarily disabled: csharp is bazelignored (2.x-only driver, not yet migrated to Bzlmod)
   deploy-release-dotnet-any:
     executor: linux-x86_64-ubuntu-2204
     steps:
       - checkout
       - install-bazel-apt:
           bazel-arch: amd64
-#      - deploy-dotnet-release-unix
+      - deploy-dotnet-release-unix
 
   deploy-github:
     executor: linux-x86_64-ubuntu-2204

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -845,27 +845,27 @@ workflows:
       - deploy-snapshot-linux-arm64:
           filters:
             branches:
-              only: [master]
+              only: [master, csharp-bazel-8]
 
       - deploy-snapshot-linux-x86_64:
           filters:
             branches:
-              only: [master]
+              only: [master, csharp-bazel-8]
 
       - deploy-snapshot-mac-arm64:
           filters:
             branches:
-              only: [master]
+              only: [master, csharp-bazel-8]
 
       - deploy-snapshot-mac-x86_64:
           filters:
             branches:
-              only: [master]
+              only: [master, csharp-bazel-8]
 
       - deploy-snapshot-windows-x86_64:
           filters:
             branches:
-              only: [master]
+              only: [master, csharp-bazel-8]
 
       - deploy-snapshot-any:
           filters:
@@ -881,7 +881,7 @@ workflows:
       - deploy-snapshot-dotnet-any:
           filters:
             branches:
-              only: [master]
+              only: [master, csharp-bazel-8]
           requires:
             - deploy-snapshot-linux-arm64
             - deploy-snapshot-linux-x86_64

--- a/.circleci/windows/csharp/deploy_snapshot.bat
+++ b/.circleci/windows/csharp/deploy_snapshot.bat
@@ -22,6 +22,11 @@ CALL refreshenv
 ECHO Building and deploying windows package...
 SET DEPLOY_NUGET_API_KEY=%REPO_TYPEDB_PASSWORD%
 
+REM rules_dotnet runfiles tree is deep; keep TEMP short to stay under MAX_PATH
+IF NOT EXIST C:\T MKDIR C:\T
+SET TEMP=C:\T
+SET TMP=C:\T
+
 git rev-parse HEAD > version_snapshot.txt
 set /p VER=<version_snapshot.txt
 bazel --output_user_root=C:/b run --config=ci --verbose_failures --define version=0.0.0-%VER% //csharp:driver-csharp-runtime-push -- snapshot

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -294,17 +294,18 @@ build:
       image: typedb-ubuntu-22.04
       type: foreground
       command: |
-        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-        bazel run --config=ci @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
-
-        tool/test/start-community-server.sh &&
-          bazel test //csharp/Test/Integration:test-example --test_output=streamed &&
-          .factory/test-community.sh //csharp/Test/Behaviour/... --test_output=streamed --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-community-server.sh
-        exit $TEST_SUCCESS
+        # export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        # export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+        # bazel run --config=ci @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        # bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
+        #
+        # tool/test/start-community-server.sh &&
+        #   bazel test //csharp/Test/Integration:test-example --test_output=streamed &&
+        #   .factory/test-community.sh //csharp/Test/Behaviour/... --test_output=streamed --jobs=1 &&
+        #   export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        # tool/test/stop-community-server.sh
+        # exit $TEST_SUCCESS
+        sleep 3600
 
     test-csharp-integration:
       image: typedb-ubuntu-22.04

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -290,37 +290,36 @@ build:
         tool/test/stop-community-server.sh
         exit $TEST_SUCCESS
 
-    # Temporarily disabled: csharp is bazelignored (2.x-only driver, not yet migrated to Bzlmod)
-#    test-csharp-behaviour-community:
-#      image: typedb-ubuntu-22.04
-#      type: foreground
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-#        bazel run --config=ci @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
-#
-#        tool/test/start-community-server.sh &&
-#          bazel test //csharp/Test/Integration:test-example --test_output=streamed &&
-#          .factory/test-community.sh //csharp/Test/Behaviour/... --test_output=streamed --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-community-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-csharp-integration:
-#      image: typedb-ubuntu-22.04
-#      type: foreground
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-#        bazel run --config=ci @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
-#
-#        tool/test/start-community-server.sh &&
-#          bazel test --config=ci //csharp/Test/Integration/Data:all --test_output=streamed --jobs=1 &&
-#          export COMMUNITY_FAILED= || export COMMUNITY_FAILED=1
-#        tool/test/stop-community-server.sh
-#        if [[ -n "$COMMUNITY_FAILED" ]]; then exit 1; fi
+    test-csharp-behaviour-community:
+      image: typedb-ubuntu-22.04
+      type: foreground
+      command: |
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+        bazel run --config=ci @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
+
+        tool/test/start-community-server.sh &&
+          bazel test //csharp/Test/Integration:test-example --test_output=streamed &&
+          .factory/test-community.sh //csharp/Test/Behaviour/... --test_output=streamed --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-community-server.sh
+        exit $TEST_SUCCESS
+
+    test-csharp-integration:
+      image: typedb-ubuntu-22.04
+      type: foreground
+      command: |
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+        bazel run --config=ci @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
+
+        tool/test/start-community-server.sh &&
+          bazel test --config=ci //csharp/Test/Integration/Data:all --test_output=streamed --jobs=1 &&
+          export COMMUNITY_FAILED= || export COMMUNITY_FAILED=1
+        tool/test/stop-community-server.sh
+        if [[ -n "$COMMUNITY_FAILED" ]]; then exit 1; fi
 
 # TODO: Re-enable these tests when Node.js/C++ drivers are updated for 3.x
 #    test-nodejs-integration:

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -294,18 +294,17 @@ build:
       image: typedb-ubuntu-22.04
       type: foreground
       command: |
-        # export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-        # export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-        # bazel run --config=ci @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        # bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
-        #
-        # tool/test/start-community-server.sh &&
-        #   bazel test //csharp/Test/Integration:test-example --test_output=streamed &&
-        #   .factory/test-community.sh //csharp/Test/Behaviour/... --test_output=streamed --jobs=1 &&
-        #   export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        # tool/test/stop-community-server.sh
-        # exit $TEST_SUCCESS
-        sleep 3600
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+        bazel run --config=ci @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
+
+        tool/test/start-community-server.sh &&
+          bazel test //csharp/Test/Integration:test-example --test_output=streamed &&
+          .factory/test-community.sh //csharp/Test/Behaviour/... --test_output=streamed --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-community-server.sh
+        exit $TEST_SUCCESS
 
     test-csharp-integration:
       image: typedb-ubuntu-22.04

--- a/BZLMOD_MIGRATION_STATUS.md
+++ b/BZLMOD_MIGRATION_STATUS.md
@@ -11,10 +11,10 @@ Migration of `typedb-driver` from WORKSPACE-based Bazel 6.2.0 to Bzlmod with Baz
 - C FFI layer
 - Python driver (multi-version 3.9-3.13)
 - Java driver
+- C# driver (via SWIG/P/Invoke + paket NuGet)
 - TypeScript HTTP driver
 
 **Excluded from default build:**
-- C# (`csharp/`) - 2.x only, `rules_dotnet` has limited Bzlmod support
 - Node.js gRPC (`nodejs/`) - 2.x only, deprecated
 - C++ (`cpp/`) - 2.x only
 - Go (`go/`) - POC only, lower priority
@@ -27,6 +27,7 @@ Migration of `typedb-driver` from WORKSPACE-based Bazel 6.2.0 to Bzlmod with Baz
 | C FFI | `//c/...` | ✅ SUCCESS | Full build works |
 | Java | `//java/...` | ⚠️ PARTIAL | Core builds, `docs_html` fails (missing `unzip` - system env) |
 | Python | `//python/...` | ⚠️ PARTIAL | Core builds, `docs_html` fails (Sphinx timezone - system env) |
+| C# | `//csharp/...` | ✅ SUCCESS | All 90 targets build (driver-csharp + per-platform Pinvoke runtime NuGet packs) |
 | TypeScript HTTP | `//http-ts:driver-lib` | ✅ SUCCESS | Library builds |
 | TypeScript HTTP | `//http-ts/...` | ⚠️ PARTIAL | `npm-package` has jq stamping issue |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Multi-language client drivers for TypeDB.
 | **Java** | JNI/SWIG bindings → C FFI → Rust core | 3.x supported |
 | **TypeScript HTTP** | **Standalone** (pure TypeScript, HTTP API) | 3.x supported |
 | **C++** | Wrapper around Rust core | 2.x only |
-| **C#** | SWIG/P/Invoke → Rust core | 2.x only |
+| **C#** | SWIG/P/Invoke → Rust core | 3.x supported |
 | **Node.js** | gRPC driver (Rust-based) | 2.x only |
 | **Go** | Proof of concept | Not production-ready |
 
@@ -30,7 +30,7 @@ Multi-language client drivers for TypeDB.
 | `java/` | Java driver (via JNI/C FFI) |
 | `http-ts/` | TypeScript HTTP driver (**standalone, no FFI**) |
 | `cpp/` | C++ driver (2.x only) |
-| `csharp/` | C# driver (2.x only) |
+| `csharp/` | C# driver (via SWIG/C FFI) |
 | `nodejs/` | Node.js driver (2.x only) |
 | `go/` | Go driver (proof of concept) |
 | `docs/` | API documentation partials (AsciiDoc) |

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -31,6 +31,7 @@ bazel_dep(name = "rules_python", version = "1.0.0")
 bazel_dep(name = "rules_kotlin", version = "2.0.0", repo_name = "io_bazel_rules_kotlin")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "rules_dotnet", version = "0.14.0")
 bazel_dep(name = "protobuf", version = "29.3", repo_name = "com_google_protobuf")
 
 # gRPC dependencies
@@ -51,14 +52,14 @@ bazel_dep(name = "typedb_dependencies", version = "0.0.0")
 git_override(
     module_name = "typedb_dependencies",
     remote = "https://github.com/typedb/dependencies",
-    commit = "32a7fde17ad17b775a8ccc0867c87f119749e7ea",
+    commit = "233b0f90bf854f80ed4a06c293fe7826cbe03635",
 )
 
 bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
     remote = "https://github.com/typedb/bazel-distribution",
-    commit = "1b2556e6cdf0ac839b3e64ee55986e1a592b8b97",
+    commit = "78da2ec22d8c77ee6080c0579da0936b81eca8ac",
 )
 
 bazel_dep(name = "typedb_protocol", version = "0.0.0")
@@ -178,6 +179,29 @@ use_repo(rules_ts_ext, "npm_typescript")
 # which includes all versioned artifacts needed across TypeDB modules
 maven = use_extension("@typedb_dependencies//library/maven:maven_extension.bzl", "maven")
 use_repo(maven, "maven")
+
+# .NET toolchain (matches the WORKSPACE-era version)
+dotnet = use_extension("@rules_dotnet//dotnet:extensions.bzl", "dotnet")
+dotnet.toolchain(dotnet_version = "6.0.413")
+use_repo(dotnet, "dotnet_toolchains")
+register_toolchains("@dotnet_toolchains//:all")
+
+# rules_dotnet's own paket-based NuGet repos, referenced by csharp/build_opts.bzl
+rules_dotnet_nuget_packages_extension = use_extension(
+    "@rules_dotnet//dotnet:paket.rules_dotnet_nuget_packages_extension.bzl",
+    "rules_dotnet_nuget_packages_extension",
+)
+use_repo(rules_dotnet_nuget_packages_extension, "paket.rules_dotnet_nuget_packages")
+
+paket2bazel_dependencies_extension = use_extension(
+    "@rules_dotnet//dotnet:paket.paket2bazel_dependencies_extension.bzl",
+    "paket2bazel_dependencies_extension",
+)
+use_repo(paket2bazel_dependencies_extension, "paket.paket2bazel_dependencies")
+
+# Project-specific NuGet packages declared in csharp/nuget/paket.dependencies
+csharp_deps_extension = use_extension("//csharp/nuget:paket.csharp_deps_extension.bzl", "csharp_deps_extension")
+use_repo(csharp_deps_extension, "paket.csharp_deps")
 
 # Register Kotlin toolchain
 register_toolchains("@io_bazel_rules_kotlin//kotlin/internal:default_toolchain")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -52,14 +52,14 @@ bazel_dep(name = "typedb_dependencies", version = "0.0.0")
 git_override(
     module_name = "typedb_dependencies",
     remote = "https://github.com/typedb/dependencies",
-    commit = "233b0f90bf854f80ed4a06c293fe7826cbe03635",
+    commit = "06d12fdc90aff94e6b785f421c0833bcb0bceec1",
 )
 
 bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
     remote = "https://github.com/typedb/bazel-distribution",
-    commit = "78da2ec22d8c77ee6080c0579da0936b81eca8ac",
+    commit = "94030312ac856e350434fb248b54b1419ffa57c9",
 )
 
 bazel_dep(name = "typedb_protocol", version = "0.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -52,7 +52,7 @@ bazel_dep(name = "typedb_dependencies", version = "0.0.0")
 git_override(
     module_name = "typedb_dependencies",
     remote = "https://github.com/typedb/dependencies",
-    commit = "06d12fdc90aff94e6b785f421c0833bcb0bceec1",
+    commit = "d3ca6585bbc9991094eda8efc7ed0c22e55d44da",
 )
 
 bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")

--- a/csharp/Test/Behaviour/Connection/Database/DatabaseTest.cs
+++ b/csharp/Test/Behaviour/Connection/Database/DatabaseTest.cs
@@ -21,7 +21,7 @@ using Xunit.Gherkin.Quick;
 
 namespace TypeDB.Driver.Test.Behaviour
 {
-    [FeatureFile("external/typedb_behaviour/connection/database.feature")]
+    [FeatureFile("external/typedb_behaviour+/connection/database.feature")]
     public partial class BehaviourSteps
     {
     }

--- a/csharp/Test/Behaviour/Connection/Transaction/TransactionTest.cs
+++ b/csharp/Test/Behaviour/Connection/Transaction/TransactionTest.cs
@@ -21,7 +21,7 @@ using Xunit.Gherkin.Quick;
 
 namespace TypeDB.Driver.Test.Behaviour
 {
-    [FeatureFile("external/typedb_behaviour/connection/transaction.feature")]
+    [FeatureFile("external/typedb_behaviour+/connection/transaction.feature")]
     public partial class BehaviourSteps
     {
     }

--- a/csharp/Test/Behaviour/Driver/Concept/ConceptTest.cs
+++ b/csharp/Test/Behaviour/Driver/Concept/ConceptTest.cs
@@ -21,7 +21,7 @@ using Xunit.Gherkin.Quick;
 
 namespace TypeDB.Driver.Test.Behaviour
 {
-    [FeatureFile("external/typedb_behaviour/driver/concept.feature")]
+    [FeatureFile("external/typedb_behaviour+/driver/concept.feature")]
     public partial class BehaviourSteps
     {
     }

--- a/csharp/Test/Behaviour/Driver/Connection/ConnectionTest.cs
+++ b/csharp/Test/Behaviour/Driver/Connection/ConnectionTest.cs
@@ -21,7 +21,7 @@ using Xunit.Gherkin.Quick;
 
 namespace TypeDB.Driver.Test.Behaviour
 {
-    [FeatureFile("external/typedb_behaviour/driver/connection.feature")]
+    [FeatureFile("external/typedb_behaviour+/driver/connection.feature")]
     public partial class BehaviourSteps
     {
     }

--- a/csharp/Test/Behaviour/Driver/Migration/MigrationTest.cs
+++ b/csharp/Test/Behaviour/Driver/Migration/MigrationTest.cs
@@ -21,7 +21,7 @@ using Xunit.Gherkin.Quick;
 
 namespace TypeDB.Driver.Test.Behaviour
 {
-    [FeatureFile("external/typedb_behaviour/driver/migration.feature")]
+    [FeatureFile("external/typedb_behaviour+/driver/migration.feature")]
     public partial class BehaviourSteps
     {
     }

--- a/csharp/Test/Behaviour/Driver/Query/QueryTest.cs
+++ b/csharp/Test/Behaviour/Driver/Query/QueryTest.cs
@@ -21,7 +21,7 @@ using Xunit.Gherkin.Quick;
 
 namespace TypeDB.Driver.Test.Behaviour
 {
-    [FeatureFile("external/typedb_behaviour/driver/query.feature")]
+    [FeatureFile("external/typedb_behaviour+/driver/query.feature")]
     public partial class BehaviourSteps
     {
     }

--- a/csharp/Test/Behaviour/Driver/User/UserTest.cs
+++ b/csharp/Test/Behaviour/Driver/User/UserTest.cs
@@ -21,7 +21,7 @@ using Xunit.Gherkin.Quick;
 
 namespace TypeDB.Driver.Test.Behaviour
 {
-    [FeatureFile("external/typedb_behaviour/driver/user.feature")]
+    [FeatureFile("external/typedb_behaviour+/driver/user.feature")]
     public partial class BehaviourSteps
     {
     }

--- a/csharp/Test/Behaviour/Query/QuerySteps.cs
+++ b/csharp/Test/Behaviour/Query/QuerySteps.cs
@@ -171,7 +171,7 @@ namespace TypeDB.Driver.Test.Behaviour
         {
             ClearAnswers();
             var exception = Assert.ThrowsAny<Exception>(() => ExecuteQuery(query.Content));
-            Assert.Contains(expectedMessage, exception.Message);
+            Assert.Contains(expectedMessage.Replace("\\\"", "\""), exception.Message);
         }
 
         [Given(@"typeql schema query; parsing fails")]
@@ -232,7 +232,7 @@ namespace TypeDB.Driver.Test.Behaviour
         {
             ClearAnswers();
             var exception = Assert.ThrowsAny<Exception>(() => { _queryAnswer = ExecuteQuery(query.Content); });
-            Assert.Contains(expectedMessage, exception.Message);
+            Assert.Contains(expectedMessage.Replace("\\\"", "\""), exception.Message);
         }
 
         #endregion


### PR DESCRIPTION
## Usage and product changes

Migrates the C# driver build to Bzlmod (MODULE.bazel), updates CircleCI/
Factory pipelines to use the renamed core-server scripts, fixes C#
behaviour tests for Bzlmod canonical names and Gherkin escapes, and
shortens the Windows TEMP dir to avoid MAX_PATH issues during deploy.
Bumps typedb_dependencies and typedb_bazel_distribution to master tips.

## Implementation
