### PR TITLE
Fix transaction on_close callback panic

### DIFF
--- a/rust/src/connection/network/transmitter/transaction.rs
+++ b/rust/src/connection/network/transmitter/transaction.rs
@@ -168,7 +168,6 @@ impl TransactionTransmitter {
         box_promise(async move {
             let (sender, mut sink) = unbounded_async();
             self.on_close_register_sink.send((Box::new(callback), sender)).ok();
-            // A closed channel means the listener already stopped: the transaction is closed.
             let _ = sink.recv().await;
             Ok(())
         })
@@ -182,7 +181,6 @@ impl TransactionTransmitter {
         box_promise(move || {
             let (sender, mut sink) = unbounded_async();
             self.on_close_register_sink.send((Box::new(callback), sender)).ok();
-            // A closed channel means the listener already stopped: the transaction is closed.
             let _ = sink.blocking_recv();
             Ok(())
         })

--- a/rust/src/connection/network/transmitter/transaction.rs
+++ b/rust/src/connection/network/transmitter/transaction.rs
@@ -119,7 +119,7 @@ impl TransactionTransmitter {
             if self.background_runtime.is_open() && self.is_open.compare_exchange(true, false).is_ok() {
                 let (closed_sink, mut closed_source) = unbounded_async();
                 let close_notifier_callback = Box::new(move |_error| {
-                    closed_sink.send(()).unwrap();
+                    closed_sink.send(()).ok();
                 });
                 let on_close_submit_promise = self.on_close(close_notifier_callback);
                 let _ = resolve!(on_close_submit_promise);
@@ -139,7 +139,7 @@ impl TransactionTransmitter {
             if self.background_runtime.is_open() && self.is_open.compare_exchange(true, false).is_ok() {
                 let (closed_sink, closed_source) = oneshot();
                 let close_notifier_callback = Box::new(move |_error| {
-                    closed_sink.send(()).unwrap();
+                    closed_sink.send(()).ok();
                 });
                 let _ = resolve!(self.on_close(close_notifier_callback));
                 *self.error.write().unwrap() = Some(ConnectionError::TransactionIsClosed.into());
@@ -168,7 +168,8 @@ impl TransactionTransmitter {
         box_promise(async move {
             let (sender, mut sink) = unbounded_async();
             self.on_close_register_sink.send((Box::new(callback), sender)).ok();
-            sink.recv().await.expect("Did not receive on_close registration success signal");
+            // A closed channel means the listener already stopped: the transaction is closed.
+            let _ = sink.recv().await;
             Ok(())
         })
     }
@@ -181,7 +182,8 @@ impl TransactionTransmitter {
         box_promise(move || {
             let (sender, mut sink) = unbounded_async();
             self.on_close_register_sink.send((Box::new(callback), sender)).ok();
-            sink.blocking_recv().expect("Did not receive on_close registration success signal");
+            // A closed channel means the listener already stopped: the transaction is closed.
+            let _ = sink.blocking_recv();
             Ok(())
         })
     }
@@ -367,7 +369,8 @@ impl TransactionTransmitter {
                 callback_option = on_close_callback_source.recv() => {
                     if let Some((callback, recorded_signal)) = callback_option {
                         collector.on_close.write().unwrap().push(callback);
-                        recorded_signal.send(()).expect("Failed to signal back that on_close callback was recorded.")
+                        // Best-effort: the registrant may have stopped waiting (e.g. a cancelled close()).
+                        recorded_signal.send(()).ok();
                     }
                 }
             };

--- a/rust/tests/integration/driver.rs
+++ b/rust/tests/integration/driver.rs
@@ -76,3 +76,29 @@ fn transaction_on_close_callback() {
         assert!(close_called.load(Ordering::SeqCst))
     })
 }
+
+// on_close (or a second close) after the transaction has already closed must not panic: the
+// registration can no longer be acknowledged, which previously aborted the process via `expect`.
+#[test]
+#[serial]
+fn transaction_on_close_after_close_does_not_panic() {
+    async_std::task::block_on(async {
+        cleanup().await;
+        let driver = TypeDBDriver::new(
+            Addresses::try_from_address_str(TypeDBDriver::DEFAULT_ADDRESS).unwrap(),
+            Credentials::new("admin", "password"),
+            DriverOptions::new(DriverTlsConfig::disabled()),
+        )
+        .await
+        .unwrap();
+
+        driver.databases().create("typedb").await.unwrap();
+        let database = driver.databases().get("typedb").await.unwrap();
+
+        let transaction = driver.transaction(database.name(), TransactionType::Read).await.unwrap();
+        transaction.close().await.unwrap();
+
+        transaction.on_close(Box::new(|_| {})).await.unwrap();
+        transaction.close().await.unwrap();
+    })
+}

--- a/rust/tests/integration/driver.rs
+++ b/rust/tests/integration/driver.rs
@@ -77,8 +77,7 @@ fn transaction_on_close_callback() {
     })
 }
 
-// on_close (or a second close) after the transaction has already closed must not panic: the
-// registration can no longer be acknowledged, which previously aborted the process via `expect`.
+// on_close (or a second close) after the transaction has already closed must not panic
 #[test]
 #[serial]
 fn transaction_on_close_after_close_does_not_panic() {


### PR DESCRIPTION
## Usage and product changes

A race between on_close and transaction teardown could cause the driver to panic and crash the user's application. We fix this by assuming an error from the register/acknowledgement channel means 'transaction already closed' instead of panicking. 

## Implementation

Don't abort the process when on_close races transaction teardown. A transaction close racing the teardown of its gRPC stream could abort the host process. Transaction::close() registers an on_close notifier and blocks on an acknowledgement from the transaction's background listener; if that listener had already stopped (because the stream was torn down — e.g. the server killing the transaction when its timeout expires), the acknowledgement never arrived and on_close() panicked via `expect`. The panic cannot unwind across the FFI boundary, so the whole host process (e.g. a JVM using the Java driver) aborted with SIGABRT instead of close() returning normally.

on_close (sync + async) now treats a closed registration/acknowledgement channel as "the transaction is already closed" and returns Ok. The callback is dropped un-invoked, matching close()/close_with_error(), which only run callbacks recorded before teardown. The two sibling unwrap()/expect() calls on the same teardown path — the listener's acknowledgement (recorded_signal.send) and close()'s notifier (closed_sink.send) — are likewise made best-effort, so a peer that has legitimately gone away (e.g. a cancelled close()) no longer panics.

Added an integration regression test that registers on_close and closes again after the transaction has already closed; it aborted the process before this change and passes after it.