### PR TITLE
Use saturating subtraction for network latency estimation

### DIFF
--- a/rust/src/connection/server/server_connection.rs
+++ b/rust/src/connection/server/server_connection.rs
@@ -105,8 +105,9 @@ impl ServerConnection {
         let request_time = Instant::now();
         match request_transmitter.request(message).await? {
             Response::ConnectionOpen { connection_id, server_duration_millis, servers } => {
-                let latency =
-                    Instant::now().duration_since(request_time) - Duration::from_millis(server_duration_millis);
+                let latency = Instant::now()
+                    .duration_since(request_time)
+                    .saturating_sub(Duration::from_millis(server_duration_millis));
                 Ok((connection_id, latency, servers))
             }
             other => Err(ConnectionError::UnexpectedResponse { response: format!("{other:?}") }.into()),
@@ -260,8 +261,10 @@ impl ServerConnection {
                 response_source,
                 server_duration_millis,
             } => {
-                let open_latency =
-                    Instant::now().duration_since(open_request_start).as_millis() as u64 - server_duration_millis;
+                let open_latency = Instant::now()
+                    .duration_since(open_request_start)
+                    .saturating_sub(Duration::from_millis(server_duration_millis))
+                    .as_millis() as u64;
                 self.latency_tracker.update_latency(open_latency);
                 let transmitter =
                     TransactionTransmitter::new(self.background_runtime.clone(), request_sink, response_source);


### PR DESCRIPTION
## Change & Motivation

The driver estimates network latency by subtracting the server-reported processing duration from the client-observed elapsed time. The two durations come from different clocks that can tick at slightly different rates, so the server's value can exceed the client's. 

This can cause panics and in other cases could cause the transaction-open latency to near u64::MAX, poisoning the latency tracker and inflating the network_latency_millis the server uses as its answer-streaming budget.
 
## Implementation
- Both subtraction sites in server_connection.rs now use `Duration::saturating_sub`, clamping to a conservative zero-latency estimate that the tracker's averaging absorbs gracefully.
 

Closes #902
