### PR TITLE
Fix string marshalling over JNI

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -73,7 +73,7 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "1fc96034c69924aebdd40648429508ead1cf2f3f",
+    commit = "cad3c7b5b0475b3fe9bba81c0c425df6dcdf5b6a",
 )
 
 # Rust rules need typedb_dependencies for patching

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -73,7 +73,7 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "cad3c7b5b0475b3fe9bba81c0c425df6dcdf5b6a",
+    commit = "0a0e2dee11cef1f8e15a97e1428fb9d0c79c4225",
 )
 
 # Rust rules need typedb_dependencies for patching

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -73,7 +73,7 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "86d85293478196eac21ef4bc46b507f9d6918230",
+    commit = "ba391df36199957a39c02bb47aeda4c5e9410959",
 )
 
 # Rust rules need typedb_dependencies for patching

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -73,7 +73,7 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "cd585f09c61381a31dc19c2e129cbf40d36acc3d",
+    commit = "1fc96034c69924aebdd40648429508ead1cf2f3f",
 )
 
 # Rust rules need typedb_dependencies for patching

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -73,7 +73,7 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "ba391df36199957a39c02bb47aeda4c5e9410959",
+    commit = "73fd23e2c1ae15f3c4be35bbc7884598319ea892",
 )
 
 # Rust rules need typedb_dependencies for patching

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -73,7 +73,7 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "0a0e2dee11cef1f8e15a97e1428fb9d0c79c4225",
+    commit = "86d85293478196eac21ef4bc46b507f9d6918230",
 )
 
 # Rust rules need typedb_dependencies for patching

--- a/c/src/common/memory.rs
+++ b/c/src/common/memory.rs
@@ -19,7 +19,7 @@
 
 use std::{
     cell::RefCell,
-    ffi::{c_char, CStr, CString},
+    ffi::{CStr, CString, c_char},
     ptr::null_mut,
     sync::Arc,
 };

--- a/c/src/common/memory.rs
+++ b/c/src/common/memory.rs
@@ -19,7 +19,7 @@
 
 use std::{
     cell::RefCell,
-    ffi::{CStr, CString, c_char},
+    ffi::{c_char, CStr, CString},
     ptr::null_mut,
     sync::Arc,
 };
@@ -96,7 +96,10 @@ pub(crate) fn free<T>(raw: *mut T) {
 
 pub(crate) fn string_view(str: *const c_char) -> &'static str {
     assert!(!str.is_null());
-    unsafe { CStr::from_ptr(str).to_str().unwrap() }
+    unsafe {
+        let cstr = CStr::from_ptr(str);
+        cstr.to_str().unwrap_or_else(|e| panic!("Could not parse {cstr:?}: {e}"))
+    }
 }
 
 /// Frees a native rust string.

--- a/c/swig/typedb_driver_java.swg
+++ b/c/swig/typedb_driver_java.swg
@@ -650,7 +650,7 @@
     jenv->ReleaseByteArrayElements($input, bae, 0);
 }
 
-%typemap(freearg) char* { free($1) }
+%typemap(freearg) char* { free($1); }
 
 %typemap(out) char* {
     if ($1) {

--- a/c/swig/typedb_driver_java.swg
+++ b/c/swig/typedb_driver_java.swg
@@ -636,9 +636,11 @@
 %typemap(jni) char* "jbyteArray"
 %typemap(jtype) char* "byte[]"
 %typemap(jstype) char* "String"
+
 %typemap(javain) char* %{
     $javainput.getBytes(java.nio.charset.Charset.forName("UTF-8"))
 %}
+
 %typemap(in) char* {
     size_t sz = jenv->GetArrayLength($input);
     $1 = (char*)malloc(sz + 1);
@@ -647,6 +649,7 @@
     $1[sz] = 0;
     jenv->ReleaseByteArrayElements($input, bae, 0);
 }
+
 %typemap(out) char* {
     if ($1) {
         size_t sz = strlen($1);
@@ -658,6 +661,7 @@
         $result = 0;
     }
 }
+
 %typemap(javaout) char* {
     byte[] ba = $jnicall;
     if (ba == null) {
@@ -665,6 +669,7 @@
     }
     return new String(ba, java.nio.charset.Charset.forName("UTF-8"));
 }
+
 %typemap(freearg) char* {
     if ($1) jenv->ReleaseByteArrayElements($input, (jbyte*)$1, 0);
 }

--- a/c/swig/typedb_driver_java.swg
+++ b/c/swig/typedb_driver_java.swg
@@ -675,6 +675,14 @@
 }
 
 /* char** needs special handling */
+%typemap(jni) char ** "jobjectArray"
+%typemap(jtype) char ** "byte[][]"
+%typemap(jstype) char ** "String[]"
+
+%typemap(javain) char ** %{
+    java.util.stream.Stream.of($javainput).map(s -> s.getBytes(java.nio.charset.Charset.forName("UTF-8"))).toArray(byte[][]::new)
+%}
+
 %typemap(in) char ** (jint size) {
     int i = 0;
     size = jenv->GetArrayLength($input);
@@ -698,11 +706,3 @@
     free($1);
 }
 
-%typemap(jni) char ** "jobjectArray"
-%typemap(jtype) char ** "String[]"
-%typemap(jstype) char ** "String[]"
-
-%typemap(javain) char ** "$javainput"
-%typemap(javaout) char ** {
-    return $jnicall;
-}

--- a/c/swig/typedb_driver_java.swg
+++ b/c/swig/typedb_driver_java.swg
@@ -678,7 +678,7 @@
         const char * c_string = (char*)jenv->GetByteArrayElements(j_string, 0);
         $1[i] = (char*)malloc((strlen(c_string)+1)*sizeof(char));
         strcpy($1[i], c_string);
-        // jenv->ReleaseStringUTFChars(j_string, c_string);
+        jenv->ReleaseByteArrayElements(j_string, (jbyte*)c_string, 0);
         jenv->DeleteLocalRef(j_string);
     }
     $1[i] = 0;

--- a/c/swig/typedb_driver_java.swg
+++ b/c/swig/typedb_driver_java.swg
@@ -46,7 +46,11 @@
     protected transient boolean swigCMemOwn;
 
     protected $javaclassname(long cPtr, boolean cMemoryOwn) {
-        super((typedb_driverJNI.error_code(cPtr, null) + " " + typedb_driverJNI.error_message(cPtr, null)).strip());
+        super((
+            new String(typedb_driverJNI.error_code(cPtr, null), java.nio.charset.Charset.forName("UTF-8"))
+            + " "
+            + new String(typedb_driverJNI.error_message(cPtr, null), java.nio.charset.Charset.forName("UTF-8"))
+        ).strip());
         swigCMemOwn = cMemoryOwn;
         swigCPtr = cPtr;
     }
@@ -626,6 +630,41 @@
 }
 %enddef
 
+%typemap(jni) char* "jbyteArray"
+%typemap(jtype) char* "byte[]"
+%typemap(jstype) char* "String"
+%typemap(javain) char* %{
+    $javainput.getBytes(java.nio.charset.Charset.forName("UTF-8"))
+%}
+%typemap(in) char* {
+    size_t sz = jenv->GetArrayLength($input);
+    $1 = (char*)malloc(sz + 1);
+    jbyte* bae = jenv->GetByteArrayElements($input, 0);
+    memcpy($1, (const char*)bae, sz);
+    jenv->ReleaseByteArrayElements($input, bae, 0);
+}
+%typemap(out) char* {
+    if ($1) {
+        size_t sz = strlen($1);
+        $result = jenv->NewByteArray(sz);
+        jbyte* bae = jenv->GetByteArrayElements($result, 0);
+        memcpy((char*)bae, $1, sz);
+        jenv->ReleaseByteArrayElements($result, bae, 0);
+    } else {
+        $result = 0;
+    }
+}
+%typemap(javaout) char* {
+    byte[] ba = $jnicall;
+    if (ba == null) {
+        return null;
+    }
+    return new String(ba, java.nio.charset.Charset.forName("UTF-8"));
+}
+%typemap(freearg) char* {
+    if ($1) jenv->ReleaseByteArrayElements($input, (jbyte*)$1, 0);
+}
+
 %array(Concept)
 
 /* char** needs special handling */
@@ -635,11 +674,11 @@
     $1 = (char **) malloc((size+1)*sizeof(char *));
     /* make a copy of each string */
     for (i = 0; i<size; i++) {
-        jstring j_string = (jstring)jenv->GetObjectArrayElement($input, i);
-        const char * c_string = jenv->GetStringUTFChars(j_string, 0);
+        jbyteArray j_string = (jbyteArray)jenv->GetObjectArrayElement($input, i);
+        const char * c_string = (char*)jenv->GetByteArrayElements(j_string, 0);
         $1[i] = (char*)malloc((strlen(c_string)+1)*sizeof(char));
         strcpy($1[i], c_string);
-        jenv->ReleaseStringUTFChars(j_string, c_string);
+        // jenv->ReleaseStringUTFChars(j_string, c_string);
         jenv->DeleteLocalRef(j_string);
     }
     $1[i] = 0;

--- a/c/swig/typedb_driver_java.swg
+++ b/c/swig/typedb_driver_java.swg
@@ -630,6 +630,9 @@
 }
 %enddef
 
+%array(Concept)
+
+/* Strings: reencode as UTF-8 byte arrays rather than use Java's MUTF-8 */
 %typemap(jni) char* "jbyteArray"
 %typemap(jtype) char* "byte[]"
 %typemap(jstype) char* "String"
@@ -665,8 +668,6 @@
 %typemap(freearg) char* {
     if ($1) jenv->ReleaseByteArrayElements($input, (jbyte*)$1, 0);
 }
-
-%array(Concept)
 
 /* char** needs special handling */
 %typemap(in) char ** (jint size) {

--- a/c/swig/typedb_driver_java.swg
+++ b/c/swig/typedb_driver_java.swg
@@ -690,9 +690,11 @@
     /* make a copy of each string */
     for (i = 0; i<size; i++) {
         jbyteArray j_string = (jbyteArray)jenv->GetObjectArrayElement($input, i);
+        size_t sz = jenv->GetArrayLength(j_string);
         const char * c_string = (char*)jenv->GetByteArrayElements(j_string, 0);
-        $1[i] = (char*)malloc((strlen(c_string)+1)*sizeof(char));
-        strcpy($1[i], c_string);
+        $1[i] = (char*)malloc((sz + 1)*sizeof(char));
+        memcpy($1[i], c_string, sz);
+        $1[i][sz] = 0;
         jenv->ReleaseByteArrayElements(j_string, (jbyte*)c_string, 0);
         jenv->DeleteLocalRef(j_string);
     }

--- a/c/swig/typedb_driver_java.swg
+++ b/c/swig/typedb_driver_java.swg
@@ -641,6 +641,7 @@
     $1 = (char*)malloc(sz + 1);
     jbyte* bae = jenv->GetByteArrayElements($input, 0);
     memcpy($1, (const char*)bae, sz);
+    $1[sz] = 0;
     jenv->ReleaseByteArrayElements($input, bae, 0);
 }
 %typemap(out) char* {

--- a/c/swig/typedb_driver_java.swg
+++ b/c/swig/typedb_driver_java.swg
@@ -650,6 +650,8 @@
     jenv->ReleaseByteArrayElements($input, bae, 0);
 }
 
+%typemap(freearg) char* { free($1) }
+
 %typemap(out) char* {
     if ($1) {
         size_t sz = strlen($1);
@@ -668,10 +670,6 @@
         return null;
     }
     return new String(ba, java.nio.charset.Charset.forName("UTF-8"));
-}
-
-%typemap(freearg) char* {
-    if ($1) jenv->ReleaseByteArrayElements($input, (jbyte*)$1, 0);
 }
 
 /* char** needs special handling */


### PR DESCRIPTION
## Usage and product changes

We forcibly re-encode Java strings from MUTF-8 (modified UTF-8 that uses surrogate characters for code points starting at U+10000) to UTF-8 before passing them over JNI.

## Implementation

Resolves #699 