### PR TITLE
Fix address sanitizer errors in C integration tests

### DIFF
--- a/c/tests/integration/test_driver.c
+++ b/c/tests/integration/test_driver.c
@@ -151,7 +151,7 @@ bool test_query_schema() {
     success = true;
 
 cleanup:
-    if (NULL != transaction) transaction_close(transaction);
+    if (NULL != transaction) transaction_drop_sync(transaction);
     transaction_options_drop(tx_opts);
     query_options_drop(query_opts);
 
@@ -257,7 +257,7 @@ bool test_query_data() {
     success = true;
 
 cleanup:
-    if (NULL != transaction) transaction_close(transaction);
+    if (NULL != transaction) transaction_drop_sync(transaction);
     transaction_options_drop(tx_opts);
     query_options_drop(query_opts);
 


### PR DESCRIPTION
## Usage and product changes
Use proper transaction cleanup functions in the C integration tests to avoid address sanitizer errors in CI.

## Implementation
`test_driver.c` uses `transaction_close(transaction)` and discard the returned `VoidPromise*`. Looking at the FFI:                                                                                                                     
  
```                                                                                                                       
pub extern "C" fn transaction_close(txn: *mut Transaction) -> *mut VoidPromise {                                         
    release(VoidPromise(Box::new(borrow_mut(txn).close())))                                                              
}    
```                                                                                                                    
                                                                
It only borrows the transaction — it does not free it. So:
1. The `VoidPromise` (a `Box`) is leaked.                                                                                    
2. The `Transaction` (also a `Box`) is leaked — nothing frees it.
3. The close future is never polled, so the close gRPC call never happens.                                               
                                                                          
The leaked `Transaction` owns a `TransactionStream` -> `TransactionTransmitter` which holds an `Arc<BackgroundRuntime>`. So when `driver_close()` drops its `Arc<BackgroundRuntime>`, the refcount stays > 0, the `BackgroundRuntime::Drop` impl never runs, the shutdown signal is never sent, and the gRPC worker + callback handler threads keep running. 

The C-based drivers handle `transaction_close` correctly and don't require any changes, because SWIG's `%dropproxy(Transaction, transaction)` combined with `transaction_drop transaction_drop_sync` generates a destructor that calls `transaction_drop_sync` automatically.