### PR TITLE
Fix remote cache setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,15 +67,16 @@ commands:
           amazon-linux-extras install java-openjdk11 -y
           yum install wget make gcc gcc-c++ openssl-devel bzip2-devel libffi-devel zlib-devel file lsof which procps tar git -y
           
-          cd /tmp
-          wget https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz
-          tar -xvf Python-3.9.6.tgz
-          cd Python-3.9.6
-          ./configure --enable-optimizations --enable-shared
-          make altinstall
-          echo "/usr/local/lib" >> /etc/ld.so.conf.d/python3.9.conf
-          ldconfig
-          ln -s /usr/local/bin/python3.9 /usr/bin/python3
+          (pushd /tmp
+            wget https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz
+            tar -xvf Python-3.9.6.tgz
+            cd Python-3.9.6
+            ./configure --enable-optimizations --enable-shared
+            make altinstall
+            echo "/usr/local/lib" >> /etc/ld.so.conf.d/python3.9.conf
+            ldconfig
+            ln -s /usr/local/bin/python3.9 /usr/bin/python3
+          popd)
           
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.bazel-arch>>"
           mv "bazelisk-linux-<<parameters.bazel-arch>>" /usr/local/bin/bazel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ commands:
           amazon-linux-extras install java-openjdk11 -y
           yum install wget make gcc gcc-c++ openssl-devel bzip2-devel libffi-devel zlib-devel file lsof which procps tar git -y
           
-          (pushd /tmp
+          pushd /tmp
             wget https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz
             tar -xvf Python-3.9.6.tgz
             cd Python-3.9.6
@@ -76,7 +76,7 @@ commands:
             echo "/usr/local/lib" >> /etc/ld.so.conf.d/python3.9.conf
             ldconfig
             ln -s /usr/local/bin/python3.9 /usr/bin/python3
-          popd)
+          popd
           
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.bazel-arch>>"
           mv "bazelisk-linux-<<parameters.bazel-arch>>" /usr/local/bin/bazel

--- a/.circleci/windows/prepare.bat
+++ b/.circleci/windows/prepare.bat
@@ -29,7 +29,6 @@ choco uninstall openjdk --limit-output --yes --no-progress
 
 REM install dependencies needed for build
 choco install .circleci\windows\dependencies.config  --limit-output --yes --no-progress
-call refreshenv
 
 REM create a symlink python3.exe and make it available in %PATH%
 mklink C:\Python311\python3.exe C:\Python311\python.exe
@@ -50,4 +49,3 @@ IF DEFINED CARGO_BAZEL_GENERATOR_URL_WIN_X86_64 (
 IF DEFINED CARGO_BAZEL_GENERATOR_SHA_WIN_X86_64 (
     SETX CARGO_BAZEL_GENERATOR_SHA256 %CARGO_BAZEL_GENERATOR_SHA_WIN_X86_64%
 )
-bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh

--- a/.circleci/windows/prepare.bat
+++ b/.circleci/windows/prepare.bat
@@ -29,6 +29,7 @@ choco uninstall openjdk --limit-output --yes --no-progress
 
 REM install dependencies needed for build
 choco install .circleci\windows\dependencies.config  --limit-output --yes --no-progress
+call refreshenv
 
 REM create a symlink python3.exe and make it available in %PATH%
 mklink C:\Python311\python3.exe C:\Python311\python.exe


### PR DESCRIPTION
## Implementation
Moves python installation into sub-shell and does pushd/popd.
Removes from windows because it doesn't look like we ever do it in windows.