### PR TITLE
Update behaviour for new Given tests

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -73,7 +73,7 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "d668fb0c6d42f3fa22e3c6bd8be34369c268553d",
+    commit = "4b09ab8f7f5fcb27b4926a1707ddd11402502f07",
 )
 
 # Rust rules need typedb_dependencies for patching

--- a/csharp/Test/Behaviour/Query/QuerySteps.cs
+++ b/csharp/Test/Behaviour/Query/QuerySteps.cs
@@ -250,7 +250,7 @@ namespace TypeDB.Driver.Test.Behaviour
 
         [Given(@"set answers of typeql read query as given rows with order: (\$[a-zA-Z0-9\-_]+(?:, \$[a-zA-Z0-9\-_]+)*)")]
         [When(@"set answers of typeql read query as given rows with order: (\$[a-zA-Z0-9\-_]+(?:, \$[a-zA-Z0-9\-_]+)*)")]
-        public void SetAnswersAsGivenRows(string varListStr, DocString query)
+        public void SetAnswersOfTypeqlReadQueryAsGivenRows(string varListStr, DocString query)
         {
             var varList = varListStr.Split(',').Select(v => v.Replace("$", "").Trim()).ToList();
             var tableRows = Tx.Query(query.Content).Resolve()!.AsConceptRows().ToList();
@@ -260,7 +260,7 @@ namespace TypeDB.Driver.Test.Behaviour
 
         [Given(@"set answers of typeql read query as given rows dictionary with variables: (\$[a-zA-Z0-9\-_]+(?:, \$[a-zA-Z0-9\-_]+)*)")]
         [When(@"set answers of typeql read query as given rows dictionary with variables: (\$[a-zA-Z0-9\-_]+(?:, \$[a-zA-Z0-9\-_]+)*)")]
-        public void SetAnswersAsGivenRowsDict(string varListStr, DocString query)
+        public void SetAnswersOfTypeqlReadQueryAsGivenRowsDict(string varListStr, DocString query)
         {
             var varList = varListStr.Split(',').Select(v => v.Replace("$", "").Trim()).ToList();
             var tableRows = Tx.Query(query.Content).Resolve()!.AsConceptRows().ToList();

--- a/http-ts/tests/behaviour/steps/query.ts
+++ b/http-ts/tests/behaviour/steps/query.ts
@@ -77,15 +77,15 @@ function checkConceptKind(concept: Concept, kind: ConceptKind) {
     else return concept.kind === kind;
 }
 
-const setGivenRowsFromAnswer = async (varList: string[], query: string) => {
+const setAnswersOfTypeqlReadQueryAsGivenRows = async (varList: string[], query: string) => {
     const results = await makeQuery(query).then(assertNotError);
     if (results.ok.answerType === "ok" || results.ok.answerType === "conceptDocuments") assert.fail("Expected concept rows");
     const rows = results.ok.answers.map(row => Object.fromEntries(varList.map(v => [v, row.data[v] as GivenRowEntry])));
     setGivenRows(rows);
 };
 
-When('set answers of typeql read query as given rows with order: {variable_list}', setGivenRowsFromAnswer);
-When('set answers of typeql read query as given rows dictionary with variables: {variable_list}', setGivenRowsFromAnswer);
+When('set answers of typeql read query as given rows with order: {variable_list}', setAnswersOfTypeqlReadQueryAsGivenRows);
+When('set answers of typeql read query as given rows dictionary with variables: {variable_list}', setAnswersOfTypeqlReadQueryAsGivenRows);
 
 const runQueryWithGiven = async (mayError: MayError, query: string) => {
     const given = takeGivenRows();

--- a/java/test/behaviour/query/QuerySteps.java
+++ b/java/test/behaviour/query/QuerySteps.java
@@ -876,7 +876,7 @@ public class QuerySteps {
     }
 
     @Given("set answers of typeql read query as given rows dictionary with variables: {variable_list}")
-    public void set_answers_as_given_rows_dict(List<String> varList, String query) {
+    public void set_answers_of_typeql_read_query_as_given_rows_dict(List<String> varList, String query) {
         List<ConceptRow> tableRows = tx().query(query).resolve().asConceptRows().stream().collect(Collectors.toList());
         List<? extends Map<String, ? extends Concept>> asMap = tableRows.stream()
                 .map(row -> {
@@ -889,7 +889,7 @@ public class QuerySteps {
     }
 
     @Given("set answers of typeql read query as given rows with order: {variable_list}")
-    public void set_answers_as_given_rows(List<String> varList, String query) {
+    public void set_answers_of_typeql_read_query_as_given_rows(List<String> varList, String query) {
         List<ConceptRow> tableRows = tx().query(query).resolve().asConceptRows().stream().collect(Collectors.toList());
         List<? extends List<? extends Concept>> rows = tableRows.stream()
                 .map(row -> varList.stream().<Concept>map(var -> row.get(var).orElse(null)).collect(Collectors.toList()))

--- a/rust/tests/behaviour/steps/query.rs
+++ b/rust/tests/behaviour/steps/query.rs
@@ -190,7 +190,7 @@ pub async fn typeql_query(context: &mut Context, with_given: WithGiven, may_erro
 
 #[cucumber::given(expr = "set answers of typeql read query as given rows with order: {variable_list}")]
 #[cucumber::when(expr = "set answers of typeql read query as given rows with order: {variable_list}")]
-async fn set_given_rows(context: &mut Context, var_list: VariableList, step: &Step) {
+async fn set_answers_of_typeql_read_query_as_given_rows(context: &mut Context, var_list: VariableList, step: &Step) {
     let result = run_query(context.transaction(), step.docstring().unwrap(), None, context.query_options).await;
     let mut given_rows = GivenRows::new(var_list.0.clone(), 0);
     let mut as_rows_result = result.unwrap().into_rows();
@@ -217,7 +217,7 @@ async fn set_given_rows(context: &mut Context, var_list: VariableList, step: &St
 
 #[cucumber::given(expr = "set answers of typeql read query as given rows dictionary with variables: {variable_list}")]
 #[cucumber::when(expr = "set answers of typeql read query as given rows dictionary with variables: {variable_list}")]
-async fn set_given_rows_dict(context: &mut Context, var_list: VariableList, step: &Step) {
+async fn set_answers_of_typeql_read_query_as_given_rows_dict(context: &mut Context, var_list: VariableList, step: &Step) {
     let result = run_query(context.transaction(), step.docstring().unwrap(), None, context.query_options).await;
     let mut given_rows = GivenRows::new(var_list.0.clone(), 0);
     let mut as_rows_result = result.unwrap().into_rows();


### PR DESCRIPTION
## Usage and product changes
Update behaviour dependency that includes all value type tests for 'given' rows, and rename the steps for setting 'given' rows to match existing naming conventions.

## Implementation

- Update behaviour dep
- Rename steps to match existing conventions
