### PR TITLE
Extend migration tests

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -156,14 +156,8 @@ build:
         bazel run --config=ci @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run --config=ci @typedb_dependencies//distribution/artifact:create-netrc
 
-        # TODO: run `bazel test --config=ci //rust/tests/behaviour/...` instead of multiple tests (cannot do Clustered migration now)
         source tool/test/start-cluster-servers.sh 3 &&
-          bazel test --config=ci //rust/tests/behaviour/connection/... --test_env=ROOT_CA=$ROOT_CA --//rust/tests/behaviour/config:mode=cluster --test_output=streamed &&
-          bazel test --config=ci //rust/tests/behaviour/driver:test_concept --test_env=ROOT_CA=$ROOT_CA --//rust/tests/behaviour/config:mode=cluster --test_output=streamed &&
-          bazel test --config=ci //rust/tests/behaviour/driver:test_connection --test_env=ROOT_CA=$ROOT_CA --//rust/tests/behaviour/config:mode=cluster --test_output=streamed &&
-          bazel test --config=ci //rust/tests/behaviour/driver:test_query --test_env=ROOT_CA=$ROOT_CA --//rust/tests/behaviour/config:mode=cluster --test_output=streamed &&
-          bazel test --config=ci //rust/tests/behaviour/driver:test_user --test_env=ROOT_CA=$ROOT_CA --//rust/tests/behaviour/config:mode=cluster --test_output=streamed &&
-          bazel test --config=ci //rust/tests/behaviour/driver:test_cluster --test_env=ROOT_CA=$ROOT_CA --//rust/tests/behaviour/config:mode=cluster --test_output=streamed &&
+          bazel test --config=ci //rust/tests/behaviour/... --test_env=ROOT_CA=$ROOT_CA --//rust/tests/behaviour/config:mode=cluster --test_output=streamed &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-cluster-servers.sh
         exit $TEST_SUCCESS
@@ -240,14 +234,8 @@ build:
             export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
         fi
 
-        # TODO: run `.factory/test-cluster.sh //java/test/behaviour/...` instead of multiple tests (cannot do Clustered migration now)
         source tool/test/start-cluster-servers.sh 3 &&
-          .factory/test-cluster.sh //java/test/behaviour/connection/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
-          .factory/test-cluster.sh //java/test/behaviour/driver/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
-          .factory/test-cluster.sh //java/test/behaviour/driver/connection/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
-          .factory/test-cluster.sh //java/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
-          .factory/test-cluster.sh //java/test/behaviour/driver/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
-          .factory/test-cluster.sh //java/test/behaviour/driver/cluster/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
+          .factory/test-cluster.sh //java/test/behaviour/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-cluster-servers.sh
         exit $TEST_SUCCESS
@@ -312,14 +300,8 @@ build:
             export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
         fi
 
-        # TODO: run `.factory/test-cluster.sh //python/tests/behaviour/...` instead of multiple tests (cannot do Clustered migration now)
         source tool/test/start-cluster-servers.sh 3 &&
-          .factory/test-cluster.sh //python/tests/behaviour/connection/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
-          .factory/test-cluster.sh //python/tests/behaviour/driver/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
-          .factory/test-cluster.sh //python/tests/behaviour/driver/connection/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
-          .factory/test-cluster.sh //python/tests/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
-          .factory/test-cluster.sh //python/tests/behaviour/driver/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
-          .factory/test-cluster.sh //python/tests/behaviour/driver/cluster/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
+          .factory/test-cluster.sh //python/tests/behaviour/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-cluster-servers.sh
         exit $TEST_SUCCESS
@@ -452,15 +434,8 @@ build:
             export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
         fi
 
-        # TODO: run `.factory/test-cluster.sh //csharp/Test/Behaviour/...` instead of multiple tests (cannot do Clustered migration now)
         source tool/test/start-cluster-servers.sh 3 &&
-          .factory/test-cluster.sh //csharp/Test/Behaviour/Connection/Database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
-          .factory/test-cluster.sh //csharp/Test/Behaviour/Connection/Transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
-          .factory/test-cluster.sh //csharp/Test/Behaviour/Driver/Concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
-          .factory/test-cluster.sh //csharp/Test/Behaviour/Driver/Connection/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
-          .factory/test-cluster.sh //csharp/Test/Behaviour/Driver/Query/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
-          .factory/test-cluster.sh //csharp/Test/Behaviour/Driver/User/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
-          .factory/test-cluster.sh //csharp/Test/Behaviour/Driver/Cluster/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
+          .factory/test-cluster.sh //csharp/Test/Behaviour/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-cluster-servers.sh
         exit $TEST_SUCCESS

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -262,7 +262,7 @@ native_artifact_files.artifact(
     name = "typedb_cluster_artifact",
     group_name = "typedb-cluster-all-{platform}",
     artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
-    commit = "15031943a5b9de4f0669e749efeedd61350b1f5f",
+    commit = "8cf0755e0fa5d4a35ca5a30ae0ba53938449432f",
     private = True,
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -73,7 +73,7 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "a9a2988bdb642ad4d7d776d0869d44d2118ef3a7",
+    commit = "26aa6bebf5e921654f832cf861b29d58d0608a7d",
 )
 
 # Rust rules need typedb_dependencies for patching

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -255,14 +255,14 @@ native_artifact_files.artifact(
     name = "typedb_artifact",
     group_name = "typedb-all-{platform}",
     artifact_name = "typedb-all-{platform}-{version}.{ext}",
-    commit = "d3c2c6d70eee4f6618931a9ce1cf7fda4e2bf0d4",
+    commit = "e0f0313532381b963804109b050ec248912717c5",
 )
 # IMPORTANT: must be CLUSTERED typedb-cluster (with multi-node support)!
 native_artifact_files.artifact(
     name = "typedb_cluster_artifact",
     group_name = "typedb-cluster-all-{platform}",
     artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
-    commit = "df7a32ae01703bbcc68fad81e72a9262236705fe",
+    commit = "15031943a5b9de4f0669e749efeedd61350b1f5f",
     private = True,
 )
 

--- a/csharp/Test/Behaviour/Driver/Migration/MigrationTest.cs
+++ b/csharp/Test/Behaviour/Driver/Migration/MigrationTest.cs
@@ -21,7 +21,7 @@ using Xunit.Gherkin.Quick;
 
 namespace TypeDB.Driver.Test.Behaviour
 {
-    [FeatureFile("external/typedb_behaviour+/driver/migration.feature")]
+    [FeatureFile("migration.csharp.feature")]
     public partial class BehaviourSteps
     {
     }

--- a/csharp/Test/Behaviour/Util/BUILD
+++ b/csharp/Test/Behaviour/Util/BUILD
@@ -50,7 +50,7 @@ csharp_library(
 )
 
 exports_files(
-    ["TestRunner.cs"],
+    ["TestRunner.cs", "FeatureFileFilter.cs"],
     visibility = ["//csharp/Test:__subpackages__"],
 )
 

--- a/csharp/Test/Behaviour/Util/FeatureFileFilter.cs
+++ b/csharp/Test/Behaviour/Util/FeatureFileFilter.cs
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace TypeDB.Driver.Test.TestRunner
+{
+    // Xunit.Gherkin.Quick cannot filter scenarios by tag, so scenarios tagged as ignored for this
+    // driver are stripped from the shared feature files before test discovery reads them. Feature
+    // files needing filtering are rewritten next to the test binary, and their tests reference the
+    // rewritten copy in [FeatureFile].
+    public static class FeatureFileFilter
+    {
+        private const string IgnoreTag = "@ignore-typedb-driver-csharp";
+
+        private static readonly Dictionary<string, string> FilteredFeatures = new Dictionary<string, string>
+        {
+            { "external/typedb_behaviour+/driver/migration.feature", "migration.csharp.feature" },
+        };
+
+        public static void PrepareFeatureFiles()
+        {
+            foreach (var (source, target) in FilteredFeatures)
+            {
+                if (File.Exists(source))
+                {
+                    File.WriteAllText(target, Filter(File.ReadAllLines(source)));
+                }
+            }
+        }
+
+        private static string Filter(string[] sourceLines)
+        {
+            var filtered = new StringBuilder();
+            var block = new StringBuilder();
+            var previousLineIsTag = false;
+            foreach (var line in sourceLines)
+            {
+                var trimmed = line.TrimStart();
+                var indent = line.Length - trimmed.Length;
+                var isScenarioHeader = indent == 2 && (trimmed.StartsWith("@") || trimmed.StartsWith("Scenario"));
+                if (isScenarioHeader && !previousLineIsTag)
+                {
+                    FlushBlock(filtered, block);
+                }
+                block.AppendLine(line);
+                previousLineIsTag = indent == 2 && trimmed.StartsWith("@");
+            }
+            FlushBlock(filtered, block);
+            return filtered.ToString();
+        }
+
+        private static void FlushBlock(StringBuilder filtered, StringBuilder block)
+        {
+            var content = block.ToString();
+            if (!content.Contains(IgnoreTag))
+            {
+                filtered.Append(content);
+            }
+            block.Clear();
+        }
+    }
+}

--- a/csharp/Test/Behaviour/Util/TestRunner.cs
+++ b/csharp/Test/Behaviour/Util/TestRunner.cs
@@ -43,6 +43,8 @@ namespace TypeDB.Driver.Test.TestRunner
 
             var typeName = args.Length == 1 ? args[0] : null;
 
+            FeatureFileFilter.PrepareFeatureFiles();
+
             using (var runner = AssemblyRunner.WithoutAppDomain(testAssembly))
             {
                 runner.OnDiscoveryComplete = OnDiscoveryComplete;

--- a/csharp/Test/rules.bzl
+++ b/csharp/Test/rules.bzl
@@ -70,6 +70,7 @@ def csharp_behaviour_test(
         name = name,
         srcs = test_files + step_files + [
             "//csharp/Test/Behaviour/Util:TestRunner.cs",
+            "//csharp/Test/Behaviour/Util:FeatureFileFilter.cs",
             "//csharp/Test/Behaviour:TestValueHelper.cs",
         ],
         data = features + certificates,

--- a/rust/src/connection/database/import_stream.rs
+++ b/rust/src/connection/database/import_stream.rs
@@ -27,7 +27,8 @@ use crate::{
     promisify, resolve,
 };
 
-pub(crate) struct DatabaseImportStream {
+#[doc(hidden)]
+pub struct DatabaseImportStream {
     import_transmitter: DatabaseImportTransmitter,
 }
 
@@ -40,7 +41,8 @@ impl DatabaseImportStream {
         self.import_transmitter.single(DatabaseImportRequest::ItemPart { items })
     }
 
-    pub(crate) fn done(mut self) -> impl Promise<'static, Result> {
+    #[doc(hidden)]
+    pub fn done(mut self) -> impl Promise<'static, Result> {
         promisify! {
             self.import_transmitter.single(DatabaseImportRequest::Done)?;
             let promise = self.import_transmitter.wait_done();

--- a/rust/src/database/database_manager.rs
+++ b/rust/src/database/database_manager.rs
@@ -25,7 +25,10 @@ use typedb_protocol::migration::Item;
 use super::Database;
 use crate::{
     common::Result,
-    connection::server::{server_manager::ServerManager, server_routing::ServerRouting},
+    connection::{
+        database::import_stream::DatabaseImportStream,
+        server::{server_manager::ServerManager, server_routing::ServerRouting},
+    },
     database::migration::{ProtoMessageIterator, try_open_import_file},
     info::DatabaseInfo,
     resolve,
@@ -132,6 +135,25 @@ impl DatabaseManager {
             .execute(ServerRouting::Auto, move |server_connection| {
                 let name = name.clone();
                 async move { server_connection.create_database(name).await }
+            })
+            .await
+    }
+
+    // Opens a raw import stream, exposed for behaviour tests only
+    #[doc(hidden)]
+    #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
+    pub async fn import_stream(
+        &self,
+        name: impl Into<String>,
+        schema: impl Into<String>,
+    ) -> Result<DatabaseImportStream> {
+        let name = name.into();
+        let schema: String = schema.into();
+        let schema_ref: &str = schema.as_ref();
+        self.server_manager
+            .execute(ServerRouting::Auto, move |server_connection| {
+                let name = name.clone();
+                async move { server_connection.import_database(name, schema_ref.to_string()).await }
             })
             .await
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -25,6 +25,8 @@
 #![allow(clippy::too_many_arguments, reason = "too many false positives")]
 #![allow(clippy::type_complexity, reason = "too many false positives")]
 
+#[doc(hidden)]
+pub use self::connection::database::import_stream::DatabaseImportStream;
 pub use self::{
     common::{
         Address, Addresses, BoxPromise, BoxStream, Error, IID, Promise, QueryOptions, Result, TransactionOptions,

--- a/rust/tests/behaviour/steps/connection/database.rs
+++ b/rust/tests/behaviour/steps/connection/database.rs
@@ -266,6 +266,32 @@ async fn connection_import_database_from_data_file_and_schema(
 }
 
 #[apply(generic_step)]
+#[step(expr = r"connection opens import of database\({word}\) with schema file\({word}\)")]
+async fn connection_opens_import_of_database(context: &mut Context, name: String, schema_file_name: String) {
+    let schema = read_file_to_string(context.get_full_file_path(&schema_file_name));
+    let import = context.driver.as_ref().unwrap().databases().import_stream(name.clone(), schema).await.unwrap();
+    context.open_imports.insert(name, import);
+}
+
+#[apply(generic_step)]
+#[step(expr = r"connection completes the open import of database\({word}\){may_error}")]
+async fn connection_completes_the_open_import_of_database(
+    context: &mut Context,
+    name: String,
+    may_error: params::MayError,
+) {
+    let import = context.open_imports.remove(&name).expect("Expected an open import");
+    may_error.check(import.done().await);
+}
+
+#[apply(generic_step)]
+#[step(expr = r"connection aborts the open import of database\({word}\)")]
+async fn connection_aborts_the_open_import_of_database(context: &mut Context, name: String) {
+    let import = context.open_imports.remove(&name).expect("Expected an open import");
+    drop(import);
+}
+
+#[apply(generic_step)]
 #[step(expr = r"file\({word}\) has schema:")]
 async fn file_has_schema(context: &mut Context, file_name: String, step: &Step) {
     let expected_schema = step.docstring.as_ref().unwrap().trim().to_string();

--- a/rust/tests/behaviour/steps/lib.rs
+++ b/rust/tests/behaviour/steps/lib.rs
@@ -22,7 +22,7 @@
 #![allow(clippy::too_many_arguments, reason = "too many false positives")]
 
 use std::{
-    collections::{HashSet, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     error::Error,
     fmt,
     fmt::Formatter,
@@ -38,8 +38,8 @@ use futures::{
 use itertools::Itertools;
 use tokio::time::{Duration, sleep};
 use typedb_driver::{
-    Addresses, BoxStream, Credentials, DriverOptions, DriverTlsConfig, QueryOptions, Result as TypeDBResult,
-    ServerRouting, Transaction, TransactionOptions, TypeDBDriver,
+    Addresses, BoxStream, Credentials, DatabaseImportStream, DriverOptions, DriverTlsConfig, QueryOptions,
+    Result as TypeDBResult, ServerRouting, Transaction, TransactionOptions, TypeDBDriver,
     analyze::AnalyzedQuery,
     answer::{ConceptDocument, ConceptRow, QueryAnswer, QueryType},
     given::GivenRows,
@@ -120,6 +120,7 @@ pub struct Context {
     pub collected_documents: Option<Vec<ConceptDocument>>,
     pub concurrent_answers: Vec<QueryAnswer>,
     pub concurrent_rows_streams: Option<Vec<BoxStream<'static, TypeDBResult<ConceptRow>>>>,
+    pub open_imports: HashMap<String, DatabaseImportStream>,
 }
 
 impl fmt::Debug for Context {
@@ -549,6 +550,7 @@ impl Default for Context {
             collected_documents: None,
             concurrent_answers: Vec::new(),
             concurrent_rows_streams: None,
+            open_imports: HashMap::new(),
         }
     }
 }

--- a/rust/tests/behaviour/steps/query.rs
+++ b/rust/tests/behaviour/steps/query.rs
@@ -22,12 +22,9 @@ use futures::{StreamExt, future::join_all};
 use itertools::Itertools;
 use macro_rules_attribute::apply;
 use typedb_driver::{
-    IID, QueryOptions, Result as TypeDBResult, Transaction,
+    QueryOptions, Result as TypeDBResult, Transaction,
     answer::{ConceptRow, QueryAnswer},
-    concept::{
-        Attribute, AttributeType, Concept, ConceptCategory, Entity, EntityType, Relation, RelationType, Value,
-        ValueType,
-    },
+    concept::{AttributeType, Concept, ConceptCategory, EntityType, RelationType, Value, ValueType},
     error::ConceptError,
     given::{GivenRowEntry, GivenRows},
 };


### PR DESCRIPTION
## Usage and product changes
Extend the migration tests for the Rust driver to include more corner cases of incomplete database imports.

## Implementation
Update refs.
Add new steps for the Rust driver -- it's the only driver that can manually control the import stream to emulate the steps required. 
Extend the C# test infrastructure to allow it to parse ignored scenarios.