### PR TITLE
Update the test script for the latest cluster setup

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -73,7 +73,7 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "73fd23e2c1ae15f3c4be35bbc7884598319ea892",
+    commit = "d668fb0c6d42f3fa22e3c6bd8be34369c268553d",
 )
 
 # Rust rules need typedb_dependencies for patching
@@ -255,14 +255,14 @@ native_artifact_files.artifact(
     name = "typedb_artifact",
     group_name = "typedb-all-{platform}",
     artifact_name = "typedb-all-{platform}-{version}.{ext}",
-    commit = "6fcf3bc075b3e19e1293edd3a878db22ced710c9",
+    commit = "86ca4aa944f664bae03cfdfa3367f6253ef97af5",
 )
 # IMPORTANT: must be CLUSTERED typedb-cluster (with multi-node support)!
 native_artifact_files.artifact(
     name = "typedb_cluster_artifact",
     group_name = "typedb-cluster-all-{platform}",
     artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
-    commit = "48f59129a4e9101221ce1d0f23f4fad1fb34b538",
+    commit = "701ecc0cb38e15e4ece022828ebc3c89f5170865",
     private = True,
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -262,7 +262,7 @@ native_artifact_files.artifact(
     name = "typedb_cluster_artifact",
     group_name = "typedb-cluster-all-{platform}",
     artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
-    commit = "701ecc0cb38e15e4ece022828ebc3c89f5170865",
+    commit = "a0c9375298893ee82fabbb0f8ebd6961b51c277a",
     private = True,
 )
 

--- a/tool/test/cluster-server.sh
+++ b/tool/test/cluster-server.sh
@@ -139,11 +139,6 @@ server_start() {
     init_arg="--server.clustering.init=true"
   fi
 
-  # Restrict umask so the admin unix socket is created with mode 0600 (world-r/w
-  # sockets are rejected by the admin tool with [ADM9]). The subshell isolates
-  # the change from anything else in the caller's environment.
-  umask 0077
-
   # Use setsid on Linux to start in a new session (prevents process group cleanup).
   # On macOS, nohup + disown is sufficient.
   local setsid_cmd=""

--- a/tool/test/cluster-server.sh
+++ b/tool/test/cluster-server.sh
@@ -29,6 +29,8 @@
 #   CLUSTER_DIR         - Directory containing numbered node dirs (default: CWD)
 #   ENCRYPTION_ENABLED  - Enable encryption (default: true)
 #   DEPLOYMENT_ID       - Deployment ID for diagnostics (default: test)
+#   INIT                - When 'true', passes --server.clustering.init=true (default: false)
+#                         Only the first node of a fresh cluster should set this.
 #
 # Assumes:
 #   - CWD contains numbered directories (1/, 2/, 3/) with typedb binary
@@ -81,6 +83,7 @@ fi
 
 ENCRYPTION_ENABLED="${ENCRYPTION_ENABLED:-true}"
 DEPLOYMENT_ID="${DEPLOYMENT_ID:-test}"
+INIT="${INIT:-false}"
 POLL_INTERVAL_SECS=0.5
 MAX_RETRIES=60
 
@@ -131,6 +134,16 @@ server_start() {
   # by the outside-sandbox cluster start and the unlink fails with EPERM, even
   # though typedb itself can still truncate-and-write via the existing path.
 
+  local init_arg=""
+  if [ "${INIT}" = "true" ]; then
+    init_arg="--server.clustering.init=true"
+  fi
+
+  # Restrict umask so the admin unix socket is created with mode 0600 (world-r/w
+  # sockets are rejected by the admin tool with [ADM9]). The subshell isolates
+  # the change from anything else in the caller's environment.
+  umask 0077
+
   # Use setsid on Linux to start in a new session (prevents process group cleanup).
   # On macOS, nohup + disown is sufficient.
   local setsid_cmd=""
@@ -160,7 +173,8 @@ server_start() {
     --storage.data-directory="${data_dir}" \
     --storage.clustering-directory="${clustering_dir}" \
     --diagnostics.monitoring.port="${monitoring_port}" \
-    --development-mode.enabled=true > "${log_file}" 2>&1 &
+    --development-mode.enabled=true \
+    ${init_arg} > "${log_file}" 2>&1 &
   disown
 
   echo "Started node ${node_id} (port ${server_port}, log ${log_file})"

--- a/tool/test/cluster-server.sh
+++ b/tool/test/cluster-server.sh
@@ -134,10 +134,7 @@ server_start() {
   # by the outside-sandbox cluster start and the unlink fails with EPERM, even
   # though typedb itself can still truncate-and-write via the existing path.
 
-  local init_arg=""
-  if [ "${INIT}" = "true" ]; then
-    init_arg="--server.clustering.init=true"
-  fi
+  local init_arg="--server.clustering.init=$INIT"
 
   # Use setsid on Linux to start in a new session (prevents process group cleanup).
   # On macOS, nohup + disown is sufficient.

--- a/tool/test/start-cluster-servers.sh
+++ b/tool/test/start-cluster-servers.sh
@@ -29,7 +29,16 @@ ROOT_CA_PATH="$(realpath tool/test/resources/encryption/ext-grpc-root-ca.pem)"
 
 rm -rf $(seq 1 $NODE_COUNT) typedb-cluster-all
 
-bazel run //tool/test:typedb-cluster-extractor -- typedb-cluster-all
+# Local override for development / hermetic testing: if TYPEDB_CLUSTER_TARBALL is set,
+# extract it directly instead of fetching via bazel. Useful when the artifact repo is
+# unavailable or when you want to test a locally-built typedb-cluster tarball.
+if [ -n "${TYPEDB_CLUSTER_TARBALL:-}" ]; then
+  echo "Using local typedb-cluster tarball: ${TYPEDB_CLUSTER_TARBALL}"
+  mkdir -p typedb-cluster-all
+  tar -xzf "${TYPEDB_CLUSTER_TARBALL}" -C typedb-cluster-all --strip-components=1
+else
+  bazel run //tool/test:typedb-cluster-extractor -- typedb-cluster-all
+fi
 
 # Local-binary override (session-only): if TYPEDB_CLUSTER_SERVER_BIN / TYPEDB_CLUSTER_ADMIN_BIN
 # point at executables, replace the bundled binaries before copying to node dirs.
@@ -56,7 +65,13 @@ done
 
 echo Starting a cluster consisting of $NODE_COUNT servers...
 for i in $(seq 1 $NODE_COUNT); do
-  "${CLUSTER_SERVER}" start $i
+  # Only the initial node seeds the cluster with itself as the sole voter;
+  # subsequent nodes are added via `servers register` below.
+  if [ "$i" -eq 1 ]; then
+    INIT=true "${CLUSTER_SERVER}" start $i
+  else
+    INIT=false "${CLUSTER_SERVER}" start $i
+  fi
 done
 
 for i in $(seq 1 $NODE_COUNT); do

--- a/tool/test/start-cluster-servers.sh
+++ b/tool/test/start-cluster-servers.sh
@@ -29,9 +29,6 @@ ROOT_CA_PATH="$(realpath tool/test/resources/encryption/ext-grpc-root-ca.pem)"
 
 rm -rf $(seq 1 $NODE_COUNT) typedb-cluster-all
 
-# Local override for development / hermetic testing: if TYPEDB_CLUSTER_TARBALL is set,
-# extract it directly instead of fetching via bazel. Useful when the artifact repo is
-# unavailable or when you want to test a locally-built typedb-cluster tarball.
 if [ -n "${TYPEDB_CLUSTER_TARBALL:-}" ]; then
   echo "Using local typedb-cluster tarball: ${TYPEDB_CLUSTER_TARBALL}"
   mkdir -p typedb-cluster-all
@@ -65,8 +62,6 @@ done
 
 echo Starting a cluster consisting of $NODE_COUNT servers...
 for i in $(seq 1 $NODE_COUNT); do
-  # Only the initial node seeds the cluster with itself as the sole voter;
-  # subsequent nodes are added via `servers register` below.
   if [ "$i" -eq 1 ]; then
     INIT=true "${CLUSTER_SERVER}" start $i
   else


### PR DESCRIPTION
## Usage and product changes
Upgrade the test infrastructure to support the flag-driver initialization of TypeDB Cluster.

## Implementation
Update server and BDD references to the latest commits.
Include the new `--server.clustering.init=true` flag to allow new clusters initialization when needed for the first test node.