### PR TITLE
Make the HTTP-TS driver optimally follow redirects to scheme-less primary addresses

### DIFF
--- a/docs/modules/ROOT/partials/http-ts/connection/connectionStaticFunctions.adoc
+++ b/docs/modules/ROOT/partials/http-ts/connection/connectionStaticFunctions.adoc
@@ -36,7 +36,7 @@ a| `params` a|  a| `DriverParams`
 hostPortFromOrigin(origin: string): string
 ----
 
-Extract host:port from a URL string. "https://127.0.0.1:18000" → "127.0.0.1:18000"
+
 
 [caption=""]
 .Input parameters
@@ -128,7 +128,7 @@ a| `params` a|  a| `DriverParams`
 resolveOrigin(params: DriverParams, primaryAddress: string): string
 ----
 
-Resolve an advertised primaryAddress (a full origin) to the matching configured address, else itself.
+
 
 [caption=""]
 .Input parameters

--- a/http-ts/src/index.ts
+++ b/http-ts/src/index.ts
@@ -230,6 +230,7 @@ export class TypeDBHttpDriver {
     }
 
     private async apiReqOnce<BODY>(method: string, path: string, body?: BODY, options?: { headers?: Record<string, string> }): Promise<ApiErrorResponse | Response> {
+        const triedOrigins = new Set([this.currentOrigin]);
         const initial = await this.tryApiReq(method, path, body, options);
         if (isApiErrResp(initial)) return initial;
         let result: Response | null = initial;
@@ -240,7 +241,8 @@ export class TypeDBHttpDriver {
         }
         if (result === null || !result.ok) {
             const startOrigin = this.currentOrigin;
-            const fallback = await this.tryFallbackOrigins(method, path, body, options);
+            triedOrigins.add(startOrigin);
+            const fallback = await this.tryFallbackOrigins(method, path, body, options, triedOrigins);
             if (isApiErrResp(fallback)) return fallback;
             if (fallback !== null && (result === null || fallback.ok)) {
                 result = fallback;
@@ -302,12 +304,11 @@ export class TypeDBHttpDriver {
         return true;
     }
 
-    private async tryFallbackOrigins<BODY>(method: string, path: string, body?: BODY, options?: { headers?: Record<string, string> }): Promise<TryResult> {
+    private async tryFallbackOrigins<BODY>(method: string, path: string, body: BODY | undefined, options: { headers?: Record<string, string> } | undefined, triedOrigins: Set<string>): Promise<TryResult> {
         const origins = allOrigins(this.params);
-        const failedOrigin = this.currentOrigin;
         let lastError: Response | null = null;
         for (const origin of origins) {
-            if (origin === failedOrigin) continue;
+            if (triedOrigins.has(origin)) continue;
             this.switchOrigin(origin);
             const initial = await this.tryApiReq(method, path, body, options);
             if (initial === null) continue;

--- a/http-ts/src/params.ts
+++ b/http-ts/src/params.ts
@@ -49,31 +49,41 @@ export function remoteOrigin(params: DriverParams) {
     else return `${params.translatedAddresses[0].external}`;
 }
 
-/** Extract host:port from a URL string. "https://127.0.0.1:18000" → "127.0.0.1:18000" */
+const SCHEME_PREFIX_REGEX = /^[a-z][a-z0-9+.-]*:\/\//i;
+
 export function hostPortFromOrigin(origin: string): string {
+    if (!SCHEME_PREFIX_REGEX.test(origin)) return origin;
     try {
-        const url = new URL(origin);
-        return url.host;
+        return new URL(origin).host;
     } catch {
         return origin;
     }
 }
 
-/** Resolve an advertised primaryAddress (a full origin) to the matching configured address, else itself. */
 export function resolveOrigin(params: DriverParams, primaryAddress: string): string {
     const target = hostPortFromOrigin(primaryAddress);
     if (isBasicParams(params)) {
         for (const addr of params.addresses) {
             if (hostPortFromOrigin(addr) === target) return addr;
         }
+        return originWithScheme(primaryAddress, params.addresses[0]);
     } else {
         for (const ta of params.translatedAddresses) {
             if (hostPortFromOrigin(ta.internal) === target || hostPortFromOrigin(ta.external) === target) {
                 return ta.external;
             }
         }
+        return originWithScheme(primaryAddress, params.translatedAddresses[0].external);
     }
-    return primaryAddress;
+}
+
+function originWithScheme(address: string, referenceOrigin: string): string {
+    if (SCHEME_PREFIX_REGEX.test(address)) return address;
+    try {
+        return `${new URL(referenceOrigin).protocol}//${address}`;
+    } catch {
+        return `https://${address}`;
+    }
 }
 
 /** Return all configured origins for connection error fallback. */


### PR DESCRIPTION
## Usage and product changes

Make the failover logic of the http-ts driver correctly follow the advertised primary address (both bare host:port and full-origin values) in priority over the list of replicas configured on connection. Previously, a bare advertised address was ignored: the driver brute-force scanned the configured replicas (retrying the one that had just redirected it), and could not reach a primary outside the configured list at all.

## Implementation

- `hostPortFromOrigin`: return scheme-less input unchanged instead of misparsing it via URL (scheme detected by requiring `://`).
- `resolveOrigin`: an advertised primary that matches no configured address is used directly, borrowing the scheme from a configured address if it has none.
- Fallback scan: skip all origins already tried in this attempt.
