### PR TITLE
Fix http-ts failover logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2807,7 +2807,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?tag=3.10.0-alpha-0#e234cf2df5f025afd6f694c05473448b8cef3697"
+source = "git+https://github.com/typedb/typedb-protocol?rev=25ab3fb02715062bd036f8b83908de92b106a202#25ab3fb02715062bd036f8b83908de92b106a202"
 dependencies = [
  "prost",
  "tonic",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -240,7 +240,7 @@ native_artifact_files.artifact(
     name = "typedb_cluster_artifact",
     group_name = "typedb-cluster-all-{platform}",
     artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
-    tag = "3.10.0-alpha-1",
+    commit = "598c47cc13c8400ae64061b390bb035de46a64d0",
     private = True,
 )
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -192,6 +192,8 @@
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
     "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
     "https://bcr.bazel.build/modules/rules_cc/0.1.1/source.json": "d61627377bd7dd1da4652063e368d9366fc9a73920bfa396798ad92172cf645c",
+    "https://bcr.bazel.build/modules/rules_dotnet/0.14.0/MODULE.bazel": "f006f845f5e75c5a3e691947062bf33cfef66d2b66af9f1d5f6a35fc99d4ed78",
+    "https://bcr.bazel.build/modules/rules_dotnet/0.14.0/source.json": "0fd3ac33da1afa98261a99251396e99eab82261739aa81beee6c814cc83b897e",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.10.1/MODULE.bazel": "b9527010e5fef060af92b6724edb3691970a5b1f76f74b21d39f7d433641be60",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.10.1/source.json": "9300e71df0cdde0952f10afff1401fa664e9fc5d9ae6204660ba1b158d90d6a6",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
@@ -11511,7 +11513,7 @@
     "@@typedb_dependencies+//distribution/artifact:rules.bzl%native_artifact_files": {
       "general": {
         "bzlTransitiveDigest": "G2tVfxi6pNMPwxLud5h67xKrwcp4+6MJIFRhSA7KBWo=",
-        "usagesDigest": "8Si2pVYrYwuAcf7aYv0N+1BN8ttrG/LP/JFqC4F+BLk=",
+        "usagesDigest": "bse1BjQU6qVon5QUgtgoM8X8DD9CiOpVmrKwo3qVqJ4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -11520,90 +11522,90 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-all-linux-arm64/versions/3.10.0-alpha-1/typedb-all-linux-arm64-3.10.0-alpha-1.tar.gz"
+                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-linux-arm64/versions/7cc4a3e9edcaaee2c8fa9cdce6ffef170eeed503/typedb-all-linux-arm64-7cc4a3e9edcaaee2c8fa9cdce6ffef170eeed503.tar.gz"
               ],
-              "downloaded_file_path": "typedb-all-linux-arm64-3.10.0-alpha-1.tar.gz"
+              "downloaded_file_path": "typedb-all-linux-arm64-7cc4a3e9edcaaee2c8fa9cdce6ffef170eeed503.tar.gz"
             }
           },
           "typedb_artifact_linux-x86_64": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-all-linux-x86_64/versions/3.10.0-alpha-1/typedb-all-linux-x86_64-3.10.0-alpha-1.tar.gz"
+                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-linux-x86_64/versions/7cc4a3e9edcaaee2c8fa9cdce6ffef170eeed503/typedb-all-linux-x86_64-7cc4a3e9edcaaee2c8fa9cdce6ffef170eeed503.tar.gz"
               ],
-              "downloaded_file_path": "typedb-all-linux-x86_64-3.10.0-alpha-1.tar.gz"
+              "downloaded_file_path": "typedb-all-linux-x86_64-7cc4a3e9edcaaee2c8fa9cdce6ffef170eeed503.tar.gz"
             }
           },
           "typedb_artifact_mac-arm64": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-all-mac-arm64/versions/3.10.0-alpha-1/typedb-all-mac-arm64-3.10.0-alpha-1.zip"
+                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-mac-arm64/versions/7cc4a3e9edcaaee2c8fa9cdce6ffef170eeed503/typedb-all-mac-arm64-7cc4a3e9edcaaee2c8fa9cdce6ffef170eeed503.zip"
               ],
-              "downloaded_file_path": "typedb-all-mac-arm64-3.10.0-alpha-1.zip"
+              "downloaded_file_path": "typedb-all-mac-arm64-7cc4a3e9edcaaee2c8fa9cdce6ffef170eeed503.zip"
             }
           },
           "typedb_artifact_mac-x86_64": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-all-mac-x86_64/versions/3.10.0-alpha-1/typedb-all-mac-x86_64-3.10.0-alpha-1.zip"
+                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-mac-x86_64/versions/7cc4a3e9edcaaee2c8fa9cdce6ffef170eeed503/typedb-all-mac-x86_64-7cc4a3e9edcaaee2c8fa9cdce6ffef170eeed503.zip"
               ],
-              "downloaded_file_path": "typedb-all-mac-x86_64-3.10.0-alpha-1.zip"
+              "downloaded_file_path": "typedb-all-mac-x86_64-7cc4a3e9edcaaee2c8fa9cdce6ffef170eeed503.zip"
             }
           },
           "typedb_artifact_windows-x86_64": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-all-windows-x86_64/versions/3.10.0-alpha-1/typedb-all-windows-x86_64-3.10.0-alpha-1.zip"
+                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-all-windows-x86_64/versions/7cc4a3e9edcaaee2c8fa9cdce6ffef170eeed503/typedb-all-windows-x86_64-7cc4a3e9edcaaee2c8fa9cdce6ffef170eeed503.zip"
               ],
-              "downloaded_file_path": "typedb-all-windows-x86_64-3.10.0-alpha-1.zip"
+              "downloaded_file_path": "typedb-all-windows-x86_64-7cc4a3e9edcaaee2c8fa9cdce6ffef170eeed503.zip"
             }
           },
           "typedb_cluster_artifact_linux-arm64": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/basic/private-release/raw/names/typedb-cluster-all-linux-arm64/versions/3.10.0-alpha-1/typedb-cluster-all-linux-arm64-3.10.0-alpha-1.tar.gz"
+                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-linux-arm64/versions/598c47cc13c8400ae64061b390bb035de46a64d0/typedb-cluster-all-linux-arm64-598c47cc13c8400ae64061b390bb035de46a64d0.tar.gz"
               ],
-              "downloaded_file_path": "typedb-cluster-all-linux-arm64-3.10.0-alpha-1.tar.gz"
+              "downloaded_file_path": "typedb-cluster-all-linux-arm64-598c47cc13c8400ae64061b390bb035de46a64d0.tar.gz"
             }
           },
           "typedb_cluster_artifact_linux-x86_64": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/basic/private-release/raw/names/typedb-cluster-all-linux-x86_64/versions/3.10.0-alpha-1/typedb-cluster-all-linux-x86_64-3.10.0-alpha-1.tar.gz"
+                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-linux-x86_64/versions/598c47cc13c8400ae64061b390bb035de46a64d0/typedb-cluster-all-linux-x86_64-598c47cc13c8400ae64061b390bb035de46a64d0.tar.gz"
               ],
-              "downloaded_file_path": "typedb-cluster-all-linux-x86_64-3.10.0-alpha-1.tar.gz"
+              "downloaded_file_path": "typedb-cluster-all-linux-x86_64-598c47cc13c8400ae64061b390bb035de46a64d0.tar.gz"
             }
           },
           "typedb_cluster_artifact_mac-arm64": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/basic/private-release/raw/names/typedb-cluster-all-mac-arm64/versions/3.10.0-alpha-1/typedb-cluster-all-mac-arm64-3.10.0-alpha-1.zip"
+                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-mac-arm64/versions/598c47cc13c8400ae64061b390bb035de46a64d0/typedb-cluster-all-mac-arm64-598c47cc13c8400ae64061b390bb035de46a64d0.zip"
               ],
-              "downloaded_file_path": "typedb-cluster-all-mac-arm64-3.10.0-alpha-1.zip"
+              "downloaded_file_path": "typedb-cluster-all-mac-arm64-598c47cc13c8400ae64061b390bb035de46a64d0.zip"
             }
           },
           "typedb_cluster_artifact_mac-x86_64": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/basic/private-release/raw/names/typedb-cluster-all-mac-x86_64/versions/3.10.0-alpha-1/typedb-cluster-all-mac-x86_64-3.10.0-alpha-1.zip"
+                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-mac-x86_64/versions/598c47cc13c8400ae64061b390bb035de46a64d0/typedb-cluster-all-mac-x86_64-598c47cc13c8400ae64061b390bb035de46a64d0.zip"
               ],
-              "downloaded_file_path": "typedb-cluster-all-mac-x86_64-3.10.0-alpha-1.zip"
+              "downloaded_file_path": "typedb-cluster-all-mac-x86_64-598c47cc13c8400ae64061b390bb035de46a64d0.zip"
             }
           },
           "typedb_cluster_artifact_windows-x86_64": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/basic/private-release/raw/names/typedb-cluster-all-windows-x86_64/versions/3.10.0-alpha-1/typedb-cluster-all-windows-x86_64-3.10.0-alpha-1.zip"
+                "https://repo.typedb.com/basic/private-snapshot/raw/names/typedb-cluster-all-windows-x86_64/versions/598c47cc13c8400ae64061b390bb035de46a64d0/typedb-cluster-all-windows-x86_64-598c47cc13c8400ae64061b390bb035de46a64d0.zip"
               ],
-              "downloaded_file_path": "typedb-cluster-all-windows-x86_64-3.10.0-alpha-1.zip"
+              "downloaded_file_path": "typedb-cluster-all-windows-x86_64-598c47cc13c8400ae64061b390bb035de46a64d0.zip"
             }
           }
         },

--- a/http-ts/src/index.ts
+++ b/http-ts/src/index.ts
@@ -37,11 +37,13 @@ import {
 const HTTP_UNAUTHORIZED = 401;
 const HTTP_MISDIRECTED = 421;
 
-// SRV14 ("Not yet initialised") is briefly returned by `/v1/signin` on a node that just
-// became the new cluster primary.
-const SIGNIN_TRANSIENT_RETRY_BUDGET_MS = 30_000;
-const SIGNIN_TRANSIENT_RETRY_INTERVAL_MS = 200;
-const SIGNIN_TRANSIENT_ERROR_CODES = new Set(["SRV14"]);
+// Codes that mean "this origin is not currently usable for signin" — treated like a
+// connection failure so the caller falls back to another origin instead of waiting:
+//   HDR2  - local driver error: could not reach the server
+//   SRV14 - server returned "Not yet initialised". Happens on a freshly restarted secondary
+//           that has not yet loaded the system DB, or briefly on a node mid-promotion. Either
+//           way another origin is likely healthy, so fall back rather than retry in place.
+const TRANSIENT_SIGNIN_ERROR_CODES = new Set(["HDR2", "SRV14"]);
 
 // Result of attempting a single request against a single origin.
 //   Response          - reached the server and got an HTTP response
@@ -54,20 +56,12 @@ function isApiErrResp(value: TryResult): value is ApiErrorResponse {
     return value !== null && "err" in value;
 }
 
-// HDR2 (driverError) is a connection failure raised inside refreshToken: surfacing it as
-// null lets tryApiReq's caller fall back to other origins. Any other err response was
-// returned by the server itself (e.g. 401 "Invalid credential supplied") and must be
-// propagated, since fallback origins would reject the same credentials the same way.
+// Surface transient signin errors as null so tryApiReq's caller falls back to other origins.
+// Any other err response was returned by the server itself (e.g. 401 "Invalid credential
+// supplied") and must be propagated, since fallback origins would reject the same credentials
+// the same way.
 function tokenErrToResult(tokenResp: ApiErrorResponse): ApiErrorResponse | null {
-    return tokenResp.err.code === "HDR2" ? null : tokenResp;
-}
-
-function isTransientSigninError(result: ApiResponse<SignInResponse>): boolean {
-    return "err" in result && SIGNIN_TRANSIENT_ERROR_CODES.has(result.err.code);
-}
-
-function sleep(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
+    return TRANSIENT_SIGNIN_ERROR_CODES.has(tokenResp.err.code) ? null : tokenResp;
 }
 
 export * from "./analyze";
@@ -332,12 +326,7 @@ export class TypeDBHttpDriver {
     }
 
     private async refreshToken(): Promise<ApiResponse<SignInResponse>> {
-        const deadline = Date.now() + SIGNIN_TRANSIENT_RETRY_BUDGET_MS;
-        while (true) {
-            const result = await this.signinOnce();
-            if (!isTransientSigninError(result) || Date.now() >= deadline) return result;
-            await sleep(SIGNIN_TRANSIENT_RETRY_INTERVAL_MS);
-        }
+        return this.signinOnce();
     }
 
     private async signinOnce(): Promise<ApiResponse<SignInResponse>> {


### PR DESCRIPTION
## Usage and product changes

When the cluster primary is no longer responsive, the HTTP-TS driver may route its next signin to a secondary that's briefly returning `SRV14 "Not yet initialised"` — e.g. a just-restarted node whose system DB isn't loaded into memory yet, or a node mid-promotion.

This made the failover incomplete and the `cluster-failover.ts` test flaky in CI: when fallback landed on a stuck secondary before a healthy origin, the driver burned the test budget on a single dead-end.

## Implementation
- `tokenErrToResult` now treats `SRV14` the same as `HDR2`: surface as `null` so the caller iterates to the next origin.
- Removed the 30s SRV14 retry loop in `refreshToken`. Fallback to a healthy origin is in the millisecond range; callers (and the test harness) already retry on returned errors, which covers the rarer "every origin is briefly transient" case at a coarser cadence.