### PR TITLE
Make the HTTP driver correctly always follow cluster 'misdirected request' redirects

### DIFF
--- a/docs/modules/ROOT/partials/http-ts/connection/connectionStaticFunctions.adoc
+++ b/docs/modules/ROOT/partials/http-ts/connection/connectionStaticFunctions.adoc
@@ -128,7 +128,7 @@ a| `params` a|  a| `DriverParams`
 resolveOrigin(params: DriverParams, primaryAddress: string): string
 ----
 
-Resolve a bare primaryAddress (host:port) to a full URL using configured params.
+Resolve an advertised primaryAddress (a full origin) to the matching configured address, else itself.
 
 [caption=""]
 .Input parameters

--- a/http-ts/src/index.ts
+++ b/http-ts/src/index.ts
@@ -44,7 +44,13 @@ const HTTP_MISDIRECTED = 421;
 //   SRV14 - server returned "Not yet initialised". Happens on a freshly restarted secondary
 //           that has not yet loaded the system DB, or briefly on a node mid-promotion. Either
 //           way another origin is likely healthy, so fall back rather than retry in place.
-const TRANSIENT_SIGNIN_ERROR_CODES = new Set(["HDR2", "SRV14"]);
+//   CSV8/CSV9 - node is not the primary; another origin may be, so fall back.
+const TRANSIENT_SIGNIN_ERROR_CODES = new Set(["HDR2", "SRV14", "CSV8", "CSV9"]);
+
+// A misdirected (421) result that survived redirect-following and origin fallback means
+// no reachable server is primary right now (typically mid-election); wait and retry.
+const PRIMARY_FAILOVER_RETRIES = 3;
+const PRIMARY_SELECTION_WAIT_MS = 2000;
 
 // Result of attempting a single request against a single origin.
 //   Response          - reached the server and got an HTTP response
@@ -215,6 +221,15 @@ export class TypeDBHttpDriver {
     }
 
     private async apiReq<BODY>(method: string, path: string, body?: BODY, options?: { headers?: Record<string, string> }): Promise<ApiErrorResponse | Response> {
+        let result = await this.apiReqOnce(method, path, body, options);
+        for (let retry = 0; retry < PRIMARY_FAILOVER_RETRIES && result.status === HTTP_MISDIRECTED; retry++) {
+            await new Promise(resolve => setTimeout(resolve, PRIMARY_SELECTION_WAIT_MS));
+            result = await this.apiReqOnce(method, path, body, options);
+        }
+        return result;
+    }
+
+    private async apiReqOnce<BODY>(method: string, path: string, body?: BODY, options?: { headers?: Record<string, string> }): Promise<ApiErrorResponse | Response> {
         const initial = await this.tryApiReq(method, path, body, options);
         if (isApiErrResp(initial)) return initial;
         let result: Response | null = initial;
@@ -340,20 +355,20 @@ export class TypeDBHttpDriver {
             return driverError("HDR2", `Cannot connect to server at ${this.currentOrigin}`);
         }
         const json = await this.jsonOrNull(resp);
-        if (resp.ok) {
-            this.token = (json as SignInResponse).token;
+        if (resp.ok && typeof json?.token === "string") {
+            this.token = json.token;
             return { ok: json };
         }
         if (isApiError(json)) return { err: json, status: resp.status };
-        throw resp;
+        return driverError("HDR2", `Unexpected signin response from ${this.currentOrigin} (HTTP ${resp.status})`);
     }
 
-    private async jsonOrNull(resp: Response) {
-        const contentLengthRaw = resp.headers.get("Content-Length");
-        if (!contentLengthRaw) return null;
-        const contentLength = parseInt(contentLengthRaw || "");
-        if (isNaN(contentLength)) throw `Received invalid Content-Length header: ${contentLengthRaw}`;
-        return contentLength > 0 ? await resp.json() : null;
+    private async jsonOrNull(resp: Response): Promise<any> {
+        try {
+            return await resp.json();
+        } catch {
+            return null;
+        }
     }
 
     private async stringOrNull(resp: Response) {

--- a/http-ts/src/params.ts
+++ b/http-ts/src/params.ts
@@ -59,31 +59,21 @@ export function hostPortFromOrigin(origin: string): string {
     }
 }
 
-/** Resolve a bare primaryAddress (host:port) to a full URL using configured params. */
+/** Resolve an advertised primaryAddress (a full origin) to the matching configured address, else itself. */
 export function resolveOrigin(params: DriverParams, primaryAddress: string): string {
+    const target = hostPortFromOrigin(primaryAddress);
     if (isBasicParams(params)) {
         for (const addr of params.addresses) {
-            if (hostPortFromOrigin(addr) === primaryAddress) return addr;
+            if (hostPortFromOrigin(addr) === target) return addr;
         }
-        return deriveOriginWithScheme(params.addresses[0], primaryAddress);
     } else {
         for (const ta of params.translatedAddresses) {
-            if (hostPortFromOrigin(ta.internal) === primaryAddress
-                || hostPortFromOrigin(ta.external) === primaryAddress) {
+            if (hostPortFromOrigin(ta.internal) === target || hostPortFromOrigin(ta.external) === target) {
                 return ta.external;
             }
         }
-        return deriveOriginWithScheme(params.translatedAddresses[0].external, primaryAddress);
     }
-}
-
-function deriveOriginWithScheme(referenceUrl: string, hostPort: string): string {
-    try {
-        const url = new URL(referenceUrl);
-        return `${url.protocol}//${hostPort}`;
-    } catch {
-        return `https://${hostPort}`;
-    }
+    return primaryAddress;
 }
 
 /** Return all configured origins for connection error fallback. */


### PR DESCRIPTION
## Usage and product changes
Make the http-ts driver retry a couple of times when redirecting request (usually, it is needed when a new primary is selected, and there can be a lag between the states of the target cluster). 

Additionally, simplify the address resolution logic and avoid appending excessive schemas to the target URLs, expecting correct input params from the users.


### Example: 
If you specify three addresses, and the driver first tries a non-primary while connecting, this replica will say "I'm not a primary, go to XXX". If this XXX does not https://, the redirect fails. And it does not:
* understand that the returned address without the schema is exactly one of the addresses from the connection string
* try the other addresses from the connection string (because there are no retries)


After this change:
It **does**:
* understand that the returned address without the schema is exactly one of the addresses from the connection string (matching between the redirect address and the configured addresses is canonical)
* try the other addresses from the connection string (retries are introduced)

## Implementation
Replicate the retry logic from the Rust driver (which is propagated to all other grpc-based drivers). 