### PR TITLE
Update server 3.12.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2807,7 +2807,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?tag=3.12.0-rc0#cef7aaf8144b7534f47c9ca82db3fefc3b81d623"
+source = "git+https://github.com/typedb/typedb-protocol?tag=3.12.0#0373c1ae106b1f68e80edb06c1b7375075fe62e2"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@
 		[workspace.dependencies.typedb-protocol]
 			features = []
 			git = "https://github.com/typedb/typedb-protocol"
-			tag = "3.12.0-rc0"
+			tag = "3.12.0"
 			default-features = false
 
 		[workspace.dependencies.serde]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -73,7 +73,7 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "4b09ab8f7f5fcb27b4926a1707ddd11402502f07",
+    commit = "a9a2988bdb642ad4d7d776d0869d44d2118ef3a7",
 )
 
 # Rust rules need typedb_dependencies for patching
@@ -255,7 +255,7 @@ native_artifact_files.artifact(
     name = "typedb_artifact",
     group_name = "typedb-all-{platform}",
     artifact_name = "typedb-all-{platform}-{version}.{ext}",
-    commit = "5eee51d74069445883cd7c32ab8bc4cbc63ad801",
+    commit = "d3c2c6d70eee4f6618931a9ce1cf7fda4e2bf0d4",
 )
 # IMPORTANT: must be CLUSTERED typedb-cluster (with multi-node support)!
 native_artifact_files.artifact(


### PR DESCRIPTION
## Usage and product changes
Update references to a pre-3.12.3 server to test the combination of the server and the driver against the updated set of migration BDD scenarios.

## Implementation
