### PR TITLE
Use connection address for standalone connections

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -234,7 +234,7 @@ native_artifact_files.artifact(
     name = "typedb_artifact",
     group_name = "typedb-all-{platform}",
     artifact_name = "typedb-all-{platform}-{version}.{ext}",
-    tag = "3.11.0-rc1",
+    commit = "642e0a774729a8e52d7eea2cb123fb8f52fb1bc1",
 )
 # IMPORTANT: must be CLUSTERED typedb-cluster (with multi-node support)!
 native_artifact_files.artifact(

--- a/rust/example.rs
+++ b/rust/example.rs
@@ -4,13 +4,13 @@ use std::time::Duration;
 
 use futures::{StreamExt, TryStreamExt};
 use typedb_driver::{
-    Credentials, DriverOptions, Error, QueryOptions, TransactionOptions, TransactionType, TypeDBDriver,
+    Addresses, Credentials, DriverOptions, DriverTlsConfig, Error, QueryOptions, TransactionOptions, TransactionType,
+    TypeDBDriver,
     answer::{
         ConceptRow, QueryAnswer,
         concept_document::{Leaf, Node},
     },
-    concept::{Concept},
-    Addresses, DriverTlsConfig,
+    concept::Concept,
 };
 
 fn main() {

--- a/rust/src/connection/server/server_connection.rs
+++ b/rust/src/connection/server/server_connection.rs
@@ -49,6 +49,7 @@ use crate::{
 #[derive(Clone)]
 pub(crate) struct ServerConnection {
     background_runtime: Arc<BackgroundRuntime>,
+    address: Address,
     username: String,
     connection_id: Uuid,
     request_transmitter: Arc<RPCTransmitter>,
@@ -68,12 +69,13 @@ impl ServerConnection {
     ) -> Result<(Self, Vec<Server>)> {
         let username = credentials.username().to_string();
         let request_transmitter =
-            Arc::new(RPCTransmitter::start(address, credentials.clone(), driver_options, &background_runtime)?);
+            Arc::new(RPCTransmitter::start(address.clone(), credentials.clone(), driver_options, &background_runtime)?);
         let (connection_id, latency, servers) =
             Self::open_connection(&request_transmitter, driver_lang, driver_version, credentials).await?;
         let latency_tracker = LatencyTracker::new(latency);
         let server_connection = Self {
             background_runtime,
+            address,
             username,
             connection_id,
             request_transmitter,
@@ -81,6 +83,10 @@ impl ServerConnection {
             latency_tracker,
         };
         Ok((server_connection, servers))
+    }
+
+    pub(crate) fn address(&self) -> &Address {
+        &self.address
     }
 
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]

--- a/rust/src/connection/server/server_manager.rs
+++ b/rust/src/connection/server/server_manager.rs
@@ -393,7 +393,8 @@ impl ServerManager {
             match replica_connection {
                 Ok((replica_connection, replicas)) => {
                     debug!("Fetched replicas from configured address '{address}': {replicas:?}");
-                    let translated_replicas = Self::translate_replicas(replicas, &address_translation);
+                    let translated_replicas =
+                        Self::translate_replicas(replicas, &address_translation, &replica_connection);
                     let mut source_connections = HashMap::with_capacity(translated_replicas.len());
                     source_connections.insert(address.clone(), replica_connection);
                     return Ok((source_connections, translated_replicas));
@@ -438,14 +439,28 @@ impl ServerManager {
         replica_connection: &ServerConnection,
         address_translation: &AddressTranslation,
     ) -> Result<HashSet<Server>> {
-        replica_connection.servers_all().await.map(|replicas| Self::translate_replicas(replicas, address_translation))
+        replica_connection
+            .servers_all()
+            .await
+            .map(|replicas| Self::translate_replicas(replicas, address_translation, replica_connection))
     }
 
     fn translate_replicas(
         replicas: impl IntoIterator<Item = Server>,
         address_translation: &AddressTranslation,
+        source: &ServerConnection,
     ) -> HashSet<Server> {
-        replicas.into_iter().map(|replica| replica.translated(address_translation)).collect()
+        replicas
+            .into_iter()
+            .map(|replica| match replica {
+                // standalone server without advertised address: use connection address directly
+                Server::Unavailable { replication_status: None } => {
+                    Server::available_from_private(source.address().clone(), None)
+                }
+                other => other,
+            })
+            .map(|replica| replica.translated(address_translation))
+            .collect()
     }
 
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]


### PR DESCRIPTION
## Usage and product changes

Make the driver use the connection address in case the server is not a part of a cluster and does not advertise an address for connection. 

This feature is required to allow easy connections to servers behind a proxy or inside a container -- otherwise, they'd have to provide advertise addresses, which makes the initial TypeDB set up more complicated (requires https://github.com/typedb/typedb/pull/7817).

For clustered connections, all clustered servers are still expected to provide the address through the protocol. 

## Implementation

Do not change the network layer -- just add a special case for non-clustered (no replication info) server without an advertise address.

HTTP-TS does not use the returned address in its connection, so it requires no changes.