### PR TITLE
Use Bazel `exclusive` tag for tests instead of CLI --jobs=1

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -126,7 +126,7 @@ build:
         bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
 
         tool/test/start-core-server.sh &&
-          bazel test --config=ci //rust/tests/behaviour/... --test_output=streamed --jobs=1 &&
+          bazel test --config=ci //rust/tests/behaviour/... --test_output=streamed &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
@@ -141,12 +141,12 @@ build:
 
         # TODO: run `bazel test --config=ci //rust/tests/behaviour/...` instead of multiple tests (cannot do Clustered migration now)
         source tool/test/start-cluster-servers.sh 3 &&
-          bazel test --config=ci //rust/tests/behaviour/connection/... --test_env=ROOT_CA=$ROOT_CA --//rust/tests/behaviour/config:mode=cluster --test_output=streamed --jobs=1 &&
-          bazel test --config=ci //rust/tests/behaviour/driver:test_concept --test_env=ROOT_CA=$ROOT_CA --//rust/tests/behaviour/config:mode=cluster --test_output=streamed --jobs=1 &&
-          bazel test --config=ci //rust/tests/behaviour/driver:test_connection --test_env=ROOT_CA=$ROOT_CA --//rust/tests/behaviour/config:mode=cluster --test_output=streamed --jobs=1 &&
-          bazel test --config=ci //rust/tests/behaviour/driver:test_query --test_env=ROOT_CA=$ROOT_CA --//rust/tests/behaviour/config:mode=cluster --test_output=streamed --jobs=1 &&
-          bazel test --config=ci //rust/tests/behaviour/driver:test_user --test_env=ROOT_CA=$ROOT_CA --//rust/tests/behaviour/config:mode=cluster --test_output=streamed --jobs=1 &&
-          bazel test --config=ci //rust/tests/behaviour/driver:test_cluster --test_env=ROOT_CA=$ROOT_CA --//rust/tests/behaviour/config:mode=cluster --test_output=streamed --jobs=1 &&
+          bazel test --config=ci //rust/tests/behaviour/connection/... --test_env=ROOT_CA=$ROOT_CA --//rust/tests/behaviour/config:mode=cluster --test_output=streamed &&
+          bazel test --config=ci //rust/tests/behaviour/driver:test_concept --test_env=ROOT_CA=$ROOT_CA --//rust/tests/behaviour/config:mode=cluster --test_output=streamed &&
+          bazel test --config=ci //rust/tests/behaviour/driver:test_connection --test_env=ROOT_CA=$ROOT_CA --//rust/tests/behaviour/config:mode=cluster --test_output=streamed &&
+          bazel test --config=ci //rust/tests/behaviour/driver:test_query --test_env=ROOT_CA=$ROOT_CA --//rust/tests/behaviour/config:mode=cluster --test_output=streamed &&
+          bazel test --config=ci //rust/tests/behaviour/driver:test_user --test_env=ROOT_CA=$ROOT_CA --//rust/tests/behaviour/config:mode=cluster --test_output=streamed &&
+          bazel test --config=ci //rust/tests/behaviour/driver:test_cluster --test_env=ROOT_CA=$ROOT_CA --//rust/tests/behaviour/config:mode=cluster --test_output=streamed &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-cluster-servers.sh
         exit $TEST_SUCCESS
@@ -173,13 +173,13 @@ build:
         bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
 
         tool/test/start-core-server.sh &&
-          bazel test --config=ci //java/test/integration:all --test_output=streamed --jobs=1 &&
+          bazel test --config=ci //java/test/integration:all --test_output=streamed &&
           export CORE_FAILED= || export CORE_FAILED=1
         tool/test/stop-core-server.sh
         if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
 
         source tool/test/start-cluster-servers.sh 3 &&
-          bazel test --config=ci //java/test/integration/cluster:test-failover --test_env=CLUSTER_SERVER_SCRIPT=$CLUSTER_SERVER_SCRIPT --test_env=ROOT_CA=$ROOT_CA --test_env=CLUSTER_DIR=$CLUSTER_DIR --test_output=streamed --jobs=1 &&
+          bazel test --config=ci //java/test/integration/cluster:test-failover --test_env=CLUSTER_SERVER_SCRIPT=$CLUSTER_SERVER_SCRIPT --test_env=ROOT_CA=$ROOT_CA --test_env=CLUSTER_DIR=$CLUSTER_DIR --test_output=streamed &&
           export CLUSTER_FAILED= || export CLUSTER_FAILED=1
         tool/test/stop-cluster-servers.sh
         if [[ -n "$CLUSTER_FAILED" ]]; then exit 1; fi
@@ -193,7 +193,7 @@ build:
         bazel run --config=ci @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
 
         tool/test/start-core-server.sh &&
-          .factory/test-core.sh //java/test/behaviour/... --test_output=streamed --jobs=1 &&
+          .factory/test-core.sh //java/test/behaviour/... --test_output=streamed &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
@@ -208,12 +208,12 @@ build:
 
         # TODO: run `.factory/test-cluster.sh //java/test/behaviour/...` instead of multiple tests (cannot do Clustered migration now)
         source tool/test/start-cluster-servers.sh 3 &&
-          .factory/test-cluster.sh //java/test/behaviour/connection/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cluster.sh //java/test/behaviour/driver/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cluster.sh //java/test/behaviour/driver/connection/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cluster.sh //java/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cluster.sh //java/test/behaviour/driver/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cluster.sh //java/test/behaviour/driver/cluster/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cluster.sh //java/test/behaviour/connection/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
+          .factory/test-cluster.sh //java/test/behaviour/driver/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
+          .factory/test-cluster.sh //java/test/behaviour/driver/connection/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
+          .factory/test-cluster.sh //java/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
+          .factory/test-cluster.sh //java/test/behaviour/driver/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
+          .factory/test-cluster.sh //java/test/behaviour/driver/cluster/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-cluster-servers.sh
         exit $TEST_SUCCESS
@@ -229,13 +229,13 @@ build:
         bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
 
         tool/test/start-core-server.sh &&
-          bazel test --config=ci //python/tests/integration:all --test_output=streamed --jobs=1 &&
+          bazel test --config=ci //python/tests/integration:all --test_output=streamed &&
           export CORE_FAILED= || export CORE_FAILED=1
         tool/test/stop-core-server.sh
         if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
 
         source tool/test/start-cluster-servers.sh 3 &&
-          bazel test --config=ci //python/tests/integration/cluster:test_failover --test_env=CLUSTER_SERVER_SCRIPT=$CLUSTER_SERVER_SCRIPT --test_env=ROOT_CA=$ROOT_CA --test_env=CLUSTER_DIR=$CLUSTER_DIR --test_output=streamed --jobs=1 &&
+          bazel test --config=ci //python/tests/integration/cluster:test_failover --test_env=CLUSTER_SERVER_SCRIPT=$CLUSTER_SERVER_SCRIPT --test_env=ROOT_CA=$ROOT_CA --test_env=CLUSTER_DIR=$CLUSTER_DIR --test_output=streamed &&
           export CLUSTER_FAILED= || export CLUSTER_FAILED=1
         tool/test/stop-cluster-servers.sh
         if [[ -n "$CLUSTER_FAILED" ]]; then exit 1; fi
@@ -251,7 +251,7 @@ build:
         bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
 
         tool/test/start-core-server.sh &&
-          .factory/test-core.sh //python/tests/behaviour/... --test_output=streamed --jobs=1 &&
+          .factory/test-core.sh //python/tests/behaviour/... --test_output=streamed &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
@@ -268,12 +268,12 @@ build:
 
         # TODO: run `.factory/test-cluster.sh //python/tests/behaviour/...` instead of multiple tests (cannot do Clustered migration now)
         source tool/test/start-cluster-servers.sh 3 &&
-          .factory/test-cluster.sh //python/tests/behaviour/connection/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cluster.sh //python/tests/behaviour/driver/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cluster.sh //python/tests/behaviour/driver/connection/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cluster.sh //python/tests/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cluster.sh //python/tests/behaviour/driver/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cluster.sh //python/tests/behaviour/driver/cluster/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cluster.sh //python/tests/behaviour/connection/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
+          .factory/test-cluster.sh //python/tests/behaviour/driver/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
+          .factory/test-cluster.sh //python/tests/behaviour/driver/connection/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
+          .factory/test-cluster.sh //python/tests/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
+          .factory/test-cluster.sh //python/tests/behaviour/driver/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
+          .factory/test-cluster.sh //python/tests/behaviour/driver/cluster/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-cluster-servers.sh
         exit $TEST_SUCCESS
@@ -291,7 +291,7 @@ build:
         tool/http-ts/install-deps.sh
 
         source tool/test/start-cluster-servers.sh 3 &&
-          bazel test --config=ci //http-ts/tests/integration:cluster-failover --test_env=CLUSTER_SERVER_SCRIPT=$CLUSTER_SERVER_SCRIPT --test_env=ROOT_CA=$ROOT_CA --test_env=CLUSTER_DIR=$CLUSTER_DIR --test_output=streamed --jobs=1 &&
+          bazel test --config=ci //http-ts/tests/integration:cluster-failover --test_env=CLUSTER_SERVER_SCRIPT=$CLUSTER_SERVER_SCRIPT --test_env=ROOT_CA=$ROOT_CA --test_env=CLUSTER_DIR=$CLUSTER_DIR --test_output=streamed &&
           export CLUSTER_FAILED= || export CLUSTER_FAILED=1
         tool/test/stop-cluster-servers.sh
         if [[ -n "$CLUSTER_FAILED" ]]; then exit 1; fi
@@ -309,7 +309,7 @@ build:
         tool/http-ts/install-deps.sh
 
         tool/test/start-core-server.sh &&
-          .factory/test-core.sh //http-ts/tests/behaviour/... --test_output=streamed --jobs=1 &&
+          .factory/test-core.sh //http-ts/tests/behaviour/... --test_output=streamed &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
@@ -327,11 +327,11 @@ build:
         tool/http-ts/install-deps.sh
 
         source tool/test/start-cluster-servers.sh 3 &&
-          .factory/test-cluster.sh //http-ts/tests/behaviour/feature:concept-cluster --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cluster.sh //http-ts/tests/behaviour/feature:query-cluster --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cluster.sh //http-ts/tests/behaviour/feature:user-cluster --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cluster.sh //http-ts/tests/behaviour/feature:connection-cluster --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cluster.sh //http-ts/tests/behaviour/feature:cluster-cluster --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cluster.sh //http-ts/tests/behaviour/feature:concept-cluster --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
+          .factory/test-cluster.sh //http-ts/tests/behaviour/feature:query-cluster --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
+          .factory/test-cluster.sh //http-ts/tests/behaviour/feature:user-cluster --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
+          .factory/test-cluster.sh //http-ts/tests/behaviour/feature:connection-cluster --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
+          .factory/test-cluster.sh //http-ts/tests/behaviour/feature:cluster-cluster --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-cluster-servers.sh
         exit $TEST_SUCCESS
@@ -346,14 +346,14 @@ build:
         bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
 
         tool/test/start-core-server.sh &&
-          bazel test --config=ci //csharp/Test/Integration:all --test_output=streamed --jobs=1 &&
-          bazel test --config=ci //csharp/Test/Integration/Data:all --test_output=streamed --jobs=1 &&
+          bazel test --config=ci //csharp/Test/Integration:all --test_output=streamed &&
+          bazel test --config=ci //csharp/Test/Integration/Data:all --test_output=streamed &&
           export CORE_FAILED= || export CORE_FAILED=1
         tool/test/stop-core-server.sh
         if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
 
         source tool/test/start-cluster-servers.sh 3 &&
-          bazel test --config=ci //csharp/Test/Integration/Cluster:test-failover --test_env=CLUSTER_SERVER_SCRIPT=$CLUSTER_SERVER_SCRIPT --test_env=ROOT_CA=$ROOT_CA --test_env=CLUSTER_DIR=$CLUSTER_DIR --test_output=streamed --jobs=1 &&
+          bazel test --config=ci //csharp/Test/Integration/Cluster:test-failover --test_env=CLUSTER_SERVER_SCRIPT=$CLUSTER_SERVER_SCRIPT --test_env=ROOT_CA=$ROOT_CA --test_env=CLUSTER_DIR=$CLUSTER_DIR --test_output=streamed &&
           export CLUSTER_FAILED= || export CLUSTER_FAILED=1
         tool/test/stop-cluster-servers.sh
         if [[ -n "$CLUSTER_FAILED" ]]; then exit 1; fi
@@ -368,7 +368,7 @@ build:
         bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
 
         tool/test/start-core-server.sh &&
-          .factory/test-core.sh //csharp/Test/Behaviour/... --test_output=streamed --jobs=1 &&
+          .factory/test-core.sh //csharp/Test/Behaviour/... --test_output=streamed &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
@@ -384,13 +384,13 @@ build:
 
         # TODO: run `.factory/test-cluster.sh //csharp/Test/Behaviour/...` instead of multiple tests (cannot do Clustered migration now)
         source tool/test/start-cluster-servers.sh 3 &&
-          .factory/test-cluster.sh //csharp/Test/Behaviour/Connection/Database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cluster.sh //csharp/Test/Behaviour/Connection/Transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cluster.sh //csharp/Test/Behaviour/Driver/Concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cluster.sh //csharp/Test/Behaviour/Driver/Connection/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cluster.sh //csharp/Test/Behaviour/Driver/Query/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cluster.sh //csharp/Test/Behaviour/Driver/User/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cluster.sh //csharp/Test/Behaviour/Driver/Cluster/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cluster.sh //csharp/Test/Behaviour/Connection/Database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
+          .factory/test-cluster.sh //csharp/Test/Behaviour/Connection/Transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
+          .factory/test-cluster.sh //csharp/Test/Behaviour/Driver/Concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
+          .factory/test-cluster.sh //csharp/Test/Behaviour/Driver/Connection/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
+          .factory/test-cluster.sh //csharp/Test/Behaviour/Driver/Query/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
+          .factory/test-cluster.sh //csharp/Test/Behaviour/Driver/User/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
+          .factory/test-cluster.sh //csharp/Test/Behaviour/Driver/Cluster/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-cluster-servers.sh
         exit $TEST_SUCCESS

--- a/csharp/Test/rules.bzl
+++ b/csharp/Test/rules.bzl
@@ -62,6 +62,7 @@ def csharp_behaviour_test(
         target_frameworks,
         targeting_packs,
         add_certificates = False,
+        tags = [],
         **kwargs):
     certificates = ["//tool/test/resources:certificates"] if add_certificates else []
 
@@ -78,11 +79,12 @@ def csharp_behaviour_test(
         runtime_identifier = "any",
         nullable = nullable_context,
         visibility = ["//visibility:public"],
+        tags = tags + ["exclusive"],
         **kwargs,
     )
 
 
-def csharp_integration_test(name, srcs, deps, target_frameworks, targeting_packs, **kwargs):
+def csharp_integration_test(name, srcs, deps, target_frameworks, targeting_packs, tags = [], **kwargs):
     csharp_nunit_test(
         name = name,
         srcs = srcs,
@@ -92,5 +94,6 @@ def csharp_integration_test(name, srcs, deps, target_frameworks, targeting_packs
         runtime_identifier = "any",
         nullable = nullable_context,
         visibility = ["//visibility:public"],
+        tags = tags + ["exclusive"],
         **kwargs,
     )

--- a/http-ts/tests/behaviour/rules.bzl
+++ b/http-ts/tests/behaviour/rules.bzl
@@ -34,7 +34,7 @@ def typedb_behaviour_http_ts_test(name, **kwargs):
     typedb_behaviour_http_ts_core_test(name, **kwargs)
     typedb_behaviour_http_ts_cluster_test(name, **kwargs)
 
-def typedb_behaviour_http_ts_core_test(name, features, data = [], **kwargs):
+def typedb_behaviour_http_ts_core_test(name, features, data = [], tags = [], **kwargs):
     cucumber_bin.cucumber_js_test(
         name = name + "-core",
         data = [
@@ -46,10 +46,11 @@ def typedb_behaviour_http_ts_core_test(name, features, data = [], **kwargs):
             "--tags 'not @ignore and not @ignore-typedb-driver and not @ignore-typedb-driver-nodejs and not @ignore-typedb-http'",
             "--require", "http-ts/tests/**/*.js",
         ] + ["$(location {})".format(feature) for feature in features],
+        tags = tags + ["exclusive"],
         **kwargs,
     )
 
-def typedb_behaviour_http_ts_cluster_test(name, features, data = [], **kwargs):
+def typedb_behaviour_http_ts_cluster_test(name, features, data = [], tags = [], **kwargs):
     cucumber_bin.cucumber_js_test(
         name = name + "-cluster",
         data = [
@@ -65,5 +66,6 @@ def typedb_behaviour_http_ts_cluster_test(name, features, data = [], **kwargs):
         env = {
             "TYPEDB_CLUSTER_MODE": "true",
         },
+        tags = tags + ["exclusive"],
         **kwargs,
     )

--- a/http-ts/tests/integration/BUILD
+++ b/http-ts/tests/integration/BUILD
@@ -51,6 +51,7 @@ js_test(
     },
     size = "large",
     local = True,  # Test manages external server processes via CLUSTER_DIR
+    tags = ["exclusive"],
 )
 
 checkstyle_test(

--- a/java/test/behaviour/rules.bzl
+++ b/java/test/behaviour/rules.bzl
@@ -37,16 +37,18 @@ def typedb_behaviour_java_test(
         **kwargs
     )
 
-def typedb_behaviour_java_test_core(name, steps, runtime_deps = [], **kwargs):
+def typedb_behaviour_java_test_core(name, steps, runtime_deps = [], tags = [], **kwargs):
     typedb_java_test(
         name = name + "-core",
         runtime_deps = runtime_deps + ["//java/test/behaviour/connection:steps-core"] + steps,
+        tags = tags + ["exclusive"],
         **kwargs,
     )
 
-def typedb_behaviour_java_test_cluster(name, steps, runtime_deps = [], **kwargs):
+def typedb_behaviour_java_test_cluster(name, steps, runtime_deps = [], tags = [], **kwargs):
     typedb_java_test(
         name = name + "-cluster",
         runtime_deps = runtime_deps + ["//java/test/behaviour/connection:steps-cluster"] + steps,
+        tags = tags + ["exclusive"],
         **kwargs,
     )

--- a/java/test/integration/BUILD
+++ b/java/test/integration/BUILD
@@ -37,6 +37,7 @@ typedb_java_test(
         "@typedb_maven//:org_slf4j_slf4j_api",
 #        "@typedb_maven//:com_typedb_typedb_runner",
     ],
+    tags = ["exclusive"],
 )
 
 typedb_java_test(
@@ -53,6 +54,7 @@ typedb_java_test(
         "@typedb_maven//:org_slf4j_slf4j_api",
 #        "@typedb_maven//:com_typedb_typedb_runner",
     ],
+    tags = ["exclusive"],
 )
 
 typedb_java_test(
@@ -69,6 +71,7 @@ typedb_java_test(
         "@typedb_maven//:org_slf4j_slf4j_api",
 #        "@typedb_maven//:com_typedb_typedb_runner",
     ],
+    tags = ["exclusive"],
 )
 
 checkstyle_test(

--- a/java/test/integration/cluster/BUILD
+++ b/java/test/integration/cluster/BUILD
@@ -45,7 +45,7 @@ typedb_java_test(
     # data directories under $CLUSTER_DIR (the outer workspace). The Bazel sandbox
     # blocks writes to those paths, so this test must run unsandboxed and locally,
     # and it relies on host-level state so cached results would be misleading.
-    tags = ["external", "no-cache", "no-sandbox"],
+    tags = ["external", "no-cache", "no-sandbox", "exclusive"],
 )
 
 checkstyle_test(

--- a/python/tests/behaviour/behave_rule.bzl
+++ b/python/tests/behaviour/behave_rule.bzl
@@ -18,7 +18,7 @@
 load("@typedb_driver_pip//:requirements.bzl", "requirement")
 
 
-def py_behave_test(*, name, background, steps, feats, deps, data=[], typedb_port, **kwargs):
+def py_behave_test(*, name, background, steps, feats, deps, data=[], typedb_port, tags=[], **kwargs):
     prepare_py_behave_directory(
         name = name + "_features",
         background = background,
@@ -32,6 +32,7 @@ def py_behave_test(*, name, background, steps, feats, deps, data=[], typedb_port
         srcs = ["//python/tests/behaviour:entry_point_behave.py"],
         args = ["$(location :" + name + "_features)", "--no-capture", "-D", "port=" + typedb_port],
         main = "//python/tests/behaviour:entry_point_behave.py",
+        tags = tags + ["exclusive"],
         **kwargs,
     )
 

--- a/python/tests/integration/BUILD
+++ b/python/tests/integration/BUILD
@@ -32,7 +32,8 @@ py_test(
         requirement("PyHamcrest"),
     ],
     data = ["//python:native-driver-binary-link", "//python:native-driver-wrapper-link"],
-    python_version = "PY3"
+    python_version = "PY3",
+    tags = ["exclusive"],
 )
 
 py_test(
@@ -43,7 +44,8 @@ py_test(
         requirement("PyHamcrest"),
     ],
     data = ["//python:native-driver-binary-link", "//python:native-driver-wrapper-link"],
-    python_version = "PY3"
+    python_version = "PY3",
+    tags = ["exclusive"],
 )
 
 py_test(
@@ -55,7 +57,8 @@ py_test(
         "@rules_python//python/cc:current_py_cc_libs",
     ],
     data = ["//python:native-driver-binary-link", "//python:native-driver-wrapper-link"],
-    python_version = "PY3"
+    python_version = "PY3",
+    tags = ["exclusive"],
 )
 
 py_test(
@@ -65,7 +68,8 @@ py_test(
         "//python:driver_python",
     ],
     data = ["//python:native-driver-binary-link", "//python:native-driver-wrapper-link"],
-    python_version = "PY3"
+    python_version = "PY3",
+    tags = ["exclusive"],
 )
 
 checkstyle_test(

--- a/python/tests/integration/cluster/BUILD
+++ b/python/tests/integration/cluster/BUILD
@@ -40,7 +40,7 @@ py_test(
     # data directories under $CLUSTER_DIR (the outer workspace). The Bazel sandbox
     # blocks writes to those paths, so this test must run unsandboxed and locally,
     # and it relies on host-level state so cached results would be misleading.
-    tags = ["external", "no-cache", "no-sandbox"],
+    tags = ["external", "no-cache", "no-sandbox", "exclusive"],
     size = "large",
 )
 

--- a/rust/tests/behaviour/rules.bzl
+++ b/rust/tests/behaviour/rules.bzl
@@ -27,12 +27,13 @@ behaviour_test_deps = [
     "@crates//:serial_test",
 ];
 
-def rust_behaviour_test(name, srcs, data, deps=[], crate_features=[], **kwargs):
+def rust_behaviour_test(name, srcs, data, deps=[], crate_features=[], tags=[], **kwargs):
     rust_test(
         name = name,
         srcs = srcs,
         data = data,
         deps = behaviour_test_deps + deps,
         crate_features = crate_features_common + crate_features,
+        tags = tags + ["exclusive"],
         **kwargs,
     )


### PR DESCRIPTION

## Usage and product changes
Replace the CI Bazel `--jobs=1` flag to ensure jobs aren't running in parallel and clashing for resources with the `exclusive` bazel tag.

Note that the `exclusive` flag allows parallel builds but blocks parallel test phase execution. In addition, if we ever add it, it prevents remote execution.

## Implementation
All integration and behaviour tests run against a single shared TypeDB server (started out-of-band by tool/test/start-core-server.sh / start-cluster-servers.sh), so two test targets cannot run concurrently. CI worked around this by passing --jobs=1 on every test command, which serializes the *entire* Bazel invocation.

Tag the test targets with `exclusive` instead, which serializes them against each other at the Bazel level while letting the build (and other, non-exclusive tests) parallelize. --jobs=1 is then removed from every test command in .factory/automation.yml (the //csharp/... `bazel build --jobs=1` is left as-is: it works around a C# build mutex, not test concurrency).

Behaviour tests are tagged via their shared macros (both -core and -cluster variants are covered):
  - rust/tests/behaviour/rules.bzl
  - java/test/behaviour/rules.bzl
  - python/tests/behaviour/behave_rule.bzl
  - csharp/Test/rules.bzl (csharp_behaviour_test)
  - http-ts/tests/behaviour/rules.bzl Integration tests are tagged per-target (java, python, http-ts) or via the csharp_integration_test macro (csharp); the cluster failover targets keep their existing external/no-cache/no-sandbox tags.
