### PR TITLE
Fix CI pipelines after rules_python upgrade

### DIFF
--- a/.circleci/windows/clib/deploy_release.bat
+++ b/.circleci/windows/clib/deploy_release.bat
@@ -25,5 +25,5 @@ SET DEPLOY_ARTIFACT_USERNAME=%REPO_TYPEDB_USERNAME%
 SET DEPLOY_ARTIFACT_PASSWORD=%REPO_TYPEDB_PASSWORD%
 
 SET /p VER=<VERSION
-bazel --output_user_root=C:\b run --config=ci --verbose_failures --define version=%VER% //c:deploy-windows-x86_64-zip --compilation_mode=opt -- release
+bazel --output_base=C:\b run --config=ci --verbose_failures --define version=%VER% //c:deploy-windows-x86_64-zip --compilation_mode=opt -- release
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%

--- a/.circleci/windows/clib/deploy_snapshot.bat
+++ b/.circleci/windows/clib/deploy_snapshot.bat
@@ -25,5 +25,5 @@ SET DEPLOY_ARTIFACT_PASSWORD=%REPO_TYPEDB_PASSWORD%
 
 git rev-parse HEAD > version_snapshot.txt
 set /p VER=<version_snapshot.txt
-bazel --output_user_root=C:\b run --config=ci --verbose_failures --define version=%VER% //c:deploy-windows-x86_64-zip -- snapshot
+bazel --output_base=C:\b run --config=ci --verbose_failures --define version=%VER% //c:deploy-windows-x86_64-zip -- snapshot
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%

--- a/.circleci/windows/clib/test_assembly.bat
+++ b/.circleci/windows/clib/test_assembly.bat
@@ -21,12 +21,12 @@ choco install 7zip.portable --limit-output --yes --no-progress
 choco install cmake.install --version 3.27.0 --installargs '"ADD_CMAKE_TO_PATH=User"' --limit-output --yes --no-progress
 CALL refreshenv
 
-bazel --output_user_root=C:\b build --config=ci @typedb_artifact_windows-x86_64//file
+bazel --output_base=C:\b build --config=ci @typedb_artifact_windows-x86_64//file
 powershell -Command "Move-Item -Path (Get-ChildItem -Path bazel-typedb-driver\external\*typedb_artifact_windows-x86_64\file\typedb-all-windows*) -Destination typedb-all-windows.zip"
 7z x typedb-all-windows.zip
 powershell -Command "Move-Item -Path typedb-all-windows-* -Destination typedb-all-windows"
 
-bazel --output_user_root=C:\b build --config=ci //c:assemble-windows-x86_64-zip
+bazel --output_base=C:\b build --config=ci //c:assemble-windows-x86_64-zip
 mkdir test_assembly_clib
 pushd test_assembly_clib
 7z x ..\bazel-bin\c\typedb-driver-clib-windows-x86_64.zip

--- a/.circleci/windows/cpp/deploy_release.bat
+++ b/.circleci/windows/cpp/deploy_release.bat
@@ -25,5 +25,5 @@ SET DEPLOY_ARTIFACT_USERNAME=%REPO_TYPEDB_USERNAME%
 SET DEPLOY_ARTIFACT_PASSWORD=%REPO_TYPEDB_PASSWORD%
 
 SET /p VER=<VERSION
-bazel --output_user_root=C:\b run --config=ci --verbose_failures --define version=%VER% //cpp:deploy-windows-x86_64-zip --compilation_mode=opt -- release
+bazel --output_base=C:\b run --config=ci --verbose_failures --define version=%VER% //cpp:deploy-windows-x86_64-zip --compilation_mode=opt -- release
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%

--- a/.circleci/windows/cpp/deploy_snapshot.bat
+++ b/.circleci/windows/cpp/deploy_snapshot.bat
@@ -25,5 +25,5 @@ SET DEPLOY_ARTIFACT_PASSWORD=%REPO_TYPEDB_PASSWORD%
 
 git rev-parse HEAD > version_snapshot.txt
 set /p VER=<version_snapshot.txt
-bazel --output_user_root=C:\b run --config=ci --verbose_failures --define version=%VER% //cpp:deploy-windows-x86_64-zip -- snapshot
+bazel --output_base=C:\b run --config=ci --verbose_failures --define version=%VER% //cpp:deploy-windows-x86_64-zip -- snapshot
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%

--- a/.circleci/windows/cpp/test_assembly.bat
+++ b/.circleci/windows/cpp/test_assembly.bat
@@ -21,12 +21,12 @@ choco install 7zip.portable --limit-output --yes --no-progress
 choco install cmake.install --version 3.27.0 --installargs '"ADD_CMAKE_TO_PATH=User"' --limit-output --yes --no-progress
 CALL refreshenv
 
-bazel --output_user_root=C:\b build --config=ci @typedb_artifact_windows-x86_64//file
+bazel --output_base=C:\b build --config=ci @typedb_artifact_windows-x86_64//file
 powershell -Command "Move-Item -Path (Get-ChildItem -Path bazel-typedb-driver\external\*typedb_artifact_windows-x86_64\file\typedb-all-windows*) -Destination typedb-all-windows.zip"
 7z x typedb-all-windows.zip
 powershell -Command "Move-Item -Path typedb-all-windows-* -Destination typedb-all-windows"
 
-bazel --output_user_root=C:\b build --config=ci //cpp:assemble-windows-x86_64-zip
+bazel --output_base=C:\b build --config=ci //cpp:assemble-windows-x86_64-zip
 mkdir test_assembly_cpp
 pushd test_assembly_cpp
 7z x ..\bazel-bin\cpp\typedb-driver-cpp-windows-x86_64.zip

--- a/.circleci/windows/csharp/deploy_release.bat
+++ b/.circleci/windows/csharp/deploy_release.bat
@@ -29,5 +29,5 @@ SET TEMP=C:\T
 SET TMP=C:\T
 
 SET /p VER=<VERSION
-bazel --output_user_root=C:/b run --config=ci --verbose_failures --define version=%VER% //csharp:driver-csharp-runtime-push --compilation_mode=opt -- release
+bazel --output_base=C:/b run --config=ci --verbose_failures --define version=%VER% //csharp:driver-csharp-runtime-push --compilation_mode=opt -- release
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%

--- a/.circleci/windows/csharp/deploy_snapshot.bat
+++ b/.circleci/windows/csharp/deploy_snapshot.bat
@@ -29,5 +29,5 @@ SET TMP=C:\T
 
 git rev-parse HEAD > version_snapshot.txt
 set /p VER=<version_snapshot.txt
-bazel --output_user_root=C:/b run --config=ci --verbose_failures --define version=%VER% //csharp:driver-csharp-runtime-push -- snapshot
+bazel --output_base=C:/b run --config=ci --verbose_failures --define version=%VER% //csharp:driver-csharp-runtime-push -- snapshot
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%

--- a/.circleci/windows/csharp/test_deploy_snapshot.bat
+++ b/.circleci/windows/csharp/test_deploy_snapshot.bat
@@ -20,7 +20,7 @@ choco install dotnet-6.0-runtime --limit-output --yes --no-progress
 choco install 7zip.portable --limit-output --yes --no-progress
 CALL refreshenv
 
-bazel --output_user_root=C:\b build --config=ci @typedb_artifact_windows-x86_64//file
+bazel --output_base=C:\b build --config=ci @typedb_artifact_windows-x86_64//file
 powershell -Command "Move-Item -Path (Get-ChildItem -Path bazel-typedb-driver\external\*typedb_artifact_windows-x86_64\file\typedb-all-windows*) -Destination typedb-all-windows.zip"
 7z x typedb-all-windows.zip
 RD /S /Q typedb-all-windows

--- a/.circleci/windows/java/deploy_release.bat
+++ b/.circleci/windows/java/deploy_release.bat
@@ -25,5 +25,5 @@ SET DEPLOY_MAVEN_USERNAME=%REPO_TYPEDB_USERNAME%
 SET DEPLOY_MAVEN_PASSWORD=%REPO_TYPEDB_PASSWORD%
 
 SET /p VER=<VERSION
-bazel --output_user_root=C:/b run --config=ci --verbose_failures --define version=%VER% //java:deploy-maven-jni --compilation_mode=opt -- release
+bazel --output_base=C:/b run --config=ci --verbose_failures --define version=%VER% //java:deploy-maven-jni --compilation_mode=opt -- release
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%

--- a/.circleci/windows/java/deploy_snapshot.bat
+++ b/.circleci/windows/java/deploy_snapshot.bat
@@ -25,5 +25,5 @@ SET DEPLOY_MAVEN_PASSWORD=%REPO_TYPEDB_PASSWORD%
 
 git rev-parse HEAD > version_snapshot.txt
 set /p VER=<version_snapshot.txt
-bazel --output_user_root=C:/b run --config=ci --verbose_failures --define version=%VER% //java:deploy-maven-jni -- snapshot
+bazel --output_base=C:/b run --config=ci --verbose_failures --define version=%VER% //java:deploy-maven-jni -- snapshot
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%

--- a/.circleci/windows/java/test_deploy_snapshot.bat
+++ b/.circleci/windows/java/test_deploy_snapshot.bat
@@ -20,7 +20,7 @@ choco install maven --limit-output --yes --no-progress
 choco install 7zip.portable --limit-output --yes --no-progress
 CALL refreshenv
 
-bazel --output_user_root=C:\b build --config=ci @typedb_artifact_windows-x86_64//file
+bazel --output_base=C:\b build --config=ci @typedb_artifact_windows-x86_64//file
 powershell -Command "Move-Item -Path (Get-ChildItem -Path bazel-typedb-driver\external\*typedb_artifact_windows-x86_64\file\typedb-all-windows*) -Destination typedb-all-windows.zip"
 7z x typedb-all-windows.zip
 RD /S /Q typedb-all-windows

--- a/.circleci/windows/prepare.bat
+++ b/.circleci/windows/prepare.bat
@@ -16,11 +16,11 @@ REM KIND, either express or implied.  See the License for the
 REM specific language governing permissions and limitations
 REM under the License.
 
-REM shorten the workspace name so that we can avoid the long path restriction
+REM Remove long path restriction from windows, though specific programs may still have it.
 reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
-
 call refreshenv
 
+REM shorten the workspace name so that we can avoid the long path restriction
 git apply .circleci\windows\git.patch
 IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
 

--- a/.circleci/windows/prepare.bat
+++ b/.circleci/windows/prepare.bat
@@ -17,6 +17,10 @@ REM specific language governing permissions and limitations
 REM under the License.
 
 REM shorten the workspace name so that we can avoid the long path restriction
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
+
+call refreshenv
+
 git apply .circleci\windows\git.patch
 IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
 

--- a/.circleci/windows/python/deploy_release.bat
+++ b/.circleci/windows/python/deploy_release.bat
@@ -26,17 +26,17 @@ SET DEPLOY_PIP_PASSWORD=%REPO_PYPI_PASSWORD%
 python.exe -m pip install twine==3.3.0 importlib-metadata==3.4.0
 SET /p VER=<VERSION
 
-bazel --output_user_root=C:\b run --config=ci --verbose_failures --define version=%VER% //python:deploy-pip39 --compilation_mode=opt -- release
+bazel --output_base=C:\b run --config=ci --verbose_failures --define version=%VER% //python:deploy-pip39 --compilation_mode=opt -- release
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%
 
-bazel --output_user_root=C:\b run --config=ci --verbose_failures --define version=%VER% //python:deploy-pip310 --compilation_mode=opt -- release
+bazel --output_base=C:\b run --config=ci --verbose_failures --define version=%VER% //python:deploy-pip310 --compilation_mode=opt -- release
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%
 
-bazel --output_user_root=C:\b run --config=ci --verbose_failures --define version=%VER% //python:deploy-pip311 --compilation_mode=opt -- release
+bazel --output_base=C:\b run --config=ci --verbose_failures --define version=%VER% //python:deploy-pip311 --compilation_mode=opt -- release
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%
 
-bazel --output_user_root=C:\b run --config=ci --verbose_failures --define version=%VER% //python:deploy-pip312 --compilation_mode=opt -- release
+bazel --output_base=C:\b run --config=ci --verbose_failures --define version=%VER% //python:deploy-pip312 --compilation_mode=opt -- release
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%
 
-bazel --output_user_root=C:\b run --config=ci --verbose_failures --define version=%VER% //python:deploy-pip313 --compilation_mode=opt -- release
+bazel --output_base=C:\b run --config=ci --verbose_failures --define version=%VER% //python:deploy-pip313 --compilation_mode=opt -- release
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%

--- a/.circleci/windows/python/deploy_snapshot.bat
+++ b/.circleci/windows/python/deploy_snapshot.bat
@@ -27,17 +27,17 @@ python.exe -m pip install twine==3.3.0 importlib-metadata==3.4.0
 git rev-parse HEAD > version_temp.txt
 set /p VER=<version_temp.txt
 
-bazel --output_user_root=C:\b run --config=ci --verbose_failures --define version=%VER% //python:deploy-pip39 -- snapshot
+bazel --output_base=C:\b run --config=ci --verbose_failures --define version=%VER% //python:deploy-pip39 -- snapshot
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%
 
-bazel --output_user_root=C:\b run --config=ci --verbose_failures --define version=%VER% //python:deploy-pip310 -- snapshot
+bazel --output_base=C:\b run --config=ci --verbose_failures --define version=%VER% //python:deploy-pip310 -- snapshot
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%
 
-bazel --output_user_root=C:\b run --config=ci --verbose_failures --define version=%VER% //python:deploy-pip311 -- snapshot
+bazel --output_base=C:\b run --config=ci --verbose_failures --define version=%VER% //python:deploy-pip311 -- snapshot
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%
 
-bazel --output_user_root=C:\b run --config=ci --verbose_failures --define version=%VER% //python:deploy-pip312 -- snapshot
+bazel --output_base=C:\b run --config=ci --verbose_failures --define version=%VER% //python:deploy-pip312 -- snapshot
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%
 
-bazel --output_user_root=C:\b run --config=ci --verbose_failures --define version=%VER% //python:deploy-pip313 -- snapshot
+bazel --output_base=C:\b run --config=ci --verbose_failures --define version=%VER% //python:deploy-pip313 -- snapshot
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%

--- a/.circleci/windows/python/test_deploy_snapshot.bat
+++ b/.circleci/windows/python/test_deploy_snapshot.bat
@@ -22,7 +22,7 @@ CALL refreshenv
 git rev-parse HEAD > version_temp.txt
 set /p VER=<version_temp.txt
 
-bazel --output_user_root=C:\b build --config=ci @typedb_artifact_windows-x86_64//file
+bazel --output_base=C:\b build --config=ci @typedb_artifact_windows-x86_64//file
 powershell -Command "Move-Item -Path (Get-ChildItem -Path bazel-typedb-driver\external\*typedb_artifact_windows-x86_64\file\typedb-all-windows*) -Destination typedb-all-windows.zip"
 7z x typedb-all-windows.zip
 RD /S /Q typedb-all-windows

--- a/BUILD
+++ b/BUILD
@@ -17,12 +17,16 @@
 
 package(default_visibility = ["//visibility:public"])
 
+load("@typedb_bazel_distribution//common:rules.bzl", "package_version_vars")
+
 load("@typedb_dependencies//tool/release/deps:rules.bzl", "release_validate_deps")
 load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 
 exports_files([
     "VERSION",
 ])
+
+package_version_vars(name = "driver-version-vars")
 
 checkstyle_test(
     name = "checkstyle",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -52,14 +52,14 @@ bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
     remote = "https://github.com/typedb/bazel-distribution",
-    commit = "5cbb1f82008435a5f50dcac21c8766c6111e852e",
+    commit = "dd811cf28715bbce8374e5e0f9defaf772e7dd36",
 )
 
 bazel_dep(name = "typedb_dependencies", version = "0.0.0")
 git_override(
     module_name = "typedb_dependencies",
     remote = "https://github.com/typedb/dependencies",
-    commit = "cdb696f58b0827c32e241f246b1b56360847679b",
+    commit = "c03bcfb0d8f047fd386573ad4429a2af039784ed",
 )
 
 bazel_dep(name = "typedb_protocol", version = "0.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -52,7 +52,7 @@ bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
     remote = "https://github.com/typedb/bazel-distribution",
-    commit = "c34c0c513e45e69e3f9d97664c7ccb5afd5f1341",
+    commit = "5cbb1f82008435a5f50dcac21c8766c6111e852e",
 )
 
 bazel_dep(name = "typedb_dependencies", version = "0.0.0")

--- a/c/BUILD
+++ b/c/BUILD
@@ -21,12 +21,12 @@ load("@rules_rust//rust:defs.bzl", "rust_static_library", "rust_shared_library",
 load("@typedb_dependencies//builder/rust:rules.bzl", "rust_cbindgen")
 load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 
-load("@typedb_bazel_distribution//common:rules.bzl", "assemble_targz", "assemble_zip", "checksum", "assemble_versioned")
+load("@typedb_bazel_distribution//common:rules.bzl", "checksum", "assemble_versioned")
 load("@typedb_bazel_distribution//docs/doxygen:rules.bzl", "doxygen_docs")
 load("@typedb_bazel_distribution//artifact:rules.bzl", "deploy_artifact")
 load("@typedb_dependencies//distribution:deployment.bzl", "deployment")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
+load("@rules_pkg//:pkg.bzl", "pkg_tar", "pkg_zip")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "pkg_filegroup")
 load("@typedb_bazel_distribution//platform:constraints.bzl", "constraint_linux_arm64", "constraint_linux_x86_64",
      "constraint_mac_arm64", "constraint_mac_x86_64", "constraint_win_x86_64")
 load("//c:docs_structure.bzl", "dir_mapping", "force_file")
@@ -107,53 +107,53 @@ pkg_files(
     prefix = "lib",
 )
 
-pkg_tar(
-    name = "typedb-driver-clib-tar",
+pkg_filegroup(
+    name = "typedb-driver-clib-packaged",
     srcs = [":typedb-driver-clib-headers", ":typedb-driver-clib-libraries"],
 )
 
-assemble_targz(
+pkg_tar(
     name = "assemble-linux-arm64-targz",
-    targets = [
-        ":typedb-driver-clib-tar"
-    ],
-    output_filename = "typedb-driver-clib-linux-arm64",
+    srcs = [":typedb-driver-clib-packaged"],
+    package_dir = "typedb-driver-clib-linux-arm64-{version}",
+    out = "typedb-driver-clib-linux-arm64.tar.gz",
+    package_variables = "//:driver-version-vars",
     target_compatible_with = constraint_linux_arm64,
 )
 
-assemble_targz(
+pkg_tar(
     name = "assemble-linux-x86_64-targz",
-    targets = [
-        ":typedb-driver-clib-tar"
-    ],
-    output_filename = "typedb-driver-clib-linux-x86_64",
+    srcs = [":typedb-driver-clib-packaged"],
+    package_dir = "typedb-driver-clib-linux-x86_64-{version}",
+    out = "typedb-driver-clib-linux-x86_64.tar.gz",
+    package_variables = "//:driver-version-vars",
     target_compatible_with = constraint_linux_x86_64,
 )
 
-assemble_zip(
+pkg_zip(
     name = "assemble-mac-arm64-zip",
-    targets = [
-        ":typedb-driver-clib-tar"
-    ],
-    output_filename = "typedb-driver-clib-mac-arm64",
+    srcs = [":typedb-driver-clib-packaged"],
+    package_dir = "typedb-driver-clib-mac-arm64-{version}",
+    out = "typedb-driver-clib-mac-arm64.zip",
+    package_variables = "//:driver-version-vars",
     target_compatible_with = constraint_mac_arm64,
 )
 
-assemble_zip(
+pkg_zip(
     name = "assemble-mac-x86_64-zip",
-    targets = [
-        ":typedb-driver-clib-tar"
-    ],
-    output_filename = "typedb-driver-clib-mac-x86_64",
+    srcs = [":typedb-driver-clib-packaged"],
+    package_dir = "typedb-driver-clib-mac-x86_64-{version}",
+    out = "typedb-driver-clib-mac-x86_64.zip",
+    package_variables = "//:driver-version-vars",
     target_compatible_with = constraint_mac_x86_64,
 )
 
-assemble_zip(
+pkg_zip(
     name = "assemble-windows-x86_64-zip",
-    targets = [
-        ":typedb-driver-clib-tar"
-    ],
-    output_filename = "typedb-driver-clib-windows-x86_64",
+    srcs = [":typedb-driver-clib-packaged"],
+    package_dir = "typedb-driver-clib-windows-x86_64-{version}",
+    out = "typedb-driver-clib-windows-x86_64.zip",
+    package_variables = "//:driver-version-vars",
     target_compatible_with = constraint_win_x86_64,
 )
 

--- a/c/BUILD
+++ b/c/BUILD
@@ -108,13 +108,13 @@ pkg_files(
 )
 
 pkg_filegroup(
-    name = "typedb-driver-clib-packaged",
+    name = "package-typedb-driver-clib",
     srcs = [":typedb-driver-clib-headers", ":typedb-driver-clib-libraries"],
 )
 
 pkg_tar(
     name = "assemble-linux-arm64-targz",
-    srcs = [":typedb-driver-clib-packaged"],
+    srcs = [":package-typedb-driver-clib"],
     package_dir = "typedb-driver-clib-linux-arm64-{version}",
     out = "typedb-driver-clib-linux-arm64.tar.gz",
     package_variables = "//:driver-version-vars",
@@ -123,7 +123,7 @@ pkg_tar(
 
 pkg_tar(
     name = "assemble-linux-x86_64-targz",
-    srcs = [":typedb-driver-clib-packaged"],
+    srcs = [":package-typedb-driver-clib"],
     package_dir = "typedb-driver-clib-linux-x86_64-{version}",
     out = "typedb-driver-clib-linux-x86_64.tar.gz",
     package_variables = "//:driver-version-vars",
@@ -132,7 +132,7 @@ pkg_tar(
 
 pkg_zip(
     name = "assemble-mac-arm64-zip",
-    srcs = [":typedb-driver-clib-packaged"],
+    srcs = [":package-typedb-driver-clib"],
     package_dir = "typedb-driver-clib-mac-arm64-{version}",
     out = "typedb-driver-clib-mac-arm64.zip",
     package_variables = "//:driver-version-vars",
@@ -141,7 +141,7 @@ pkg_zip(
 
 pkg_zip(
     name = "assemble-mac-x86_64-zip",
-    srcs = [":typedb-driver-clib-packaged"],
+    srcs = [":package-typedb-driver-clib"],
     package_dir = "typedb-driver-clib-mac-x86_64-{version}",
     out = "typedb-driver-clib-mac-x86_64.zip",
     package_variables = "//:driver-version-vars",
@@ -150,7 +150,7 @@ pkg_zip(
 
 pkg_zip(
     name = "assemble-windows-x86_64-zip",
-    srcs = [":typedb-driver-clib-packaged"],
+    srcs = [":package-typedb-driver-clib"],
     package_dir = "typedb-driver-clib-windows-x86_64-{version}",
     out = "typedb-driver-clib-windows-x86_64.zip",
     package_variables = "//:driver-version-vars",


### PR DESCRIPTION
## Usage and product changes
Fixes our CircleCI deployment pipelines after the rules_python upgrade

## Implementation
* Bump `typedb_bazel_distribution` for shorter repo names,
* migrate to `rules_pkg` to avoid long bazel_distribution python paths